### PR TITLE
CASSANDRA-18578 Add circleci configuration yaml for Cassandra Analytics

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
       - run:
           name: Build and test against Spark 2 Scala 2.11 JDK8
           command: |
-            git clone --branch trunk https://github.com/apache/cassandra-sidecar.git
+            git clone --single-branch --branch trunk https://github.com/apache/cassandra-sidecar.git
             ./cassandra-sidecar/gradlew --project-dir=./cassandra-sidecar -Pversion=1.0.0-jdk8-local :vertx-client-shaded:publishToMavenLocal
             ./gradlew --stacktrace clean assemble check
           environment:
@@ -42,7 +42,7 @@ jobs:
       - run:
           name: Build and test against Spark 2 Scala 2.12 JDK8
           command: |
-            git clone --branch trunk https://github.com/apache/cassandra-sidecar.git
+            git clone --single-branch --branch trunk https://github.com/apache/cassandra-sidecar.git
             ./cassandra-sidecar/gradlew --project-dir=./cassandra-sidecar -Pversion=1.0.0-jdk8-local :vertx-client-shaded:publishToMavenLocal
             ./gradlew --stacktrace clean assemble check
           environment:
@@ -58,7 +58,7 @@ jobs:
       - run:
           name: Build and test against Spark 3 Scala 2.12 JDK11
           command: |
-            git clone --branch trunk https://github.com/apache/cassandra-sidecar.git
+            git clone --single-branch --branch trunk https://github.com/apache/cassandra-sidecar.git
             ./cassandra-sidecar/gradlew --project-dir=./cassandra-sidecar -Pversion=1.0.0-local :vertx-client-shaded:publishToMavenLocal
             ./gradlew --stacktrace clean assemble check
           environment:
@@ -68,13 +68,13 @@ jobs:
 
   cassandra-analytics-core-spark3-2_13-jdk11:
     docker:
-      - image: circleci/openjdk:11-jdk-stretch
+      - image: cimg/openjdk:11.0
     steps:
       - checkout
       - run:
           name: Build and test against Spark 3 Scala 2.13 JDK11
           command: |
-            git clone --branch trunk https://github.com/apache/cassandra-sidecar.git
+            git clone --single-branch --branch trunk https://github.com/apache/cassandra-sidecar.git
             ./cassandra-sidecar/gradlew --project-dir=./cassandra-sidecar -Pversion=1.0.0-local :vertx-client-shaded:publishToMavenLocal
             ./gradlew --stacktrace clean assemble check
           environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
     steps:
       - run: |
           git clone --branch trunk https://github.com/apache/cassandra-sidecar.git
-          ./cassandra-sidecar/gradlew -Pversion=1.0.0-local publishToMavenLocal
+          ./cassandra-sidecar/gradlew --project-dir=./cassandra-sidecar -Pversion=1.0.0-local publishToMavenLocal
       - checkout
       - run:
           name: Build and test against Spark 3 Scala 2.12 JDK11

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
 
   cassandra-analytics-core-spark3-2_12-jdk11:
     docker:
-      - image: cimg/openjdk:11
+      - image: circleci/openjdk:11-jdk-stretch
     steps:
       - checkout
       - run:
@@ -62,7 +62,7 @@ jobs:
 
   cassandra-analytics-core-spark3-2_13-jdk11:
     docker:
-      - image: cimg/openjdk:11
+      - image: circleci/openjdk:11-jdk-stretch
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@
 version: 2.1
 
 jobs:
-  cassandra-analytics-core-spark2-2.11-jdk8:
+  cassandra-analytics-core-spark2-2_11-jdk8:
     docker:
       - image: circleci/openjdk:8-jdk-stretch
     steps:
@@ -32,7 +32,7 @@ jobs:
             SCALA_VERSION: "2.11"
             JDK_VERSION: "1.8"
 
-  cassandra-analytics-core-spark2-2.12-jdk8:
+  cassandra-analytics-core-spark2-2_12-jdk8:
     docker:
       - image: circleci/openjdk:8-jdk-stretch
     steps:
@@ -46,7 +46,7 @@ jobs:
             SCALA_VERSION: "2.12"
             JDK_VERSION: "1.8"
 
-  cassandra-analytics-core-spark3-2.12-jdk11:
+  cassandra-analytics-core-spark3-2_12-jdk11:
     docker:
       - image: cimg/openjdk:11
     steps:
@@ -60,7 +60,7 @@ jobs:
             SCALA_VERSION: "2.12"
             JDK_VERSION: "11"
 
-  cassandra-analytics-core-spark3-2.13-jdk11:
+  cassandra-analytics-core-spark3-2_13-jdk11:
     docker:
       - image: cimg/openjdk:11
     steps:
@@ -78,7 +78,7 @@ workflows:
   version: 2
   build-and-test:
     jobs:
-      - cassandra-analytics-core-spark2-2.11-jdk8
-      - cassandra-analytics-core-spark2-2.12-jdk8
-      - cassandra-analytics-core-spark3-2.12-jdk11
-      - cassandra-analytics-core-spark3-2.13-jdk11
+      - cassandra-analytics-core-spark2-2_11-jdk8
+      - cassandra-analytics-core-spark2-2_12-jdk8
+      - cassandra-analytics-core-spark3-2_12-jdk11
+      - cassandra-analytics-core-spark3-2_13-jdk11

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,11 +50,13 @@ jobs:
     docker:
       - image: circleci/openjdk:11-jdk-stretch
     steps:
+      - run: |
+          git clone --branch trunk https://github.com/apache/cassandra-sidecar.git
+          ./cassandra-sidecar/gradlew -Pversion=1.0.0-local publishToMavenLocal
       - checkout
       - run:
           name: Build and test against Spark 3 Scala 2.12 JDK11
-          command: |
-            ./gradlew --stacktrace clean assemble check
+          command: ./gradlew --stacktrace clean assemble check
           environment:
             SPARK_VERSION: "3"
             SCALA_VERSION: "2.12"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,13 +50,13 @@ jobs:
     docker:
       - image: circleci/openjdk:11-jdk-stretch
     steps:
-      - run: |
-          git clone --branch trunk https://github.com/apache/cassandra-sidecar.git
-          ./cassandra-sidecar/gradlew --project-dir=./cassandra-sidecar -Pversion=1.0.0-local publishToMavenLocal
       - checkout
       - run:
           name: Build and test against Spark 3 Scala 2.12 JDK11
-          command: ./gradlew --stacktrace clean assemble check
+          command: |
+            git clone --branch trunk https://github.com/apache/cassandra-sidecar.git
+            ./cassandra-sidecar/gradlew --project-dir=./cassandra-sidecar -Pversion=1.0.0-local publishToMavenLocal
+            ./gradlew --stacktrace clean assemble check
           environment:
             SPARK_VERSION: "3"
             SCALA_VERSION: "2.12"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,84 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+version: 2.1
+
+jobs:
+  cassandra-analytics-core-spark2-2.11-jdk8:
+    docker:
+      - image: circleci/openjdk:8-jdk-stretch
+    steps:
+      - checkout
+      - run:
+          name: Build and test against Spark 2 Scala 2.11 JDK8
+          command: |
+            ./gradlew --stacktrace clean assemble check
+          environment:
+            SPARK_VERSION: "2"
+            SCALA_VERSION: "2.11"
+            JDK_VERSION: "1.8"
+
+  cassandra-analytics-core-spark2-2.12-jdk8:
+    docker:
+      - image: circleci/openjdk:8-jdk-stretch
+    steps:
+      - checkout
+      - run:
+          name: Build and test against Spark 2 Scala 2.12 JDK8
+          command: |
+            ./gradlew --stacktrace clean assemble check
+          environment:
+            SPARK_VERSION: "2"
+            SCALA_VERSION: "2.12"
+            JDK_VERSION: "1.8"
+
+  cassandra-analytics-core-spark3-2.12-jdk11:
+    docker:
+      - image: cimg/openjdk:11
+    steps:
+      - checkout
+      - run:
+          name: Build and test against Spark 3 Scala 2.12 JDK11
+          command: |
+            ./gradlew --stacktrace clean assemble check
+          environment:
+            SPARK_VERSION: "3"
+            SCALA_VERSION: "2.12"
+            JDK_VERSION: "11"
+
+  cassandra-analytics-core-spark3-2.13-jdk11:
+    docker:
+      - image: cimg/openjdk:11
+    steps:
+      - checkout
+      - run:
+          name: Build and test against Spark 3 Scala 2.13 JDK11
+          command: |
+            ./gradlew --stacktrace clean assemble check
+          environment:
+            SPARK_VERSION: "3"
+            SCALA_VERSION: "2.13"
+            JDK_VERSION: "11"
+
+workflows:
+  version: 2
+  build-and-test:
+    jobs:
+      - cassandra-analytics-core-spark2-2.11-jdk8
+      - cassandra-analytics-core-spark2-2.12-jdk8
+      - cassandra-analytics-core-spark3-2.12-jdk11
+      - cassandra-analytics-core-spark3-2.13-jdk11

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ version: 2.1
 jobs:
   cassandra-analytics-core-spark2-2_11-jdk8:
     docker:
-      - image: circleci/openjdk:8-jdk-stretch
+      - image: cimg/openjdk:8.0
     steps:
       - checkout
       - run:
@@ -36,7 +36,7 @@ jobs:
 
   cassandra-analytics-core-spark2-2_12-jdk8:
     docker:
-      - image: circleci/openjdk:8-jdk-stretch
+      - image: cimg/openjdk:8.0
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,8 @@ jobs:
       - run:
           name: Build and test against Spark 2 Scala 2.11 JDK8
           command: |
+            git clone --branch trunk https://github.com/apache/cassandra-sidecar.git
+            ./cassandra-sidecar/gradlew --project-dir=./cassandra-sidecar -Pversion=1.0.0-jdk8-local publishToMavenLocal
             ./gradlew --stacktrace clean assemble check
           environment:
             SPARK_VERSION: "2"
@@ -40,6 +42,8 @@ jobs:
       - run:
           name: Build and test against Spark 2 Scala 2.12 JDK8
           command: |
+            git clone --branch trunk https://github.com/apache/cassandra-sidecar.git
+            ./cassandra-sidecar/gradlew --project-dir=./cassandra-sidecar -Pversion=1.0.0-jdk8-local publishToMavenLocal
             ./gradlew --stacktrace clean assemble check
           environment:
             SPARK_VERSION: "2"
@@ -70,6 +74,8 @@ jobs:
       - run:
           name: Build and test against Spark 3 Scala 2.13 JDK11
           command: |
+            git clone --branch trunk https://github.com/apache/cassandra-sidecar.git
+            ./cassandra-sidecar/gradlew --project-dir=./cassandra-sidecar -Pversion=1.0.0-local publishToMavenLocal
             ./gradlew --stacktrace clean assemble check
           environment:
             SPARK_VERSION: "3"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ jobs:
           name: Build and test against Spark 2 Scala 2.11 JDK8
           command: |
             git clone --branch trunk https://github.com/apache/cassandra-sidecar.git
-            ./cassandra-sidecar/gradlew --project-dir=./cassandra-sidecar -Pversion=1.0.0-jdk8-local publishToMavenLocal
+            ./cassandra-sidecar/gradlew --project-dir=./cassandra-sidecar -Pversion=1.0.0-jdk8-local :vertx-client-shaded:publishToMavenLocal
             ./gradlew --stacktrace clean assemble check
           environment:
             SPARK_VERSION: "2"
@@ -43,7 +43,7 @@ jobs:
           name: Build and test against Spark 2 Scala 2.12 JDK8
           command: |
             git clone --branch trunk https://github.com/apache/cassandra-sidecar.git
-            ./cassandra-sidecar/gradlew --project-dir=./cassandra-sidecar -Pversion=1.0.0-jdk8-local publishToMavenLocal
+            ./cassandra-sidecar/gradlew --project-dir=./cassandra-sidecar -Pversion=1.0.0-jdk8-local :vertx-client-shaded:publishToMavenLocal
             ./gradlew --stacktrace clean assemble check
           environment:
             SPARK_VERSION: "2"
@@ -52,14 +52,14 @@ jobs:
 
   cassandra-analytics-core-spark3-2_12-jdk11:
     docker:
-      - image: circleci/openjdk:11-jdk-stretch
+      - image: cimg/openjdk:11.0
     steps:
       - checkout
       - run:
           name: Build and test against Spark 3 Scala 2.12 JDK11
           command: |
             git clone --branch trunk https://github.com/apache/cassandra-sidecar.git
-            ./cassandra-sidecar/gradlew --project-dir=./cassandra-sidecar -Pversion=1.0.0-local publishToMavenLocal
+            ./cassandra-sidecar/gradlew --project-dir=./cassandra-sidecar -Pversion=1.0.0-local :vertx-client-shaded:publishToMavenLocal
             ./gradlew --stacktrace clean assemble check
           environment:
             SPARK_VERSION: "3"
@@ -75,7 +75,7 @@ jobs:
           name: Build and test against Spark 3 Scala 2.13 JDK11
           command: |
             git clone --branch trunk https://github.com/apache/cassandra-sidecar.git
-            ./cassandra-sidecar/gradlew --project-dir=./cassandra-sidecar -Pversion=1.0.0-local publishToMavenLocal
+            ./cassandra-sidecar/gradlew --project-dir=./cassandra-sidecar -Pversion=1.0.0-local :vertx-client-shaded:publishToMavenLocal
             ./gradlew --stacktrace clean assemble check
           environment:
             SPARK_VERSION: "3"

--- a/build.gradle
+++ b/build.gradle
@@ -95,6 +95,7 @@ subprojects {
   }
 
   repositories {
+    mavenCentral()
     // uncomment the line below for local development
     mavenLocal()
   }

--- a/cassandra-analytics-core-example/README.md
+++ b/cassandra-analytics-core-example/README.md
@@ -210,7 +210,7 @@ Analytics have not yet been published to maven central, we need to build them lo
 
 ```shell
 cd ${SIDECAR_REPOSITORY_HOME}
-./gradlew -Pversion=1.0.0-local :common:publishToMavenLocal :client:publishToMavenLocal :vertx-client:publishToMavenLocal :vertx-client-shaded:publishToMavenLocal
+./gradlew -Pversion=1.0.0-local :vertx-client-shaded:publishToMavenLocal
 ```
 
 We use the suffix `-local` to denote that these artifacts have been built locally.

--- a/cassandra-analytics-core/build.gradle
+++ b/cassandra-analytics-core/build.gradle
@@ -22,13 +22,18 @@ project(':cassandra-analytics-core') {
     apply(plugin: 'jacoco')
     apply(plugin: 'maven-publish')
 
+    java {
+        withJavadocJar()
+        withSourcesJar()
+    }
+
     publishing {
         publications {
             maven(MavenPublication) {
                 from components.java
                 groupId project.group
                 artifactId "${archivesBaseName}"
-                version version
+                version System.getenv("CODE_VERSION") ?: "${version}"
             }
         }
     }

--- a/cassandra-analytics-core/build.gradle
+++ b/cassandra-analytics-core/build.gradle
@@ -59,9 +59,8 @@ project(':cassandra-analytics-core') {
         runtimeOnly(group: 'net.java.dev.jna', name: 'jna', version: "${jnaVersion}")
         runtimeOnly(group: 'net.java.dev.jna', name: 'jna-platform', version: "${jnaVersion}")
 
-        // This dependency needs to be installed locally by building the Cassandra Sidecar project using the following
-        // commands:
-        //  ./gradlew -Pversion=1.0.0-local :common:publishToMavenLocal :client:publishToMavenLocal :vertx-client:publishToMavenLocal :vertx-client-shaded:publishToMavenLocal
+        // This dependency needs to be installed locally by building the Cassandra Sidecar project using the following command:
+        //  ./gradlew -Pversion=1.0.0-local :vertx-client-shaded:publishToMavenLocal
         implementation(group: 'org.apache.cassandra.sidecar', name: 'vertx-client-all', version: "${sidecarVersion}") {
             exclude(group: 'com.fasterxml.jackson.core', module: 'jackson-annotations') // use provided annotations from spark
         }

--- a/cassandra-analytics-core/build.gradle
+++ b/cassandra-analytics-core/build.gradle
@@ -61,7 +61,7 @@ project(':cassandra-analytics-core') {
 
         // This dependency needs to be installed locally by building the Cassandra Sidecar project using the following command:
         //  ./gradlew -Pversion=1.0.0-local :vertx-client-shaded:publishToMavenLocal
-        implementation(group: 'org.apache.cassandra.sidecar', name: 'vertx-client-all', version: "${sidecarVersion}") {
+        implementation(group: "${sidecarClientGroup}", name: "${sidecarClientName}", version: "${sidecarVersion}") {
             exclude(group: 'com.fasterxml.jackson.core', module: 'jackson-annotations') // use provided annotations from spark
         }
 

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/secrets/SslConfigSecretsProviderTest.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/secrets/SslConfigSecretsProviderTest.java
@@ -231,7 +231,7 @@ public class SslConfigSecretsProviderTest
             keyStorePassAr = new char[]{};
         }
 
-        try (InputStream ksf = new BufferedInputStream((provider.keyStoreInputStream())))
+        try (InputStream ksf = new BufferedInputStream(provider.keyStoreInputStream()))
         {
             keystore.load(ksf, keyStorePassAr);
             kmf.init(keystore, keyStorePassAr);

--- a/profiles/scala-2.11-spark-2-jdk-1.8.gradle
+++ b/profiles/scala-2.11-spark-2-jdk-1.8.gradle
@@ -24,5 +24,7 @@ ext {
     sparkGroupId="org.apache.spark"
     sparkMajorVersion="2"
     sparkVersion="2.4.8"
+    sidecarClientGroup="org.apache.cassandra.sidecar"
+    sidecarClientName="vertx-client-all"
     sidecarVersion="1.0.0-jdk8-local"
 }

--- a/profiles/scala-2.12-spark-2-jdk-1.8.gradle
+++ b/profiles/scala-2.12-spark-2-jdk-1.8.gradle
@@ -24,5 +24,7 @@ ext {
     sparkGroupId="org.apache.spark"
     sparkMajorVersion="2"
     sparkVersion="2.4.8"
+    sidecarClientGroup="org.apache.cassandra.sidecar"
+    sidecarClientName="vertx-client-all"
     sidecarVersion="1.0.0-jdk8-local"
 }

--- a/profiles/scala-2.12-spark-3-jdk-11.gradle
+++ b/profiles/scala-2.12-spark-3-jdk-11.gradle
@@ -24,5 +24,7 @@ ext {
     sparkGroupId="org.apache.spark"
     sparkMajorVersion="3"
     sparkVersion="3.2.2"
+    sidecarClientGroup="org.apache.cassandra.sidecar"
+    sidecarClientName="vertx-client-all"
     sidecarVersion="1.0.0-local"
 }

--- a/profiles/scala-2.13-spark-3-jdk-11.gradle
+++ b/profiles/scala-2.13-spark-3-jdk-11.gradle
@@ -24,5 +24,7 @@ ext {
     sparkGroupId="org.apache.spark"
     sparkMajorVersion="3"
     sparkVersion="3.2.2"
+    sidecarClientGroup="org.apache.cassandra.sidecar"
+    sidecarClientName="vertx-client-all"
     sidecarVersion="1.0.0-local"
 }


### PR DESCRIPTION
This commit adds the CircleCI configuration yaml to test against all the existing profiles

      - cassandra-analytics-core-spark2-2.11-jdk8
      - cassandra-analytics-core-spark2-2.12-jdk8
      - cassandra-analytics-core-spark3-2.12-jdk11
      - cassandra-analytics-core-spark3-2.13-jdk11