### PR TITLE
CASSANDRA-18599 Upgrade to JUnit 5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,4 @@ cassandra-analytics-build.properties
 
 # MacOS
 .DS_Store
+cassandra-analytics-core/dtest-jars

--- a/cassandra-analytics-core/build.gradle
+++ b/cassandra-analytics-core/build.gradle
@@ -74,14 +74,16 @@ project(':cassandra-analytics-core') {
         compileOnly(group: "${sparkGroupId}", name: "spark-sql_${scalaMajorVersion}", version: "${project.rootProject.sparkVersion}")
 
         testImplementation(group: 'com.google.guava', name: 'guava', version: '19.0')
-        testImplementation(group: 'junit', name: 'junit', version: "${project.rootProject.junitVersion}")
+        testImplementation("org.junit.jupiter:junit-jupiter-api:${project.junitVersion}")
+        testImplementation("org.junit.jupiter:junit-jupiter-params:${project.junitVersion}")
+        testImplementation("org.junit.jupiter:junit-jupiter-engine:${project.junitVersion}")
         testImplementation(group: 'org.quicktheories', name: 'quicktheories', version: "${project.rootProject.quickTheoriesVersion}")
         testImplementation(group: 'org.slf4j', name: 'slf4j-simple', version: '1.7.26')
         testImplementation(group: 'org.mockito', name: 'mockito-core', version: "${project.rootProject.mockitoVersion}")
         testImplementation(group: 'org.mockito', name: 'mockito-inline', version: "${project.rootProject.mockitoVersion}")
         testImplementation(group: "${sparkGroupId}", name: "spark-core_${scalaMajorVersion}", version: "${project.rootProject.sparkVersion}")
         testImplementation(group: "${sparkGroupId}", name: "spark-sql_${scalaMajorVersion}", version: "${project.rootProject.sparkVersion}")
-        testImplementation(group: 'org.hamcrest', name: 'hamcrest-all', version: '1.3')
+        testImplementation(group: 'org.hamcrest', name: 'hamcrest', version: '2.2')
         testImplementation(group: 'org.openjdk.jmh', name: 'jmh-core', version: '1.33')
         testImplementation(group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.13')
         testImplementation(group: 'com.github.luben', name: 'zstd-jni', version: '1.5.0-4')
@@ -132,7 +134,7 @@ project(':cassandra-analytics-core') {
         // Make it so unit tests run on a JAr with Cassandra bridge implementations built in
         dependsOn(tasks.jar)
         classpath = project.sourceSets.test.output + configurations.testRuntimeClasspath + files(jar.archiveFile)
-        useJUnit()
+        useJUnitPlatform()
     }
 
     /* Start: JaCoCo check */

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/bridge/CassandraVersionFeaturesTest.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/bridge/CassandraVersionFeaturesTest.java
@@ -19,9 +19,10 @@
 
 package org.apache.cassandra.bridge;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class CassandraVersionFeaturesTest
 {
@@ -42,18 +43,20 @@ public class CassandraVersionFeaturesTest
         testCassandraVersion("qwerty-cassandra-4.0-SNAPSHOT", 40, 0, "SNAPSHOT");
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test()
     public void testInvalidInput()
     {
-        CassandraVersionFeatures.cassandraVersionFeaturesFromCassandraVersion("qwerty");
+        assertThrows(RuntimeException.class, () ->
+            CassandraVersionFeatures.cassandraVersionFeaturesFromCassandraVersion("qwerty")
+        );
     }
 
     private static void testCassandraVersion(String version, int major, int minor, String suffix)
     {
         CassandraVersionFeatures features = CassandraVersionFeatures.cassandraVersionFeaturesFromCassandraVersion(version);
 
-        assertEquals("Wrong major version for " + version + ",", major, features.getMajorVersion());
-        assertEquals("Wrong minor version for " + version + ",", minor, features.getMinorVersion());
-        assertEquals("Wrong version suffix for " + version + ",", suffix, features.getSuffix());
+        assertEquals(major, features.getMajorVersion(), "Wrong major version for " + version + ",");
+        assertEquals(minor, features.getMinorVersion(), "Wrong minor version for " + version + ",");
+        assertEquals(suffix, features.getSuffix(), "Wrong version suffix for " + version + ",");
     }
 }

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/bridge/CompressionTests.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/bridge/CompressionTests.java
@@ -23,30 +23,32 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 
-import org.junit.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import org.apache.cassandra.spark.utils.RandomUtils;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class CompressionTests extends VersionRunner
 {
-    public CompressionTests(CassandraVersion version)
-    {
-        super(version);
-    }
+    private CassandraBridge bridge;
 
-    @Test
-    public void testCompressRandom() throws IOException
+    @ParameterizedTest()
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#versions")
+    public void testCompressRandom(CassandraVersion version) throws IOException
     {
+        bridge = CassandraBridgeFactory.get(version);
         // Test with random data - not highly compressible
         testCompression(RandomUtils.randomBytes(4096));
     }
 
-    @Test
-    public void testCompressUniform() throws IOException
+    @ParameterizedTest()
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#versions")
+    public void testCompressUniform(CassandraVersion version) throws IOException
     {
+        bridge = CassandraBridgeFactory.get(version);
         // Test with highly compressible data
         byte[] bytes = new byte[4096];
         Arrays.fill(bytes, (byte) 'a');

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/bridge/VersionRunner.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/bridge/VersionRunner.java
@@ -21,31 +21,26 @@ package org.apache.cassandra.bridge;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 import java.util.stream.Collectors;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Named;
 
 /**
- * Runs parameterized tests for all defined versions of Cassandra
+ * Shared version provider for all defined versions of Cassandra
  */
-@RunWith(Parameterized.class)
-public abstract class VersionRunner
+public class VersionRunner
 {
-    protected final CassandraVersion version;
-    protected final CassandraBridge bridge;
 
-    @Parameterized.Parameters
-    public static Collection<Object[]> versions()
+    public static Collection<CassandraVersion> versions()
     {
         return Arrays.stream(CassandraVersion.implementedVersions())
-                     .map(version -> new Object[]{version})
                      .collect(Collectors.toList());
     }
 
-    public VersionRunner(CassandraVersion version)
+    public static List<Named<CassandraBridge>> bridges()
     {
-        this.version = version;
-        this.bridge = CassandraBridgeFactory.get(version);
+        return versions().stream().map(version -> Named.of(version.toString(), CassandraBridgeFactory.get(version)))
+                                            .collect(Collectors.toList());
     }
 }

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/clients/SidecarClientConfigTest.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/clients/SidecarClientConfigTest.java
@@ -20,9 +20,9 @@
 package org.apache.cassandra.clients;
 
 import com.google.common.collect.ImmutableMap;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Unit tests for the {@link Sidecar.ClientConfig} inner class

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/clients/SidecarInstanceImplTest.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/clients/SidecarInstanceImplTest.java
@@ -19,8 +19,8 @@
 
 package org.apache.cassandra.clients;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import com.esotericsoftware.kryo.io.Output;
 import org.apache.cassandra.sidecar.client.SidecarInstance;
@@ -30,15 +30,15 @@ import static org.apache.cassandra.spark.utils.SerializationUtils.kryoDeserializ
 import static org.apache.cassandra.spark.utils.SerializationUtils.kryoSerialize;
 import static org.apache.cassandra.spark.utils.SerializationUtils.register;
 import static org.apache.cassandra.spark.utils.SerializationUtils.serialize;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * Unit tests for the {@link SidecarInstanceImpl} class
  */
 public class SidecarInstanceImplTest extends SidecarInstanceTest
 {
-    @BeforeClass
+    @BeforeAll
     public static void setupKryo()
     {
         register(SidecarInstanceImpl.class, new SidecarInstanceImpl.Serializer());

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/clients/SidecarInstanceTest.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/clients/SidecarInstanceTest.java
@@ -19,13 +19,13 @@
 
 package org.apache.cassandra.clients;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.apache.cassandra.sidecar.client.SidecarInstance;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Abstract class that provides a set of base unit tests for the {@link SidecarInstance} interface

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/secrets/SslConfigSecretsProviderTest.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/secrets/SslConfigSecretsProviderTest.java
@@ -38,29 +38,29 @@ import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.TrustManagerFactory;
 
 import org.apache.commons.io.IOUtils;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class SslConfigSecretsProviderTest
 {
-    @Rule
-    public TemporaryFolder folder = new TemporaryFolder();
+    @TempDir
+    public Path folder; // CHECKSTYLE IGNORE: Public mutable field for testing
 
     String keyStorePassword;
     String trustStorePassword;
 
-    @Before
+    @BeforeEach
     public void setup() throws IOException
     {
-        Path path = folder.newFolder("secrets-config").toPath();
+        Path path = folder.resolve("secrets-config");
+        Files.createDirectories(path);
 
         try (InputStream stream = getClass().getResourceAsStream("/secrets/fakecerts/client-keystore.p12"))
         {
@@ -88,10 +88,10 @@ public class SslConfigSecretsProviderTest
     public void testSuccessWithCertsPaths() throws IOException
     {
         Map<String, String> jobOptions = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
-        jobOptions.put(SslConfig.KEYSTORE_PATH, folder.getRoot().getAbsolutePath() + "/secrets-config/keystore.p12");
+        jobOptions.put(SslConfig.KEYSTORE_PATH, folder.toAbsolutePath() + "/secrets-config/keystore.p12");
         jobOptions.put(SslConfig.KEYSTORE_PASSWORD, keyStorePassword);
         jobOptions.put(SslConfig.KEYSTORE_TYPE, "PKCS12");
-        jobOptions.put(SslConfig.TRUSTSTORE_PATH, folder.getRoot().getAbsolutePath() + "/secrets-config/truststore.jks");
+        jobOptions.put(SslConfig.TRUSTSTORE_PATH, folder.toAbsolutePath() + "/secrets-config/truststore.jks");
         jobOptions.put(SslConfig.TRUSTSTORE_PASSWORD, trustStorePassword);
         jobOptions.put(SslConfig.TRUSTSTORE_TYPE, "JKS");
 
@@ -125,9 +125,9 @@ public class SslConfigSecretsProviderTest
     public void testSuccessWithEncodedCerts() throws IOException
     {
         Map<String, String> jobOptions = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
-        String keyStorePath = folder.getRoot().getAbsolutePath() + "/secrets-config/keystore.p12";
+        String keyStorePath = folder.toAbsolutePath() + "/secrets-config/keystore.p12";
         String encodedKeyStore = Base64.getEncoder().encodeToString(Files.readAllBytes(Paths.get(keyStorePath)));
-        String trustStorePath = folder.getRoot().getAbsolutePath() + "/secrets-config/truststore.jks";
+        String trustStorePath = folder.toAbsolutePath() + "/secrets-config/truststore.jks";
         String encodedTrustStore = Base64.getEncoder().encodeToString(Files.readAllBytes(Paths.get(trustStorePath)));
 
         jobOptions.put(SslConfig.KEYSTORE_BASE64_ENCODED, encodedKeyStore);
@@ -167,10 +167,10 @@ public class SslConfigSecretsProviderTest
     public void testInvalidPathToKeyStore()
     {
         Map<String, String> jobOptions = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
-        jobOptions.put(SslConfig.KEYSTORE_PATH, folder.getRoot().getAbsolutePath() + "/secrets-config/non-existent-keystore.p12");
+        jobOptions.put(SslConfig.KEYSTORE_PATH, folder.toAbsolutePath() + "/secrets-config/non-existent-keystore.p12");
         jobOptions.put(SslConfig.KEYSTORE_PASSWORD, keyStorePassword);
         jobOptions.put(SslConfig.KEYSTORE_TYPE, "PKCS12");
-        jobOptions.put(SslConfig.TRUSTSTORE_PATH, folder.getRoot().getAbsolutePath() + "/secrets-config/truststore.jks");
+        jobOptions.put(SslConfig.TRUSTSTORE_PATH, folder.toAbsolutePath() + "/secrets-config/truststore.jks");
         jobOptions.put(SslConfig.TRUSTSTORE_PASSWORD, trustStorePassword);
         jobOptions.put(SslConfig.TRUSTSTORE_TYPE, "JKS");
 
@@ -194,10 +194,10 @@ public class SslConfigSecretsProviderTest
     public void testInvalidPathToTrustStore()
     {
         Map<String, String> jobOptions = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
-        jobOptions.put(SslConfig.KEYSTORE_PATH, folder.getRoot().getAbsolutePath() + "/secrets-config/keystore.p12");
+        jobOptions.put(SslConfig.KEYSTORE_PATH, folder.toAbsolutePath() + "/secrets-config/keystore.p12");
         jobOptions.put(SslConfig.KEYSTORE_PASSWORD, keyStorePassword);
         jobOptions.put(SslConfig.KEYSTORE_TYPE, "PKCS12");
-        jobOptions.put(SslConfig.TRUSTSTORE_PATH, folder.getRoot().getAbsolutePath() + "/secrets-config/non-existent-truststore.jks");
+        jobOptions.put(SslConfig.TRUSTSTORE_PATH, folder.toAbsolutePath() + "/secrets-config/non-existent-truststore.jks");
         jobOptions.put(SslConfig.TRUSTSTORE_PASSWORD, trustStorePassword);
         jobOptions.put(SslConfig.TRUSTSTORE_TYPE, "JKS");
 

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/secrets/SslConfigTest.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/secrets/SslConfigTest.java
@@ -23,7 +23,7 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.TreeMap;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.apache.cassandra.secrets.SslConfig.KEYSTORE_BASE64_ENCODED;
 import static org.apache.cassandra.secrets.SslConfig.KEYSTORE_PASSWORD;
@@ -31,10 +31,10 @@ import static org.apache.cassandra.secrets.SslConfig.KEYSTORE_PATH;
 import static org.apache.cassandra.secrets.SslConfig.TRUSTSTORE_BASE64_ENCODED;
 import static org.apache.cassandra.secrets.SslConfig.TRUSTSTORE_PASSWORD;
 import static org.apache.cassandra.secrets.SslConfig.TRUSTSTORE_PATH;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Unit tests for the {@link SslConfig} class

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/EndToEndTests.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/EndToEndTests.java
@@ -41,12 +41,15 @@ import com.google.common.collect.Maps;
 import com.google.common.util.concurrent.Uninterruptibles;
 import org.apache.commons.lang3.mutable.MutableLong;
 import org.apache.commons.lang3.tuple.Pair;
-import org.junit.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
+import org.apache.cassandra.bridge.CassandraBridge;
+import org.apache.cassandra.bridge.CassandraBridgeFactory;
 import org.apache.cassandra.bridge.CassandraVersion;
+import org.apache.cassandra.bridge.VersionRunner;
 import org.apache.cassandra.spark.data.CqlField;
 import org.apache.cassandra.spark.data.SSTable;
-import org.apache.cassandra.spark.data.VersionRunner;
 import org.apache.cassandra.spark.stats.Stats;
 import org.apache.cassandra.spark.utils.RandomUtils;
 import org.apache.cassandra.spark.utils.streaming.SSTableSource;
@@ -55,11 +58,11 @@ import org.apache.spark.sql.Row;
 import scala.collection.mutable.AbstractSeq;
 
 import static org.apache.cassandra.spark.utils.ScalaConversionUtils.mutableSeqAsJavaList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.quicktheories.QuickTheory.qt;
 import static org.quicktheories.generators.SourceDSL.booleans;
 import static org.quicktheories.generators.SourceDSL.characters;
@@ -72,17 +75,14 @@ import static org.quicktheories.generators.SourceDSL.integers;
  * Uses custom SSTableTombstoneWriter to write SSTables with tombstones
  * to verify Spark Bulk Reader correctly purges tombstoned data.
  */
+
 public class EndToEndTests extends VersionRunner
 {
-    public EndToEndTests(CassandraVersion version)
-    {
-        super(version);
-    }
 
     /* Partition Key Tests */
-
-    @Test
-    public void testSinglePartitionKey()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
+    public void testSinglePartitionKey(CassandraBridge bridge)
     {
         Tester.builder(TestSchema.builder()
                                  .withPartitionKey("pk", bridge.uuid())
@@ -93,8 +93,9 @@ public class EndToEndTests extends VersionRunner
               .run();
     }
 
-    @Test
-    public void testOnlyPartitionKeys()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
+    public void testOnlyPartitionKeys(CassandraBridge bridge)
     {
         // Special case where schema is only partition keys
         Tester.builder(TestSchema.builder()
@@ -108,8 +109,9 @@ public class EndToEndTests extends VersionRunner
               .run();
     }
 
-    @Test
-    public void testOnlyPartitionClusteringKeys()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
+    public void testOnlyPartitionClusteringKeys(CassandraBridge bridge)
     {
         Tester.builder(TestSchema.builder()
                                  .withPartitionKey("a", bridge.uuid())
@@ -119,8 +121,9 @@ public class EndToEndTests extends VersionRunner
               .run();
     }
 
-    @Test
-    public void testMultiplePartitionKeys()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
+    public void testMultiplePartitionKeys(CassandraBridge bridge)
     {
         Tester.builder(TestSchema.builder()
                                  .withPartitionKey("a", bridge.uuid())
@@ -134,8 +137,9 @@ public class EndToEndTests extends VersionRunner
 
     /* Clustering Key Tests */
 
-    @Test
-    public void testBasicSingleClusteringKey()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
+    public void testBasicSingleClusteringKey(CassandraBridge bridge)
     {
         Tester.builder(TestSchema.builder()
                                  .withPartitionKey("a", bridge.bigint())
@@ -146,8 +150,9 @@ public class EndToEndTests extends VersionRunner
               .run();
     }
 
-    @Test
-    public void testSingleClusteringKeyOrderBy()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
+    public void testSingleClusteringKeyOrderBy(CassandraBridge bridge)
     {
         qt().forAll(TestUtils.cql3Type(bridge), TestUtils.sortOrder())
             .checkAssert((clusteringKeyType, sortOrder) ->
@@ -161,8 +166,9 @@ public class EndToEndTests extends VersionRunner
             );
     }
 
-    @Test
-    public void testMultipleClusteringKeys()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
+    public void testMultipleClusteringKeys(CassandraBridge bridge)
     {
         Tester.builder(TestSchema.builder()
                                  .withPartitionKey("a", bridge.uuid())
@@ -175,8 +181,9 @@ public class EndToEndTests extends VersionRunner
               .run();
     }
 
-    @Test
-    public void testManyClusteringKeys()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
+    public void testManyClusteringKeys(CassandraBridge bridge)
     {
         Tester.builder(TestSchema.builder()
                                  .withPartitionKey("a", bridge.uuid())
@@ -193,8 +200,9 @@ public class EndToEndTests extends VersionRunner
 
     /* Data Type Tests */
 
-    @Test
-    public void testAllDataTypesPartitionKey()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
+    public void testAllDataTypesPartitionKey(CassandraBridge bridge)
     {
         // Test partition key can be read for all data types
         qt().forAll(TestUtils.cql3Type(bridge))
@@ -211,8 +219,9 @@ public class EndToEndTests extends VersionRunner
             });
     }
 
-    @Test
-    public void testAllDataTypesValueColumn()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
+    public void testAllDataTypesValueColumn(CassandraBridge bridge)
     {
         // Test value column can be read for all data types
         qt().forAll(TestUtils.cql3Type(bridge))
@@ -228,8 +237,9 @@ public class EndToEndTests extends VersionRunner
 
     /* Compaction */
 
-    @Test
-    public void testMultipleSSTablesCompaction()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
+    public void testMultipleSSTablesCompaction(CassandraBridge bridge)
     {
         AtomicLong startTotal = new AtomicLong(0);
         AtomicLong newTotal = new AtomicLong(0);
@@ -286,8 +296,9 @@ public class EndToEndTests extends VersionRunner
               });
     }
 
-    @Test
-    public void testCompaction()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
+    public void testCompaction(CassandraBridge bridge)
     {
         int numRowsColumns = 20;
         AtomicInteger total = new AtomicInteger(0);
@@ -339,8 +350,9 @@ public class EndToEndTests extends VersionRunner
               .run();
     }
 
-    @Test
-    public void testSingleClusteringKey()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
+    public void testSingleClusteringKey(CassandraBridge bridge)
     {
         AtomicLong total = new AtomicLong(0);
         Map<Integer, MutableLong> testSum = new HashMap<>();
@@ -405,8 +417,9 @@ public class EndToEndTests extends VersionRunner
 
     /* Static Columns */
 
-    @Test
-    public void testOnlyStaticColumn()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
+    public void testOnlyStaticColumn(CassandraBridge bridge)
     {
         Tester.builder(TestSchema.builder()
                                  .withPartitionKey("a", bridge.uuid())
@@ -416,9 +429,10 @@ public class EndToEndTests extends VersionRunner
               .run();
     }
 
-    @Test
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
     @SuppressWarnings("UnstableApiUsage")  // Use of Guava Uninterruptibles
-    public void testStaticColumn()
+    public void testStaticColumn(CassandraBridge bridge)
     {
         int numRows = 100;
         int numColumns = 20;
@@ -468,8 +482,9 @@ public class EndToEndTests extends VersionRunner
               .run();
     }
 
-    @Test
-    public void testNulledStaticColumns()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
+    public void testNulledStaticColumns(CassandraBridge bridge)
     {
         int numClusteringKeys = 10;
         Tester.builder(TestSchema.builder()
@@ -502,9 +517,11 @@ public class EndToEndTests extends VersionRunner
               .run();
     }
 
-    @Test
-    public void testMultipleSSTableCompacted()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#versions")
+    public void testMultipleSSTableCompacted(CassandraVersion version)
     {
+        CassandraBridge bridge = CassandraBridgeFactory.get(version);
         TestSchema.Builder schemaBuilder = TestSchema.builder()
                                                      .withPartitionKey("a", bridge.uuid())
                                                      .withClusteringKey("b", bridge.aInt())
@@ -567,8 +584,9 @@ public class EndToEndTests extends VersionRunner
 
     /* Tombstone Tests */
 
-    @Test
-    public void testPartitionTombstoneInt()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
+    public void testPartitionTombstoneInt(CassandraBridge bridge)
     {
         int numRows = 100;
         int numColumns = 10;
@@ -614,8 +632,9 @@ public class EndToEndTests extends VersionRunner
             });
     }
 
-    @Test
-    public void testRowTombstoneInt()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
+    public void testRowTombstoneInt(CassandraBridge bridge)
     {
         int numRows = 100;
         int numColumns = 10;
@@ -658,8 +677,9 @@ public class EndToEndTests extends VersionRunner
             );
     }
 
-    @Test
-    public void testRangeTombstoneInt()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
+    public void testRangeTombstoneInt(CassandraBridge bridge)
     {
         int numRows = 10;
         int numColumns = 128;
@@ -708,8 +728,9 @@ public class EndToEndTests extends VersionRunner
             });
     }
 
-    @Test
-    public void testRangeTombstoneString()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
+    public void testRangeTombstoneString(CassandraBridge bridge)
     {
         int numRows = 10;
         int numColumns = 128;
@@ -763,8 +784,9 @@ public class EndToEndTests extends VersionRunner
 
     /* Partial Rows: test reading rows with missing columns */
 
-    @Test
-    public void testPartialRow()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
+    public void testPartialRow(CassandraBridge bridge)
     {
         Map<UUID, UUID> rows = new HashMap<>();
         Tester.builder(TestSchema.builder()
@@ -804,8 +826,9 @@ public class EndToEndTests extends VersionRunner
               .run();
     }
 
-    @Test
-    public void testPartialRowClusteringKeys()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
+    public void testPartialRowClusteringKeys(CassandraBridge bridge)
     {
         Map<String, String> rows = new HashMap<>();
         Tester.builder(TestSchema.builder()
@@ -857,8 +880,9 @@ public class EndToEndTests extends VersionRunner
 
     /* Collections */
 
-    @Test
-    public void testSet()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
+    public void testSet(CassandraBridge bridge)
     {
         qt().forAll(TestUtils.cql3Type(bridge))
             .checkAssert(type ->
@@ -870,8 +894,9 @@ public class EndToEndTests extends VersionRunner
             );
     }
 
-    @Test
-    public void testList()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
+    public void testList(CassandraBridge bridge)
     {
         qt().forAll(TestUtils.cql3Type(bridge))
             .checkAssert(type ->
@@ -883,8 +908,9 @@ public class EndToEndTests extends VersionRunner
             );
     }
 
-    @Test
-    public void testMap()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
+    public void testMap(CassandraBridge bridge)
     {
         qt().withExamples(50)  // Limit number of tests otherwise n x n tests takes too long
             .forAll(TestUtils.cql3Type(bridge), TestUtils.cql3Type(bridge))
@@ -897,8 +923,9 @@ public class EndToEndTests extends VersionRunner
             );
     }
 
-    @Test
-    public void testClusteringKeySet()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
+    public void testClusteringKeySet(CassandraBridge bridge)
     {
         Tester.builder(TestSchema.builder()
                                  .withPartitionKey("pk", bridge.uuid())
@@ -910,8 +937,9 @@ public class EndToEndTests extends VersionRunner
 
     /* Frozen Collections */
 
-    @Test
-    public void testFrozenSet()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
+    public void testFrozenSet(CassandraBridge bridge)
     {
         // pk -> a frozen<set<?>>
         qt().forAll(TestUtils.cql3Type(bridge))
@@ -924,8 +952,9 @@ public class EndToEndTests extends VersionRunner
             );
     }
 
-    @Test
-    public void testFrozenList()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
+    public void testFrozenList(CassandraBridge bridge)
     {
         // pk -> a frozen<list<?>>
         qt().forAll(TestUtils.cql3Type(bridge))
@@ -938,8 +967,9 @@ public class EndToEndTests extends VersionRunner
             );
     }
 
-    @Test
-    public void testFrozenMap()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
+    public void testFrozenMap(CassandraBridge bridge)
     {
         // pk -> a frozen<map<?, ?>>
         qt().withExamples(50)  // Limit number of tests otherwise n x n tests takes too long
@@ -953,8 +983,9 @@ public class EndToEndTests extends VersionRunner
             );
     }
 
-    @Test
-    public void testNestedMapSet()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
+    public void testNestedMapSet(CassandraBridge bridge)
     {
         // pk -> a map<text, frozen<set<text>>>
         Tester.builder(TestSchema.builder()
@@ -965,8 +996,9 @@ public class EndToEndTests extends VersionRunner
               .run();
     }
 
-    @Test
-    public void testNestedMapList()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
+    public void testNestedMapList(CassandraBridge bridge)
     {
         // pk -> a map<text, frozen<list<text>>>
         Tester.builder(TestSchema.builder()
@@ -977,8 +1009,9 @@ public class EndToEndTests extends VersionRunner
               .run();
     }
 
-    @Test
-    public void testNestedMapMap()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
+    public void testNestedMapMap(CassandraBridge bridge)
     {
         // pk -> a map<text, frozen<map<bigint, varchar>>>
         Tester.builder(TestSchema.builder()
@@ -991,8 +1024,9 @@ public class EndToEndTests extends VersionRunner
               .run();
     }
 
-    @Test
-    public void testFrozenNestedMapMap()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
+    public void testFrozenNestedMapMap(CassandraBridge bridge)
     {
         // pk -> a frozen<map<text, <map<int, timestamp>>>
         Tester.builder(TestSchema.builder()
@@ -1007,8 +1041,9 @@ public class EndToEndTests extends VersionRunner
 
     /* Filters */
 
-    @Test
-    public void testSinglePartitionKeyFilter()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
+    public void testSinglePartitionKeyFilter(CassandraBridge bridge)
     {
         int numRows = 10;
         Tester.builder(TestSchema.builder()
@@ -1032,8 +1067,9 @@ public class EndToEndTests extends VersionRunner
               .run();
     }
 
-    @Test
-    public void testMultiplePartitionKeyFilter()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
+    public void testMultiplePartitionKeyFilter(CassandraBridge bridge)
     {
         int numRows = 10;
         int numColumns = 5;
@@ -1068,8 +1104,9 @@ public class EndToEndTests extends VersionRunner
               .run();
     }
 
-    @Test
-    public void testFiltersDoNotMatch()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
+    public void testFiltersDoNotMatch(CassandraBridge bridge)
     {
         int numRows = 10;
         Tester.builder(TestSchema.builder()
@@ -1087,8 +1124,9 @@ public class EndToEndTests extends VersionRunner
               .run();
     }
 
-    @Test
-    public void testFilterWithClusteringKey()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
+    public void testFilterWithClusteringKey(CassandraBridge bridge)
     {
         int numRows = 10;
         Tester.builder(TestSchema.builder()
@@ -1116,8 +1154,9 @@ public class EndToEndTests extends VersionRunner
               .run();
     }
 
-    @Test
-    public void testUdtNativeTypes()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
+    public void testUdtNativeTypes(CassandraBridge bridge)
     {
         // pk -> a testudt<b text, c type, d int>
         qt().forAll(TestUtils.cql3Type(bridge))
@@ -1133,8 +1172,9 @@ public class EndToEndTests extends VersionRunner
             );
     }
 
-    @Test
-    public void testUdtInnerSet()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
+    public void testUdtInnerSet(CassandraBridge bridge)
     {
         // pk -> a testudt<b text, c frozen<type>, d int>
         qt().forAll(TestUtils.cql3Type(bridge))
@@ -1150,8 +1190,9 @@ public class EndToEndTests extends VersionRunner
             );
     }
 
-    @Test
-    public void testUdtInnerList()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
+    public void testUdtInnerList(CassandraBridge bridge)
     {
         // pk -> a testudt<b bigint, c frozen<list<type>>, d boolean>
         qt().forAll(TestUtils.cql3Type(bridge))
@@ -1167,8 +1208,9 @@ public class EndToEndTests extends VersionRunner
             );
     }
 
-    @Test
-    public void testUdtInnerMap()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
+    public void testUdtInnerMap(CassandraBridge bridge)
     {
         // pk -> a testudt<b float, c frozen<set<uuid>>, d frozen<map<type1, type2>>, e boolean>
         qt().withExamples(50)
@@ -1186,8 +1228,9 @@ public class EndToEndTests extends VersionRunner
             );
     }
 
-    @Test
-    public void testMultipleUdts()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
+    public void testMultipleUdts(CassandraBridge bridge)
     {
         // pk -> col1 udt1<a float, b frozen<set<uuid>>, c frozen<set<type>>, d boolean>,
         //       col2 udt2<a text, b bigint, g varchar>, col3 udt3<int, type, ascii>
@@ -1215,8 +1258,9 @@ public class EndToEndTests extends VersionRunner
             );
     }
 
-    @Test
-    public void testNestedUdt()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
+    public void testNestedUdt(CassandraBridge bridge)
     {
         // pk -> a test_udt<b float, c frozen<set<uuid>>, d frozen<nested_udt<x int, y type, z int>>, e boolean>
         qt().forAll(TestUtils.cql3Type(bridge))
@@ -1239,8 +1283,9 @@ public class EndToEndTests extends VersionRunner
 
     /* Tuples */
 
-    @Test
-    public void testBasicTuple()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
+    public void testBasicTuple(CassandraBridge bridge)
     {
         // pk -> a tuple<int, type1, bigint, type2>
         qt().withExamples(10)
@@ -1253,8 +1298,9 @@ public class EndToEndTests extends VersionRunner
             );
     }
 
-    @Test
-    public void testTupleWithClusteringKey()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
+    public void testTupleWithClusteringKey(CassandraBridge bridge)
     {
         // pk -> col1 type1 -> a tuple<int, type2, bigint>
         qt().withExamples(10)
@@ -1268,8 +1314,9 @@ public class EndToEndTests extends VersionRunner
             );
     }
 
-    @Test
-    public void testNestedTuples()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
+    public void testNestedTuples(CassandraBridge bridge)
     {
         // pk -> a tuple<varchar, tuple<int, type1, float, varchar, tuple<bigint, boolean, type2>>, timeuuid>
         // Test tuples nested within tuple
@@ -1291,8 +1338,9 @@ public class EndToEndTests extends VersionRunner
             );
     }
 
-    @Test
-    public void testTupleSet()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
+    public void testTupleSet(CassandraBridge bridge)
     {
         // pk -> a tuple<varchar, tuple<int, varchar, float, varchar, set<type>>, timeuuid>
         // Test set nested within tuple
@@ -1312,8 +1360,9 @@ public class EndToEndTests extends VersionRunner
             );
     }
 
-    @Test
-    public void testTupleList()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
+    public void testTupleList(CassandraBridge bridge)
     {
         // pk -> a tuple<varchar, tuple<int, varchar, float, varchar, list<type>>, timeuuid>
         // Test list nested within tuple
@@ -1333,8 +1382,9 @@ public class EndToEndTests extends VersionRunner
             );
     }
 
-    @Test
-    public void testTupleMap()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
+    public void testTupleMap(CassandraBridge bridge)
     {
         // pk -> a tuple<varchar, tuple<int, varchar, float, varchar, map<type1, type2>>, timeuuid>
         // Test map nested within tuple
@@ -1354,8 +1404,9 @@ public class EndToEndTests extends VersionRunner
             );
     }
 
-    @Test
-    public void testMapTuple()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
+    public void testMapTuple(CassandraBridge bridge)
     {
         // pk -> a map<timeuuid, frozen<tuple<boolean, type, timestamp>>>
         // Test tuple nested within map
@@ -1372,8 +1423,9 @@ public class EndToEndTests extends VersionRunner
             );
     }
 
-    @Test
-    public void testSetTuple()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
+    public void testSetTuple(CassandraBridge bridge)
     {
         // pk -> a set<frozen<tuple<type, float, text>>>
         // Test tuple nested within set
@@ -1389,8 +1441,9 @@ public class EndToEndTests extends VersionRunner
             );
     }
 
-    @Test
-    public void testListTuple()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
+    public void testListTuple(CassandraBridge bridge)
     {
         // pk -> a list<frozen<tuple<int, inet, decimal, type>>>
         // Test tuple nested within map
@@ -1407,8 +1460,9 @@ public class EndToEndTests extends VersionRunner
             );
     }
 
-    @Test
-    public void testTupleUDT()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
+    public void testTupleUDT(CassandraBridge bridge)
     {
         // pk -> a tuple<varchar, frozen<nested_udt<x int, y type, z int>>, timeuuid>
         // Test tuple with inner UDT
@@ -1428,8 +1482,9 @@ public class EndToEndTests extends VersionRunner
             );
     }
 
-    @Test
-    public void testUDTTuple()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
+    public void testUDTTuple(CassandraBridge bridge)
     {
         // pk -> a nested_udt<x text, y tuple<int, float, type, timestamp>, z ascii>
         // Test UDT with inner tuple
@@ -1450,8 +1505,9 @@ public class EndToEndTests extends VersionRunner
             );
     }
 
-    @Test
-    public void testTupleClusteringKey()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
+    public void testTupleClusteringKey(CassandraBridge bridge)
     {
         qt().forAll(TestUtils.cql3Type(bridge))
             .checkAssert(type ->
@@ -1468,8 +1524,9 @@ public class EndToEndTests extends VersionRunner
             );
     }
 
-    @Test
-    public void testUdtClusteringKey()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
+    public void testUdtClusteringKey(CassandraBridge bridge)
     {
         qt().forAll(TestUtils.cql3Type(bridge))
             .checkAssert(type ->
@@ -1487,8 +1544,9 @@ public class EndToEndTests extends VersionRunner
             );
     }
 
-    @Test
-    public void testComplexSchema()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
+    public void testComplexSchema(CassandraBridge bridge)
     {
         String keyspace = "complex_schema2";
         CqlField.CqlUdt udt1 = bridge.udt(keyspace, "udt1")
@@ -1533,8 +1591,9 @@ public class EndToEndTests extends VersionRunner
               .run();
     }
 
-    @Test
-    public void testNestedFrozenUDT()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
+    public void testNestedFrozenUDT(CassandraBridge bridge)
     {
         // "(a bigint PRIMARY KEY, b <map<int, frozen<testudt>>>)"
         // testudt(a text, b bigint, c int)
@@ -1550,8 +1609,9 @@ public class EndToEndTests extends VersionRunner
               .run();
     }
 
-    @Test
-    public void testDeepNestedUDT()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
+    public void testDeepNestedUDT(CassandraBridge bridge)
     {
         String keyspace = "deep_nested_frozen_udt";
         CqlField.CqlUdt udt1 = bridge.udt(keyspace, "udt1")
@@ -1649,8 +1709,9 @@ public class EndToEndTests extends VersionRunner
 
     /* BigDecimal/Integer Tests */
 
-    @Test
-    public void testBigDecimal()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
+    public void testBigDecimal(CassandraBridge bridge)
     {
         Tester.builder(TestSchema.builder()
                                  .withPartitionKey("pk", bridge.uuid())
@@ -1659,8 +1720,9 @@ public class EndToEndTests extends VersionRunner
               .run();
     }
 
-    @Test
-    public void testBigInteger()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
+    public void testBigInteger(CassandraBridge bridge)
     {
         Tester.builder(TestSchema.builder()
                                  .withPartitionKey("pk", bridge.uuid())
@@ -1669,8 +1731,9 @@ public class EndToEndTests extends VersionRunner
               .run();
     }
 
-    @Test
-    public void testUdtFieldOrdering()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
+    public void testUdtFieldOrdering(CassandraBridge bridge)
     {
         String keyspace = "udt_field_ordering";
         CqlField.CqlUdt udt1 = bridge.udt(keyspace, "udt1")
@@ -1685,9 +1748,10 @@ public class EndToEndTests extends VersionRunner
               .run();
     }
 
-    @Test
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
     @SuppressWarnings("unchecked")
-    public void testUdtTupleInnerNulls()
+    public void testUdtTupleInnerNulls(CassandraBridge bridge)
     {
         CqlField.CqlUdt udtType = bridge.udt("udt_inner_nulls", "udt")
                                         .withField("a", bridge.uuid())
@@ -1764,8 +1828,9 @@ public class EndToEndTests extends VersionRunner
 
     /* Complex Clustering Keys */
 
-    @Test
-    public void testUdtsWithNulls()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
+    public void testUdtsWithNulls(CassandraBridge bridge)
     {
         CqlField.CqlUdt type = bridge.udt("udt_with_nulls", "udt1")
                                      .withField("a", bridge.text())
@@ -1811,8 +1876,9 @@ public class EndToEndTests extends VersionRunner
               .run();
     }
 
-    @Test
-    public void testMapClusteringKey()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
+    public void testMapClusteringKey(CassandraBridge bridge)
     {
         Tester.builder(TestSchema.builder()
                                  .withPartitionKey("pk", bridge.uuid())
@@ -1824,8 +1890,9 @@ public class EndToEndTests extends VersionRunner
               .run();
     }
 
-    @Test
-    public void testListClusteringKey()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
+    public void testListClusteringKey(CassandraBridge bridge)
     {
         Tester.builder(TestSchema.builder()
                                  .withPartitionKey("pk", bridge.uuid())
@@ -1836,8 +1903,9 @@ public class EndToEndTests extends VersionRunner
               .run();
     }
 
-    @Test
-    public void testSetClusteringKey()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
+    public void testSetClusteringKey(CassandraBridge bridge)
     {
         Tester.builder(TestSchema.builder()
                                  .withPartitionKey("pk", bridge.uuid())
@@ -1848,8 +1916,9 @@ public class EndToEndTests extends VersionRunner
               .run();
     }
 
-    @Test
-    public void testUdTClusteringKey()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
+    public void testUdTClusteringKey(CassandraBridge bridge)
     {
         Tester.builder(keyspace -> TestSchema.builder()
                                              .withKeyspace(keyspace)
@@ -1898,8 +1967,9 @@ public class EndToEndTests extends VersionRunner
         }
     };
 
-    @Test
-    public void testLargeBlobExclude()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
+    public void testLargeBlobExclude(CassandraBridge bridge)
     {
         qt().forAll(booleans().all())
             .checkAssert(enableCompression ->
@@ -1940,8 +2010,9 @@ public class EndToEndTests extends VersionRunner
             );
     }
 
-    @Test
-    public void testExcludeColumns()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
+    public void testExcludeColumns(CassandraBridge bridge)
     {
         Tester.builder(TestSchema.builder()
                                  .withPartitionKey("pk", bridge.uuid())
@@ -1976,8 +2047,9 @@ public class EndToEndTests extends VersionRunner
               .run();
     }
 
-    @Test
-    public void testUpsertExcludeColumns()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
+    public void testUpsertExcludeColumns(CassandraBridge bridge)
     {
         Tester.builder(TestSchema.builder()
                                  .withPartitionKey("pk", bridge.uuid())
@@ -2013,8 +2085,9 @@ public class EndToEndTests extends VersionRunner
               .run();
     }
 
-    @Test
-    public void testExcludeNoColumns()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
+    public void testExcludeNoColumns(CassandraBridge bridge)
     {
         // Include all columns
         Tester.builder(TestSchema.builder()
@@ -2031,8 +2104,9 @@ public class EndToEndTests extends VersionRunner
               .run();
     }
 
-    @Test
-    public void testUpsertExcludeNoColumns()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
+    public void testUpsertExcludeNoColumns(CassandraBridge bridge)
     {
         // Include all columns
         Tester.builder(TestSchema.builder()
@@ -2050,8 +2124,9 @@ public class EndToEndTests extends VersionRunner
               .run();
     }
 
-    @Test
-    public void testExcludeAllColumns()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
+    public void testExcludeAllColumns(CassandraBridge bridge)
     {
         // Exclude all columns except for partition/clustering keys
         Tester.builder(TestSchema.builder()
@@ -2068,8 +2143,9 @@ public class EndToEndTests extends VersionRunner
               .run();
     }
 
-    @Test
-    public void testUpsertExcludeAllColumns()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
+    public void testUpsertExcludeAllColumns(CassandraBridge bridge)
     {
         // Exclude all columns except for partition/clustering keys
         Tester.builder(TestSchema.builder()
@@ -2087,8 +2163,9 @@ public class EndToEndTests extends VersionRunner
               .run();
     }
 
-    @Test
-    public void testExcludePartitionOnly()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
+    public void testExcludePartitionOnly(CassandraBridge bridge)
     {
         Tester.builder(TestSchema.builder()
                                  .withPartitionKey("pk", bridge.uuid()))
@@ -2097,8 +2174,9 @@ public class EndToEndTests extends VersionRunner
               .run();
     }
 
-    @Test
-    public void testExcludeKeysOnly()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
+    public void testExcludeKeysOnly(CassandraBridge bridge)
     {
         Tester.builder(TestSchema.builder()
                                  .withPartitionKey("pk", bridge.uuid())
@@ -2109,8 +2187,9 @@ public class EndToEndTests extends VersionRunner
               .run();
     }
 
-    @Test
-    public void testExcludeKeysStaticColumnOnly()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
+    public void testExcludeKeysStaticColumnOnly(CassandraBridge bridge)
     {
         Tester.builder(TestSchema.builder()
                                  .withPartitionKey("pk", bridge.uuid())
@@ -2122,8 +2201,9 @@ public class EndToEndTests extends VersionRunner
               .run();
     }
 
-    @Test
-    public void testExcludeStaticColumn()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
+    public void testExcludeStaticColumn(CassandraBridge bridge)
     {
         // Exclude static columns
         Tester.builder(TestSchema.builder()
@@ -2138,8 +2218,9 @@ public class EndToEndTests extends VersionRunner
               .run();
     }
 
-    @Test
-    public void testUpsertExcludeStaticColumn()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
+    public void testUpsertExcludeStaticColumn(CassandraBridge bridge)
     {
         // Exclude static columns
         Tester.builder(TestSchema.builder()
@@ -2155,8 +2236,9 @@ public class EndToEndTests extends VersionRunner
               .run();
     }
 
-    @Test
-    public void testLastModifiedTimestampAddedWithStaticColumn()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
+    public void testLastModifiedTimestampAddedWithStaticColumn(CassandraBridge bridge)
     {
         int numRows = 5;
         int numColumns = 5;
@@ -2188,14 +2270,15 @@ public class EndToEndTests extends VersionRunner
                       assertTrue(lmt > leastExpectedTimestamp);
                       // Due to the static column so the LMT is the same per partition.
                       // Using the pair of ck and lmt for uniqueness check.
-                      assertTrue("Observed a duplicated LMT", observedLMT.add(Pair.of(row.getInt(1), lmt)));
+                      assertTrue(observedLMT.add(Pair.of(row.getInt(1), lmt)), "Observed a duplicated LMT");
                   }
               })
               .run();
     }
 
-    @Test
-    public void testLastModifiedTimestampWithExcludeColumns()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
+    public void testLastModifiedTimestampWithExcludeColumns(CassandraBridge bridge)
     {
         Tester.builder(TestSchema.builder().withPartitionKey("pk", bridge.uuid())
                                  .withClusteringKey("ck", bridge.aInt())
@@ -2233,8 +2316,9 @@ public class EndToEndTests extends VersionRunner
               .run();
     }
 
-    @Test
-    public void testLastModifiedTimestampAddedWithSimpleColumns()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
+    public void testLastModifiedTimestampAddedWithSimpleColumns(CassandraBridge bridge)
     {
         int numRows = 10;
         long leastExpectedTimestamp = Timestamp.from(Instant.now()).getTime();
@@ -2268,14 +2352,15 @@ public class EndToEndTests extends VersionRunner
                       assertEquals(5, row.length());
                       long lmt = row.getTimestamp(4).getTime();
                       assertTrue(lmt > leastExpectedTimestamp + 10);
-                      assertTrue("Observed a duplicated LMT", observedLMT.add(lmt));
+                      assertTrue(observedLMT.add(lmt), "Observed a duplicated LMT");
                   }
               })
               .run();
     }
 
-    @Test
-    public void testLastModifiedTimestampAddedWithComplexColumns()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
+    public void testLastModifiedTimestampAddedWithComplexColumns(CassandraBridge bridge)
     {
         long leastExpectedTimestamp = Timestamp.from(Instant.now()).getTime();
         Set<Long> observedLMT = new HashSet<>();
@@ -2304,7 +2389,7 @@ public class EndToEndTests extends VersionRunner
                       assertEquals(8, row.length());
                       long lmt = row.getTimestamp(7).getTime();
                       assertTrue(lmt > leastExpectedTimestamp);
-                      assertTrue("Observed a duplicated LMT", observedLMT.add(lmt));
+                      assertTrue(observedLMT.add(lmt), "Observed a duplicated LMT");
                   }
               })
               .run();

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/KryoSerializationTests.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/KryoSerializationTests.java
@@ -26,41 +26,37 @@ import java.util.UUID;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.apache.commons.lang3.RandomStringUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
-import org.apache.cassandra.bridge.CassandraVersion;
+import org.apache.cassandra.bridge.CassandraBridge;
 import org.apache.cassandra.secrets.SslConfig;
 import org.apache.cassandra.spark.data.CqlField;
 import org.apache.cassandra.spark.data.CqlTable;
 import org.apache.cassandra.spark.data.LocalDataLayer;
 import org.apache.cassandra.spark.data.ReplicationFactor;
-import org.apache.cassandra.spark.data.VersionRunner;
 import org.apache.cassandra.spark.data.partitioner.CassandraInstance;
 import org.apache.cassandra.spark.data.partitioner.CassandraRing;
 import org.apache.cassandra.spark.data.partitioner.TokenPartitioner;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.quicktheories.QuickTheory.qt;
 import static org.quicktheories.generators.SourceDSL.arbitrary;
 import static org.quicktheories.generators.SourceDSL.booleans;
 import static org.quicktheories.generators.SourceDSL.integers;
 
-public class KryoSerializationTests extends VersionRunner
+public class KryoSerializationTests
 {
     private static final Kryo KRYO = new Kryo();
 
     static
     {
         new KryoRegister().registerClasses(KRYO);
-    }
-
-    public KryoSerializationTests(CassandraVersion version)
-    {
-        super(version);
     }
 
     private static Output serialize(Object object)
@@ -80,8 +76,9 @@ public class KryoSerializationTests extends VersionRunner
         }
     }
 
-    @Test
-    public void testCqlField()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
+    public void testCqlField(CassandraBridge bridge)
     {
         qt().withExamples(25)
             .forAll(booleans().all(), booleans().all(), TestUtils.cql3Type(bridge), integers().all())
@@ -103,8 +100,9 @@ public class KryoSerializationTests extends VersionRunner
             });
     }
 
-    @Test
-    public void testCqlFieldSet()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
+    public void testCqlFieldSet(CassandraBridge bridge)
     {
         qt().withExamples(25)
             .forAll(booleans().all(), booleans().all(), TestUtils.cql3Type(bridge), integers().all())
@@ -127,8 +125,9 @@ public class KryoSerializationTests extends VersionRunner
             });
     }
 
-    @Test
-    public void testCqlFieldList()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
+    public void testCqlFieldList(CassandraBridge bridge)
     {
         qt().withExamples(25)
             .forAll(booleans().all(), booleans().all(), TestUtils.cql3Type(bridge), integers().all())
@@ -151,8 +150,9 @@ public class KryoSerializationTests extends VersionRunner
             });
     }
 
-    @Test
-    public void testCqlFieldMap()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
+    public void testCqlFieldMap(CassandraBridge bridge)
     {
         qt().withExamples(25)
             .forAll(booleans().all(), booleans().all(), TestUtils.cql3Type(bridge), TestUtils.cql3Type(bridge))
@@ -175,8 +175,9 @@ public class KryoSerializationTests extends VersionRunner
             });
     }
 
-    @Test
-    public void testCqlUdt()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
+    public void testCqlUdt(CassandraBridge bridge)
     {
         qt().withExamples(25)
             .forAll(TestUtils.cql3Type(bridge), TestUtils.cql3Type(bridge))
@@ -197,8 +198,9 @@ public class KryoSerializationTests extends VersionRunner
             });
     }
 
-    @Test
-    public void testCqlTuple()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
+    public void testCqlTuple(CassandraBridge bridge)
     {
         qt().withExamples(25)
             .forAll(TestUtils.cql3Type(bridge), TestUtils.cql3Type(bridge))
@@ -221,8 +223,9 @@ public class KryoSerializationTests extends VersionRunner
             });
     }
 
-    @Test
-    public void testCqlTable()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
+    public void testCqlTable(CassandraBridge bridge)
     {
         List<CqlField> fields = ImmutableList.of(new CqlField(true, false, false, "a", bridge.bigint(), 0),
                                                  new CqlField(true, false, false, "b", bridge.bigint(), 1),
@@ -244,7 +247,8 @@ public class KryoSerializationTests extends VersionRunner
         assertEquals(table, deserialized);
     }
 
-    @Test
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
     public void testCassandraInstance()
     {
         CassandraInstance instance = new CassandraInstance("-9223372036854775807", "local1-i1", "DC1");
@@ -254,7 +258,8 @@ public class KryoSerializationTests extends VersionRunner
         assertEquals(instance, deserialized);
     }
 
-    @Test
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
     public void testCassandraRing()
     {
         qt().forAll(TestUtils.partitioners())
@@ -268,8 +273,9 @@ public class KryoSerializationTests extends VersionRunner
             });
     }
 
-    @Test
-    public void testLocalDataLayer()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
+    public void testLocalDataLayer(CassandraBridge bridge)
     {
         String path1 = UUID.randomUUID().toString();
         String path2 = UUID.randomUUID().toString();
@@ -311,8 +317,9 @@ public class KryoSerializationTests extends VersionRunner
             });
     }
 
-    @Test
-    public void testCqlUdtField()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
+    public void testCqlUdtField(CassandraBridge bridge)
     {
         CqlField.CqlUdt udt = bridge.udt("udt_keyspace", "udt_table")
                                     .withField("c", bridge.text())

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/TestUtils.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/TestUtils.java
@@ -60,7 +60,7 @@ import org.apache.spark.sql.types.StructType;
 import org.jetbrains.annotations.Nullable;
 import org.quicktheories.core.Gen;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.quicktheories.QuickTheory.qt;
 import static org.quicktheories.generators.SourceDSL.arbitrary;
 

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/Tester.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/Tester.java
@@ -51,8 +51,8 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.quicktheories.core.Gen;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.quicktheories.QuickTheory.qt;
 import static org.quicktheories.generators.SourceDSL.arbitrary;
 
@@ -449,8 +449,8 @@ public final class Tester
 
             if (shouldCheckNumSSTables)
             {
-                assertEquals("Number of SSTables written does not match expected",
-                             sstableCount, TestUtils.countSSTables(directory));
+                assertEquals(sstableCount, TestUtils.countSSTables(directory),
+                             "Number of SSTables written does not match expected");
             }
 
             Dataset<Row> dataset = TestUtils.openLocalDataset(partitioner,
@@ -470,8 +470,8 @@ public final class Tester
                 if (requiredColumns != null)
                 {
                     Set<String> actualColumns = new HashSet<>(Arrays.asList(row.schema().fieldNames()));
-                    assertEquals("Actual Columns and Required Columns should be the same",
-                                 actualColumns, requiredColumns);
+                    assertEquals(actualColumns, requiredColumns,
+                                 "Actual Columns and Required Columns should be the same");
                 }
 
                 TestSchema.TestRow actualRow = schema.toTestRow(row, requiredColumns);
@@ -479,9 +479,9 @@ public final class Tester
                 {
                     // If we wrote random data, verify values exist
                     String key = actualRow.getKey();
-                    assertTrue("Unexpected row read in Spark", rows.containsKey(key));
-                    assertEquals("Row read in Spark does not match expected",
-                                 rows.get(key).withColumns(requiredColumns), actualRow);
+                    assertTrue(rows.containsKey(key), "Unexpected row read in Spark");
+                    assertEquals(rows.get(key).withColumns(requiredColumns), actualRow,
+                                 "Row read in Spark does not match expected");
                 }
 
                 for (Consumer<TestSchema.TestRow> readListener : readListeners)
@@ -492,15 +492,15 @@ public final class Tester
             }
             if (expectedRowCount >= 0)
             {
-                assertEquals("Number of rows read does not match expected", expectedRowCount * sstableCount, rowCount);
+                assertEquals(expectedRowCount * sstableCount, rowCount, "Number of rows read does not match expected");
             }
 
             // Verify numerical fields sum to expected value
             for (String sumField : sumFields)
             {
-                assertEquals("Field '" + sumField + "' does not sum to expected amount",
-                             sum.get(sumField).getValue().longValue(),
-                             dataset.groupBy().sum(sumField).first().getLong(0));
+                assertEquals(sum.get(sumField).getValue().longValue(),
+                             dataset.groupBy().sum(sumField).first().getLong(0),
+                             "Field '" + sumField + "' does not sum to expected amount");
             }
 
             // Run SparkSQL checks

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/BulkSparkConfTest.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/BulkSparkConfTest.java
@@ -25,8 +25,8 @@ import java.util.TreeMap;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.apache.cassandra.spark.bulkwriter.util.SbwKryoRegistrator;
 import org.apache.cassandra.spark.utils.BuildInfo;
@@ -36,10 +36,10 @@ import org.jetbrains.annotations.NotNull;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.isEmptyString;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BulkSparkConfTest
 {
@@ -47,7 +47,7 @@ public class BulkSparkConfTest
     private BulkSparkConf bulkSparkConf;
     private Map<String, String> defaultOptions;
 
-    @Before
+    @BeforeEach
     public void before()
     {
         sparkConf = new SparkConf();

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/CassandraRingMonitorTest.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/CassandraRingMonitorTest.java
@@ -21,14 +21,14 @@ package org.apache.cassandra.spark.bulkwriter;
 
 import java.util.concurrent.TimeUnit;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.apache.cassandra.spark.bulkwriter.token.CassandraRing;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class CassandraRingMonitorTest
 {
@@ -36,7 +36,7 @@ public class CassandraRingMonitorTest
     private CassandraRing<RingInstance> ring;
     private MockScheduledExecutorService executorService;
 
-    @Before
+    @BeforeEach
     public void setup()
     {
         changeCount = 0;

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/CqlTableInfoProviderTest.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/CqlTableInfoProviderTest.java
@@ -19,11 +19,11 @@
 
 package org.apache.cassandra.spark.bulkwriter;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.apache.cassandra.spark.bulkwriter.CqlTableInfoProvider.removeDeprecatedOptions;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class CqlTableInfoProviderTest
 {

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/DecoratedKeyTest.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/DecoratedKeyTest.java
@@ -22,10 +22,10 @@ package org.apache.cassandra.spark.bulkwriter;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 public class DecoratedKeyTest
 {

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/RecordWriterTest.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/RecordWriterTest.java
@@ -20,6 +20,7 @@
 package org.apache.cassandra.spark.bulkwriter;
 
 import java.math.BigInteger;
+import java.nio.file.Path;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -29,30 +30,31 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import com.google.common.collect.Range;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import org.apache.cassandra.spark.bulkwriter.token.CassandraRing;
 import org.apache.cassandra.spark.common.model.CassandraInstance;
 import scala.Tuple2;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.Matchers.matchesPattern;
+import static org.hamcrest.Matchers.startsWith;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class RecordWriterTest
 {
     public static final int REPLICA_COUNT = 3;
     public static final int FILES_PER_SSTABLE = 8;
     public static final int UPLOADED_TABLES = 3;
-    @Rule
-    public TemporaryFolder folder = new TemporaryFolder();
 
-    @Rule
-    public ExpectedException exception = ExpectedException.none();
+    @TempDir
+    public Path folder; // CHECKSTYLE IGNORE: Public mutable field for parameterized testing
+
     private CassandraRing<RingInstance> ring;
     private RecordWriter rw;
     private MockTableWriter tw;
@@ -61,10 +63,10 @@ public class RecordWriterTest
     private MockBulkWriterContext writerContext;
     private TestTaskContext tc;
 
-    @Before
+    @BeforeEach
     public void setUp()
     {
-        tw = new MockTableWriter(folder.getRoot().toPath());
+        tw = new MockTableWriter(folder);
         ring = RingUtils.buildRing(0, "app", "cluster", "DC1", "test", 12);
         writerContext = new MockBulkWriterContext(ring);
         tc = new TestTaskContext();
@@ -91,33 +93,32 @@ public class RecordWriterTest
     @Test
     public void testCorruptSSTable()
     {
-        // TODO: Add better error handling with human-readable exception messages in SSTableReader::new
-        exception.expect(RuntimeException.class);
         rw = new RecordWriter(writerContext, () -> tc, (wc, path) ->  new SSTableWriter(tw.setOutDir(path), path));
         Iterator<Tuple2<DecoratedKey, Object[]>> data = generateData(5, true);
-        rw.write(data);
-        Map<CassandraInstance, List<UploadRequest>> uploads = writerContext.getUploads();
-        assertThat(uploads.keySet().size(), is(REPLICA_COUNT));  // Should upload to 3 replicas
-        assertThat(uploads.values().stream().mapToInt(List::size).sum(), is(REPLICA_COUNT * FILES_PER_SSTABLE * UPLOADED_TABLES));
+        // TODO: Add better error handling with human-readable exception messages in SSTableReader::new
+        // That way we can assert on the exception thrown here
+        RuntimeException ex = assertThrows(RuntimeException.class, () -> rw.write(data));
     }
 
     @Test
     public void testWriteWithOutOfRangeTokenFails()
     {
-        rw = new RecordWriter(writerContext, () -> tc, (wc, path) -> new SSTableWriter(tw, folder.getRoot().toPath()));
-        exception.expectMessage("Received Token 5765203080415074583 outside of expected range [-9223372036854775808‥0]");
+        rw = new RecordWriter(writerContext, () -> tc, (wc, path) -> new SSTableWriter(tw, folder));
         Iterator<Tuple2<DecoratedKey, Object[]>> data = generateData(5, false);
-        rw.write(data);
+        RuntimeException ex = assertThrows(RuntimeException.class, () -> rw.write(data));
+        assertThat(ex.getMessage(),
+                   matchesPattern("java.lang.IllegalStateException: Received Token "
+                              + "5765203080415074583 outside of expected range \\[-9223372036854775808(‥|..)0]"));
     }
 
     @Test
     public void testAddRowThrowingFails()
     {
-        rw = new RecordWriter(writerContext, () -> tc, (wc, path) -> new SSTableWriter(tw, folder.getRoot().toPath()));
+        rw = new RecordWriter(writerContext, () -> tc, (wc, path) -> new SSTableWriter(tw, folder));
         tw.setAddRowThrows(true);
-        exception.expectMessage("java.lang.RuntimeException: Failed to write because addRow throws");
         Iterator<Tuple2<DecoratedKey, Object[]>> data = generateData(5, true);
-        rw.write(data);
+        RuntimeException ex = assertThrows(RuntimeException.class, () -> rw.write(data));
+        assertEquals(ex.getMessage(), "java.lang.RuntimeException: Failed to write because addRow throws");
     }
 
     @Test
@@ -125,11 +126,11 @@ public class RecordWriterTest
     {
         // Mock context returns a 60-minute allowable time skew, so we use something just outside the limits
         long sixtyOneMinutesInMillis = TimeUnit.MINUTES.toMillis(61);
-        rw = new RecordWriter(writerContext, () -> tc, (wc, path) -> new SSTableWriter(tw, folder.getRoot().toPath()));
+        rw = new RecordWriter(writerContext, () -> tc, (wc, path) -> new SSTableWriter(tw, folder));
         writerContext.setTimeProvider(() -> System.currentTimeMillis() - sixtyOneMinutesInMillis);
-        exception.expectMessage("Time skew between Spark and Cassandra is too large. Allowable skew is 60 minutes. Spark executor time is ");
         Iterator<Tuple2<DecoratedKey, Object[]>> data = generateData(5, true);
-        rw.write(data);
+        RuntimeException ex = assertThrows(RuntimeException.class, () -> rw.write(data));
+        assertThat(ex.getMessage(), startsWith("Time skew between Spark and Cassandra is too large. Allowable skew is 60 minutes. Spark executor time is "));
     }
 
     @Test

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/RingInstanceSerializationTest.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/RingInstanceSerializationTest.java
@@ -19,13 +19,13 @@
 
 package org.apache.cassandra.spark.bulkwriter;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.apache.cassandra.sidecar.common.data.RingEntry;
 
 import static org.apache.cassandra.spark.utils.SerializationUtils.deserialize;
 import static org.apache.cassandra.spark.utils.SerializationUtils.serialize;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class RingInstanceSerializationTest
 {

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/RingInstanceTest.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/RingInstanceTest.java
@@ -34,7 +34,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Range;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.apache.cassandra.sidecar.common.data.RingEntry;
 import org.apache.cassandra.spark.bulkwriter.token.CassandraRing;
@@ -44,8 +44,8 @@ import org.apache.cassandra.spark.common.model.CassandraInstance;
 import org.apache.cassandra.spark.data.ReplicationFactor;
 import org.apache.cassandra.spark.data.partitioner.Partitioner;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 public class RingInstanceTest
 {

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/SSTableWriterTest.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/SSTableWriterTest.java
@@ -27,13 +27,11 @@ import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import org.apache.cassandra.bridge.CassandraVersion;
 import org.apache.cassandra.bridge.CassandraVersionFeatures;
@@ -41,14 +39,12 @@ import org.apache.cassandra.spark.bulkwriter.token.CassandraRing;
 import org.apache.cassandra.spark.bulkwriter.token.ConsistencyLevel;
 import org.jetbrains.annotations.NotNull;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@RunWith(Parameterized.class)
 public class SSTableWriterTest
 {
     private static String previousMbeanState;
 
-    @Parameterized.Parameters(name = "{index}: Testing Cassandra Version {0}")
     public static Iterable<Object[]> data()
     {
         return Arrays.stream(CassandraVersion.supportedVersions())
@@ -56,14 +52,14 @@ public class SSTableWriterTest
                      .collect(Collectors.toList());
     }
 
-    @BeforeClass
+    @BeforeAll
     public static void setProps()
     {
         previousMbeanState = System.getProperty("org.apache.cassandra.disable_mbean_registration");
         System.setProperty("org.apache.cassandra.disable_mbean_registration", "true");
     }
 
-    @AfterClass
+    @AfterAll
     public static void restoreProps()
     {
         if (previousMbeanState != null)
@@ -79,17 +75,16 @@ public class SSTableWriterTest
     @NotNull
     public CassandraRing<RingInstance> ring = RingUtils.buildRing(0, "app", "cluster", "DC1", "test", 12);  // CHECKSTYLE IGNORE: Public mutable field
 
-    @Rule
-    public TemporaryFolder tmpDir = new TemporaryFolder();
+    @TempDir
+    public Path tmpDir; // CHECKSTYLE IGNORE: Public mutable field for testing
 
-    @Parameterized.Parameter(0)
-    public String version;  // CHECKSTYLE IGNORE: Public mutable field for parameterized testing
 
-    @Test
-    public void canCreateWriterForVersion() throws IOException
+    @ParameterizedTest
+    @MethodSource("data")
+    public void canCreateWriterForVersion(String version) throws IOException
     {
         MockBulkWriterContext writerContext = new MockBulkWriterContext(ring, version, ConsistencyLevel.CL.LOCAL_QUORUM);
-        SSTableWriter tw = new SSTableWriter(writerContext, tmpDir.getRoot().toPath());
+        SSTableWriter tw = new SSTableWriter(writerContext, tmpDir);
         tw.addRow(BigInteger.ONE, new Object[]{1, 1, "foo", 1});
         tw.close(writerContext, 1);
         try (DirectoryStream<Path> dataFileStream = Files.newDirectoryStream(tw.getOutDir(), "*Data.db"))

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/TableSchemaNormalizeTest.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/TableSchemaNormalizeTest.java
@@ -35,7 +35,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import com.google.common.net.InetAddresses;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.apache.cassandra.spark.common.schema.ColumnType;
 import org.apache.cassandra.spark.common.schema.ColumnTypes;
@@ -73,9 +73,9 @@ import static org.apache.cassandra.spark.bulkwriter.TableSchemaTestCommon.mockCq
 import static org.apache.cassandra.spark.bulkwriter.TableSchemaTestCommon.mockListCqlType;
 import static org.apache.cassandra.spark.bulkwriter.TableSchemaTestCommon.mockMapCqlType;
 import static org.apache.cassandra.spark.bulkwriter.TableSchemaTestCommon.mockSetCqlType;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
-import static org.junit.Assert.assertThat;
 
 public class TableSchemaNormalizeTest
 {

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/TableSchemaTest.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/TableSchemaTest.java
@@ -23,9 +23,7 @@ import java.util.Arrays;
 
 import com.google.common.collect.ImmutableMap;
 import org.apache.commons.lang3.tuple.Pair;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
 import org.apache.cassandra.spark.common.schema.ColumnType;
 import org.apache.cassandra.spark.common.schema.ColumnTypes;
@@ -40,7 +38,8 @@ import static org.apache.cassandra.spark.bulkwriter.TableSchemaTestCommon.mockCq
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
-import static org.junit.Assert.assertThrows;
+import static org.hamcrest.core.StringStartsWith.startsWith;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class TableSchemaTest
 {
@@ -53,9 +52,6 @@ public class TableSchemaTest
         validDataFrameSchema = validPair.getKey();
         validCqlColumns = validPair.getValue();
     }
-
-    @Rule
-    public ExpectedException exception = ExpectedException.none();
 
     private StructType validDataFrameSchema;
 
@@ -136,11 +132,13 @@ public class TableSchemaTest
                 .add("course", DataTypes.StringType)
                 .add("marks", DataTypes.IntegerType);
 
-        exception.expect(IllegalArgumentException.class);
-        exception.expectMessage("Unknown fields");
+        IllegalArgumentException iex = assertThrows(IllegalArgumentException.class,
+                                                    () ->
         getValidSchemaBuilder()
                 .withDataFrameSchema(extraFieldsDataFrameSchema)
-                .build();
+                .build()
+        );
+        assertThat(iex.getMessage(), startsWith("Unknown fields"));
     }
 
     @Test

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/TokenPartitionerTest.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/TokenPartitionerTest.java
@@ -23,20 +23,20 @@ import java.math.BigInteger;
 import java.nio.ByteBuffer;
 
 import com.google.common.collect.ImmutableMap;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.apache.cassandra.spark.bulkwriter.token.CassandraRing;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.number.OrderingComparison.greaterThanOrEqualTo;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TokenPartitionerTest
 {
     private TokenPartitioner partitioner;
 
-    @Before
+    @BeforeEach
     public void createConfig()
     {
     }

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/cdc/watermarker/WatermarkerTests.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/cdc/watermarker/WatermarkerTests.java
@@ -22,18 +22,18 @@ package org.apache.cassandra.spark.cdc.watermarker;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import org.apache.cassandra.spark.TestDataLayer;
 import org.apache.cassandra.spark.cdc.CommitLog;
 import org.apache.cassandra.spark.cdc.IPartitionUpdateWrapper;
 import org.apache.cassandra.spark.data.partitioner.CassandraInstance;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -48,13 +48,13 @@ public class WatermarkerTests
         return update;
     }
 
-    @BeforeClass
+    @BeforeAll
     public static void setup()
     {
         InMemoryWatermarker.TEST_THREAD_NAME = Thread.currentThread().getName();
     }
 
-    @AfterClass
+    @AfterAll
     public static void tearDown()
     {
         InMemoryWatermarker.TEST_THREAD_NAME = null;

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/data/CassandraDataSourceHelperCacheTest.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/data/CassandraDataSourceHelperCacheTest.java
@@ -31,16 +31,16 @@ import java.util.concurrent.atomic.AtomicLong;
 import com.google.common.base.Ticker;
 import com.google.common.cache.Cache;
 import com.google.common.collect.ImmutableMap;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.apache.cassandra.clients.Sidecar;
 import org.apache.cassandra.secrets.SslConfig;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests the cache in {@link CassandraDataSourceHelper}
@@ -54,7 +54,7 @@ public class CassandraDataSourceHelperCacheTest
 
     private CacheTicker cacheTicker;
 
-    @Before
+    @BeforeEach
     public void setup()
     {
         cacheTicker = new CacheTicker();

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/data/CqlFieldComparators.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/data/CqlFieldComparators.java
@@ -24,30 +24,28 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.UUID;
 
-import org.junit.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
-import org.apache.cassandra.bridge.CassandraVersion;
+import org.apache.cassandra.bridge.CassandraBridge;
 import org.apache.spark.sql.types.Decimal;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.quicktheories.QuickTheory.qt;
 import static org.quicktheories.generators.SourceDSL.integers;
 
 public class CqlFieldComparators extends VersionRunner
 {
-    public CqlFieldComparators(CassandraVersion version)
-    {
-        super(version);
-    }
 
     private static CqlField createField(CqlField.CqlType type)
     {
         return new CqlField(false, false, false, "a", type, 0);
     }
 
-    @Test
-    public void testStringComparator()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.spark.data.VersionRunner#bridges")
+    public void testStringComparator(CassandraBridge bridge)
     {
         // ASCII
         assertTrue(createField(bridge.ascii()).compare("a", "b") < 0);
@@ -88,8 +86,9 @@ public class CqlFieldComparators extends VersionRunner
         assertEquals(0, createField(bridge.varchar()).compare("abd", "abd"));
     }
 
-    @Test
-    public void testBigDecimalComparator()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.spark.data.VersionRunner#bridges")
+    public void testBigDecimalComparator(CassandraBridge bridge)
     {
         BigDecimal value = BigDecimal.valueOf(Long.MAX_VALUE).multiply(BigDecimal.valueOf(2));
         Decimal decimal1 = Decimal.apply(value);
@@ -100,8 +99,9 @@ public class CqlFieldComparators extends VersionRunner
         assertTrue(createField(bridge.decimal()).compare(decimal2, decimal1) > 0);
     }
 
-    @Test
-    public void testVarIntComparator()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.spark.data.VersionRunner#bridges")
+    public void testVarIntComparator(CassandraBridge bridge)
     {
         BigDecimal value = BigDecimal.valueOf(Long.MAX_VALUE).multiply(BigDecimal.valueOf(2));
         Decimal decimal1 = Decimal.apply(value);
@@ -112,8 +112,9 @@ public class CqlFieldComparators extends VersionRunner
         assertTrue(createField(bridge.varint()).compare(decimal2, decimal1) > 0);
     }
 
-    @Test
-    public void testIntegerComparator()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.spark.data.VersionRunner#bridges")
+    public void testIntegerComparator(CassandraBridge bridge)
     {
         qt().forAll(integers().between(Integer.MIN_VALUE, Integer.MAX_VALUE - 1))
             .checkAssert(integer -> {
@@ -127,8 +128,9 @@ public class CqlFieldComparators extends VersionRunner
         assertTrue(createField(bridge.aInt()).compare(Integer.MAX_VALUE, Integer.MIN_VALUE) > 0);
     }
 
-    @Test
-    public void testLongComparator()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.spark.data.VersionRunner#bridges")
+    public void testLongComparator(CassandraBridge bridge)
     {
         assertTrue(createField(bridge.bigint()).compare(0L, 1L) < 0);
         assertEquals(0, createField(bridge.bigint()).compare(1L, 1L));
@@ -139,8 +141,9 @@ public class CqlFieldComparators extends VersionRunner
         assertTrue(createField(bridge.bigint()).compare(Long.MAX_VALUE, Long.MIN_VALUE) > 0);
     }
 
-    @Test
-    public void testTimeComparator()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.spark.data.VersionRunner#bridges")
+    public void testTimeComparator(CassandraBridge bridge)
     {
         assertTrue(createField(bridge.time()).compare(0L, 1L) < 0);
         assertEquals(0, createField(bridge.time()).compare(1L, 1L));
@@ -151,8 +154,9 @@ public class CqlFieldComparators extends VersionRunner
         assertTrue(createField(bridge.time()).compare(Long.MAX_VALUE, Long.MIN_VALUE) > 0);
     }
 
-    @Test
-    public void testBooleanComparator()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.spark.data.VersionRunner#bridges")
+    public void testBooleanComparator(CassandraBridge bridge)
     {
         assertTrue(createField(bridge.bool()).compare(false, true) < 0);
         assertEquals(0, createField(bridge.bool()).compare(false, false));
@@ -160,24 +164,27 @@ public class CqlFieldComparators extends VersionRunner
         assertTrue(createField(bridge.bool()).compare(true, false) > 0);
     }
 
-    @Test
-    public void testFloatComparator()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.spark.data.VersionRunner#bridges")
+    public void testFloatComparator(CassandraBridge bridge)
     {
         assertTrue(createField(bridge.aFloat()).compare(1f, 2f) < 0);
         assertEquals(0, createField(bridge.aFloat()).compare(2f, 2f));
         assertTrue(createField(bridge.aFloat()).compare(2f, 1f) > 0);
     }
 
-    @Test
-    public void testDoubleComparator()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.spark.data.VersionRunner#bridges")
+    public void testDoubleComparator(CassandraBridge bridge)
     {
         assertTrue(createField(bridge.aDouble()).compare(1d, 2d) < 0);
         assertEquals(0, createField(bridge.aDouble()).compare(2d, 2d));
         assertTrue(createField(bridge.aDouble()).compare(2d, 1d) > 0);
     }
 
-    @Test
-    public void testTimestampComparator()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.spark.data.VersionRunner#bridges")
+    public void testTimestampComparator(CassandraBridge bridge)
     {
         long timestamp1 = 1L;
         long timestamp2 = 2L;
@@ -187,8 +194,9 @@ public class CqlFieldComparators extends VersionRunner
         assertTrue(createField(bridge.timestamp()).compare(timestamp2, timestamp1) > 0);
     }
 
-    @Test
-    public void testDateComparator()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.spark.data.VersionRunner#bridges")
+    public void testDateComparator(CassandraBridge bridge)
     {
         int date1 = 1;
         int date2 = 2;
@@ -198,22 +206,25 @@ public class CqlFieldComparators extends VersionRunner
         assertTrue(createField(bridge.date()).compare(date2, date1) > 0);
     }
 
-    @Test
-    public void testVoidComparator()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.spark.data.VersionRunner#bridges")
+    public void testVoidComparator(CassandraBridge bridge)
     {
         assertEquals(0, createField(bridge.empty()).compare(null, null));
     }
 
-    @Test
-    public void testShortComparator()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.spark.data.VersionRunner#bridges")
+    public void testShortComparator(CassandraBridge bridge)
     {
         assertTrue(createField(bridge.smallint()).compare((short) 1, (short) 2) < 0);
         assertEquals(0, createField(bridge.smallint()).compare((short) 2, (short) 2));
         assertTrue(createField(bridge.smallint()).compare((short) 2, (short) 1) > 0);
     }
 
-    @Test
-    public void testByteArrayComparator()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.spark.data.VersionRunner#bridges")
+    public void testByteArrayComparator(CassandraBridge bridge)
     {
         byte[] bytes1 = new byte[]{0, 0, 0, 101};
         byte[] bytes2 = new byte[]{0, 0, 0, 102};
@@ -228,8 +239,9 @@ public class CqlFieldComparators extends VersionRunner
         assertTrue(createField(bridge.blob()).compare(bytes4, bytes3) > 0);
     }
 
-    @Test
-    public void testInetComparator() throws UnknownHostException
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.spark.data.VersionRunner#bridges")
+    public void testInetComparator(CassandraBridge bridge) throws UnknownHostException
     {
         byte[] ip1 = InetAddress.getByAddress(CqlFieldComparators.toByteArray(2130706433)).getAddress();  // 127.0.0.1
         byte[] ip2 = InetAddress.getByAddress(CqlFieldComparators.toByteArray(2130706434)).getAddress();  // 127.0.0.2
@@ -247,8 +259,9 @@ public class CqlFieldComparators extends VersionRunner
                           (byte)  value};
     }
 
-    @Test
-    public void testByteComparator()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.spark.data.VersionRunner#bridges")
+    public void testByteComparator(CassandraBridge bridge)
     {
         byte byte1 = 101;
         byte byte2 = 102;

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/data/CqlFieldTests.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/data/CqlFieldTests.java
@@ -21,26 +21,23 @@ package org.apache.cassandra.spark.data;
 
 import java.util.ArrayList;
 
-import org.junit.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import org.apache.cassandra.bridge.CassandraBridge;
-import org.apache.cassandra.bridge.CassandraVersion;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class CqlFieldTests extends VersionRunner
 {
-    public CqlFieldTests(CassandraVersion version)
-    {
-        super(version);
-    }
 
-    @Test
-    public void testEquality()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.spark.data.VersionRunner#bridges")
+    public void testEquality(CassandraBridge bridge)
     {
         CqlField field1 = new CqlField(true, false, false, "a", bridge.bigint(), 0);
         CqlField field2 = new CqlField(true, false, false, "a", bridge.bigint(), 0);
@@ -53,8 +50,9 @@ public class CqlFieldTests extends VersionRunner
         assertEquals(field1, field1);
     }
 
-    @Test
-    public void testNotEqualsName()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.spark.data.VersionRunner#bridges")
+    public void testNotEqualsName(CassandraBridge bridge)
     {
         CqlField field1 = new CqlField(true, false, false, "a", bridge.bigint(), 0);
         CqlField field2 = new CqlField(true, false, false, "b", bridge.bigint(), 0);
@@ -63,8 +61,9 @@ public class CqlFieldTests extends VersionRunner
         assertNotEquals(field1.hashCode(), field2.hashCode());
     }
 
-    @Test
-    public void testNotEqualsType()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.spark.data.VersionRunner#bridges")
+    public void testNotEqualsType(CassandraBridge bridge)
     {
         CqlField field1 = new CqlField(true, false, false, "a", bridge.bigint(), 0);
         CqlField field2 = new CqlField(true, false, false, "a", bridge.timestamp(), 0);
@@ -73,8 +72,9 @@ public class CqlFieldTests extends VersionRunner
         assertNotEquals(field1.hashCode(), field2.hashCode());
     }
 
-    @Test
-    public void testNotEqualsKey()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.spark.data.VersionRunner#bridges")
+    public void testNotEqualsKey(CassandraBridge bridge)
     {
         CqlField field1 = new CqlField(true, false, false, "a", bridge.bigint(), 0);
         CqlField field2 = new CqlField(false, true, false, "a", bridge.bigint(), 0);
@@ -83,8 +83,9 @@ public class CqlFieldTests extends VersionRunner
         assertNotEquals(field1.hashCode(), field2.hashCode());
     }
 
-    @Test
-    public void testNotEqualsPos()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.spark.data.VersionRunner#bridges")
+    public void testNotEqualsPos(CassandraBridge bridge)
     {
         CqlField field1 = new CqlField(true, false, false, "a", bridge.bigint(), 0);
         CqlField field2 = new CqlField(true, false, false, "a", bridge.bigint(), 1);
@@ -93,25 +94,27 @@ public class CqlFieldTests extends VersionRunner
         assertNotEquals(field1.hashCode(), field2.hashCode());
     }
 
-    @Test
-    public void testCqlTypeParser()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.spark.data.VersionRunner#bridges")
+    public void testCqlTypeParser(CassandraBridge bridge)
     {
-        testCqlTypeParser("set<text>", bridge.text());
-        testCqlTypeParser("set<float>", bridge.aFloat());
-        testCqlTypeParser("set<time>", bridge.time());
-        testCqlTypeParser("SET<BLOB>", bridge.blob());
-        testCqlTypeParser("list<ascii>", bridge.ascii());
-        testCqlTypeParser("list<int>", bridge.aInt());
-        testCqlTypeParser("LIST<BIGINT>", bridge.bigint());
-        testCqlTypeParser("map<int,text>", bridge.aInt(), bridge.text());
-        testCqlTypeParser("map<boolean , decimal>", bridge.bool(), bridge.decimal());
-        testCqlTypeParser("MAP<TIMEUUID,TIMESTAMP>", bridge.timeuuid(), bridge.timestamp());
-        testCqlTypeParser("MAP<VARCHAR , double>", bridge.varchar(), bridge.aDouble());
-        testCqlTypeParser("tuple<int, text>", bridge.aInt(), bridge.text());
+        testCqlTypeParser("set<text>", bridge.text(), bridge);
+        testCqlTypeParser("set<float>", bridge.aFloat(), bridge);
+        testCqlTypeParser("set<time>", bridge.time(), bridge);
+        testCqlTypeParser("SET<BLOB>", bridge.blob(), bridge);
+        testCqlTypeParser("list<ascii>", bridge.ascii(), bridge);
+        testCqlTypeParser("list<int>", bridge.aInt(), bridge);
+        testCqlTypeParser("LIST<BIGINT>", bridge.bigint(), bridge);
+        testCqlTypeParser("map<int,text>", bridge.aInt(), bridge.text(), bridge);
+        testCqlTypeParser("map<boolean , decimal>", bridge.bool(), bridge.decimal(), bridge);
+        testCqlTypeParser("MAP<TIMEUUID,TIMESTAMP>", bridge.timeuuid(), bridge.timestamp(), bridge);
+        testCqlTypeParser("MAP<VARCHAR , double>", bridge.varchar(), bridge.aDouble(), bridge);
+        testCqlTypeParser("tuple<int, text>", bridge.aInt(), bridge.text(), bridge);
     }
 
-    @Test
-    public void testSplitMapTypes()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.spark.data.VersionRunner#bridges")
+    public void testSplitMapTypes(CassandraBridge bridge)
     {
         splitMap("", "", null);
         splitMap("text", "text", null);
@@ -133,8 +136,9 @@ public class CqlFieldTests extends VersionRunner
                  "frozen<map<set<int>,blob>>", "frozen<map<text, frozen<map<bigint, double>>>>");
     }
 
-    @Test
-    public void testCqlNames()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.spark.data.VersionRunner#bridges")
+    public void testCqlNames(CassandraBridge bridge)
     {
         assertEquals("set<bigint>", bridge.collection("set", bridge.bigint()).cqlName());
         assertEquals("list<timestamp>", bridge.collection("LIST", bridge.timestamp()).cqlName());
@@ -145,8 +149,9 @@ public class CqlFieldTests extends VersionRunner
                      bridge.collection("tuPLe", bridge.aInt(), bridge.blob(), bridge.map(bridge.aInt(), bridge.aFloat())).cqlName());
     }
 
-    @Test
-    public void testTuple()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.spark.data.VersionRunner#bridges")
+    public void testTuple(CassandraBridge bridge)
     {
         String[] result = CassandraBridge.splitInnerTypes("a, b, c, d,e, f, g");
         assertEquals("a", result[0]);
@@ -171,8 +176,9 @@ public class CqlFieldTests extends VersionRunner
         }
     }
 
-    @Test
-    public void testNestedSet()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.spark.data.VersionRunner#bridges")
+    public void testNestedSet(CassandraBridge bridge)
     {
         CqlField.CqlType type = bridge.parseType("set<frozen<map<text, list<double>>>>");
         assertNotNull(type);
@@ -186,8 +192,9 @@ public class CqlFieldTests extends VersionRunner
         assertEquals(list.type(), bridge.aDouble());
     }
 
-    @Test
-    public void testFrozenCqlTypeParser()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.spark.data.VersionRunner#bridges")
+    public void testFrozenCqlTypeParser(CassandraBridge bridge)
     {
         CqlField.CqlType type = bridge.parseType("frozen<map<text, float>>");
         assertNotNull(type);
@@ -199,8 +206,9 @@ public class CqlFieldTests extends VersionRunner
         assertEquals(map.valueType(), bridge.aFloat());
     }
 
-    @Test
-    public void testFrozenCqlTypeNested()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.spark.data.VersionRunner#bridges")
+    public void testFrozenCqlTypeNested(CassandraBridge bridge)
     {
         CqlField.CqlType type = bridge.parseType("map<frozen<set<text>>, frozen<map<int, list<blob>>>>");
         assertNotNull(type);
@@ -222,12 +230,12 @@ public class CqlFieldTests extends VersionRunner
         assertEquals(((CqlField.CqlList) valueMap.valueType()).type(), bridge.blob());
     }
 
-    private void testCqlTypeParser(String str, CqlField.CqlType expectedType)
+    private void testCqlTypeParser(String str, CqlField.CqlType expectedType, CassandraBridge bridge)
     {
-        testCqlTypeParser(str, expectedType, null);
+        testCqlTypeParser(str, expectedType, null, bridge);
     }
 
-    private void testCqlTypeParser(String str, CqlField.CqlType expectedType, CqlField.CqlType otherType)
+    private void testCqlTypeParser(String str, CqlField.CqlType expectedType, CqlField.CqlType otherType, CassandraBridge bridge)
     {
         CqlField.CqlType type = bridge.parseType(str);
         if (type instanceof CqlField.CqlTuple)

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/data/DataLayerUnsupportedPushDownFiltersTest.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/data/DataLayerUnsupportedPushDownFiltersTest.java
@@ -24,7 +24,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import com.google.common.collect.ImmutableList;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.apache.cassandra.bridge.CassandraBridge;
 import org.apache.cassandra.spark.TestDataLayer;
@@ -48,9 +48,9 @@ import org.apache.spark.sql.sources.StringStartsWith;
 
 import static org.apache.cassandra.spark.TestUtils.getFileType;
 import static org.apache.cassandra.spark.TestUtils.runTest;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 public class DataLayerUnsupportedPushDownFiltersTest
 {

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/data/DefaultSizingTest.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/data/DefaultSizingTest.java
@@ -19,9 +19,9 @@
 
 package org.apache.cassandra.spark.data;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Unit tests for the {@link DefaultSizing} class

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/data/LocalDataLayerTests.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/data/LocalDataLayerTests.java
@@ -28,27 +28,26 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.stream.Stream;
 
-import org.junit.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
+import org.apache.cassandra.bridge.CassandraBridge;
 import org.apache.cassandra.bridge.CassandraVersion;
 import org.apache.cassandra.spark.data.partitioner.Partitioner;
 import org.apache.cassandra.spark.reader.SchemaTests;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class LocalDataLayerTests extends VersionRunner
 {
-    public LocalDataLayerTests(CassandraVersion version)
-    {
-        super(version);
-    }
 
-    @Test
-    public void testLocalDataLayer() throws IOException
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.spark.data.VersionRunner#bridges")
+    public void testLocalDataLayer(CassandraBridge bridge) throws IOException
     {
         CassandraVersion version = bridge.getVersion();
         Path directory1 = Files.createTempDirectory("d1");
@@ -69,8 +68,9 @@ public class LocalDataLayerTests extends VersionRunner
         assertTrue(ssTables.openAll((ssTable, isRepairPrimary) -> null).isEmpty());
     }
 
-    @Test
-    public void testEquality()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.spark.data.VersionRunner#bridges")
+    public void testEquality(CassandraBridge bridge)
     {
         CassandraVersion version = bridge.getVersion();
         LocalDataLayer dataLayer1 = new LocalDataLayer(version, "backup_test", SchemaTests.SCHEMA,

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/data/ReplicationFactorTests.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/data/ReplicationFactorTests.java
@@ -22,11 +22,12 @@ package org.apache.cassandra.spark.data;
 import java.util.ArrayList;
 
 import com.google.common.collect.ImmutableMap;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class ReplicationFactorTests
 {
@@ -76,20 +77,24 @@ public class ReplicationFactorTests
         assertEquals(Integer.valueOf(5), replicationFactor.getOptions().get("replication_factor"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test()
     public void testUnexpectedRFClass()
     {
-        new ReplicationFactor(ImmutableMap.of(
-                "class", "org.apache.cassandra.locator.NotSimpleStrategy",
-                "replication_factor", "5"));
+        assertThrows(IllegalArgumentException.class,
+                     () -> new ReplicationFactor(ImmutableMap.of(
+                     "class", "org.apache.cassandra.locator.NotSimpleStrategy",
+                     "replication_factor", "5"))
+        );
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test()
     public void testUnknownRFClass()
     {
-        new ReplicationFactor(ImmutableMap.of(
-                "class", "NoSuchStrategy",
-                "replication_factor", "5"));
+        assertThrows(IllegalArgumentException.class,
+                     () -> new ReplicationFactor(ImmutableMap.of(
+                     "class", "NoSuchStrategy",
+                     "replication_factor", "5"))
+        );
     }
 
     @Test

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/data/VersionRunner.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/data/VersionRunner.java
@@ -19,11 +19,9 @@
 
 package org.apache.cassandra.spark.data;
 
+import java.util.Arrays;
 import java.util.Collection;
-
-import com.google.common.collect.ImmutableList;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import java.util.stream.Collectors;
 
 import org.apache.cassandra.bridge.CassandraBridge;
 import org.apache.cassandra.bridge.CassandraBridgeFactory;
@@ -32,23 +30,22 @@ import org.apache.cassandra.bridge.CassandraVersion;
 /**
  * Run tests Parameterized for multiple versions of Cassandra
  */
-// TODO: Merge org.apache.cassandra.bridge.VersionRunner and org.apache.cassandra.spark.data.VersionRunner
-@RunWith(Parameterized.class)
-public abstract class VersionRunner
+public class VersionRunner
 {
-    protected final CassandraVersion version;
-    protected final CassandraBridge bridge;
-
-    @Parameterized.Parameters
-    public static Collection<Object[]> versions()
+    protected VersionRunner()
     {
-        // TODO: Make use of TestUtils.testableVersions() instead
-        return ImmutableList.of(new Object[]{CassandraVersion.FOURZERO});
     }
 
-    public VersionRunner(CassandraVersion version)
+    public static Collection<CassandraVersion> versions()
     {
-        this.version = version;
-        this.bridge = CassandraBridgeFactory.get(version);
+        return Arrays.stream(CassandraVersion.implementedVersions())
+                     .collect(Collectors.toList());
+    }
+
+    public static Collection<CassandraBridge> bridges()
+    {
+        return versions().stream().map(CassandraBridgeFactory::get)
+                         .collect(Collectors.toList());
     }
 }
+

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/data/partitioner/CassandraRingTests.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/data/partitioner/CassandraRingTests.java
@@ -29,14 +29,14 @@ import com.google.common.collect.Multimap;
 import com.google.common.collect.Range;
 import com.google.common.collect.RangeSet;
 import com.google.common.collect.TreeRangeSet;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.apache.cassandra.spark.data.ReplicationFactor;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SuppressWarnings("UnstableApiUsage")
 public class CassandraRingTests
@@ -59,7 +59,7 @@ public class CassandraRingTests
         RangeSet<BigInteger> rangeSet = TreeRangeSet.create();
 
         ranges.forEach(rangeSet::add);
-        validTokens.forEach(token -> assertTrue(token + " should have been a valid token", rangeSet.contains(token)));
+        validTokens.forEach(token -> assertTrue(rangeSet.contains(token), token + " should have been a valid token"));
         invalidTokens.forEach(token -> assertFalse(rangeSet.contains(token)));
     }
 

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/data/partitioner/ConsistencyLevelTests.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/data/partitioner/ConsistencyLevelTests.java
@@ -20,11 +20,11 @@
 package org.apache.cassandra.spark.data.partitioner;
 
 import com.google.common.collect.ImmutableMap;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.apache.cassandra.spark.data.ReplicationFactor;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ConsistencyLevelTests
 {

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/data/partitioner/JDKSerializationTests.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/data/partitioner/JDKSerializationTests.java
@@ -35,7 +35,8 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Range;
 import org.apache.commons.lang.NotImplementedException;
 import org.apache.commons.lang3.RandomStringUtils;
-import org.junit.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import org.apache.cassandra.bridge.CassandraBridge;
 import org.apache.cassandra.bridge.CassandraBridgeFactory;
@@ -55,21 +56,18 @@ import org.apache.cassandra.spark.data.VersionRunner;
 import org.apache.cassandra.spark.utils.test.TestSchema;
 import org.jetbrains.annotations.NotNull;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.quicktheories.QuickTheory.qt;
 import static org.quicktheories.generators.SourceDSL.arbitrary;
 
 public class JDKSerializationTests extends VersionRunner
 {
-    public JDKSerializationTests(CassandraVersion version)
-    {
-        super(version);
-    }
 
-    @Test
-    public void testCassandraRing()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.spark.data.VersionRunner#bridges")
+    public void testCassandraRing(CassandraBridge bridge)
     {
         qt().forAll(TestUtils.partitioners(), arbitrary().pick(Arrays.asList(1, 3, 6, 12, 128)))
             .checkAssert(((partitioner, numInstances) -> {
@@ -91,8 +89,9 @@ public class JDKSerializationTests extends VersionRunner
             }));
     }
 
-    @Test
-    public void testTokenPartitioner()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.spark.data.VersionRunner#bridges")
+    public void testTokenPartitioner(CassandraBridge bridge)
     {
         qt().forAll(TestUtils.partitioners(),
                     arbitrary().pick(Arrays.asList(1, 3, 6, 12, 128)),
@@ -114,8 +113,9 @@ public class JDKSerializationTests extends VersionRunner
             }));
     }
 
-    @Test
-    public void testPartitionedDataLayer()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.spark.data.VersionRunner#bridges")
+    public void testPartitionedDataLayer(CassandraBridge bridge)
     {
         CassandraRing ring = TestUtils.createRing(Partitioner.Murmur3Partitioner, 1024);
         TestSchema schema = TestSchema.basic(bridge);
@@ -130,8 +130,9 @@ public class JDKSerializationTests extends VersionRunner
         assertEquals(Partitioner.Murmur3Partitioner, deserialized.partitioner());
     }
 
-    @Test
-    public void testCqlFieldSet()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.spark.data.VersionRunner#bridges")
+    public void testCqlFieldSet(CassandraBridge bridge)
     {
         CqlField.CqlSet setType = bridge.set(bridge.text());
         CqlField field = new CqlField(true, false, false, RandomStringUtils.randomAlphanumeric(5, 20), setType, 10);
@@ -145,8 +146,9 @@ public class JDKSerializationTests extends VersionRunner
         assertEquals(field.isClusteringColumn(), deserialized.isClusteringColumn());
     }
 
-    @Test
-    public void testCqlUdt()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.spark.data.VersionRunner#bridges")
+    public void testCqlUdt(CassandraBridge bridge)
     {
         CqlField.CqlUdt udt1 = bridge
                                .udt("udt_keyspace", "udt_table")
@@ -284,8 +286,9 @@ public class JDKSerializationTests extends VersionRunner
         }
     }
 
-    @Test
-    public void testSecretsConfig()
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.spark.data.VersionRunner#bridges")
+    public void testSecretsConfig(CassandraBridge bridge)
     {
         SslConfig config = new SslConfig.Builder<>()
                            .keyStorePath("keyStorePath")

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/data/partitioner/MultipleReplicasTests.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/data/partitioner/MultipleReplicasTests.java
@@ -29,7 +29,7 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import com.google.common.collect.Range;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.apache.cassandra.spark.TestUtils;
 import org.apache.cassandra.spark.data.PartitionedDataLayer;
@@ -37,8 +37,9 @@ import org.apache.cassandra.spark.data.SSTable;
 import org.apache.cassandra.spark.reader.SparkSSTableReader;
 import org.apache.cassandra.spark.stats.Stats;
 
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.eq;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -91,22 +92,29 @@ public class MultipleReplicasTests
         runTest(5, 3, 2, 0);
     }
 
-    @Test(expected = AssertionError.class)
+    @Test()
     public void testRF1NotEnoughReplicas()
     {
-        runTest(1, 1, 1, 0);
+        assertThrows(AssertionError.class,
+                     () -> runTest(1, 1, 1, 0)
+        );
     }
 
-    @Test(expected = AssertionError.class)
+    @Test()
     public void testRF3QuorumNotEnoughReplicas()
     {
-        runTest(3, 2, 1, 1);
+        assertThrows(AssertionError.class,
+                     () -> runTest(3, 2, 1, 1)
+        );
     }
 
-    @Test(expected = AssertionError.class)
+    @Test()
     public void testRFAllNotEnoughReplicas()
     {
-        runTest(3, 3, 1, 0);
+        assertThrows(AssertionError.class,
+                     () ->
+                     runTest(3, 3, 1, 0)
+        );
     }
 
     private static void runTest(int numInstances, int rfFactor, int numDownPrimaryInstances, int numDownBackupInstances)

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/data/partitioner/SingleReplicaTests.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/data/partitioner/SingleReplicaTests.java
@@ -30,7 +30,7 @@ import java.util.stream.Stream;
 
 import com.google.common.collect.Range;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.apache.cassandra.spark.data.FileType;
 import org.apache.cassandra.spark.data.IncompleteSSTableException;
@@ -41,10 +41,11 @@ import org.apache.cassandra.spark.reader.SparkSSTableReader;
 import org.apache.cassandra.spark.reader.common.SSTableStreamException;
 import org.jetbrains.annotations.Nullable;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -82,32 +83,39 @@ public class SingleReplicaTests
         runTest(false, FileType.INDEX);
     }
 
-    @Test(expected = IOException.class)
-    public void testMissingDataFile() throws ExecutionException, InterruptedException, IOException
+    @Test()
+    public void testMissingDataFile()
     {
-        runTest(true, FileType.DATA);
+        assertThrows(IOException.class,
+                     () -> runTest(true, FileType.DATA)
+        );
     }
 
-    @Test(expected = IOException.class)
-    public void testMissingStatisticsFile() throws ExecutionException, InterruptedException, IOException
-    {
-        runTest(true, FileType.STATISTICS);
+    @Test()
+    public void testMissingStatisticsFile()
+    {        assertThrows(IOException.class,
+                          () -> runTest(true, FileType.STATISTICS)
+    );
     }
 
-    @Test(expected = IOException.class)
-    public void testMissingSummaryPrimaryIndex() throws ExecutionException, InterruptedException, IOException
+    @Test()
+    public void testMissingSummaryPrimaryIndex()
     {
-        runTest(true, FileType.SUMMARY, FileType.INDEX);
+        assertThrows(IOException.class,
+                     () -> runTest(true, FileType.SUMMARY, FileType.INDEX)
+        );
     }
 
-    @Test(expected = IOException.class)
-    public void testFailOpenReader() throws ExecutionException, InterruptedException, IOException
+    @Test()
+    public void testFailOpenReader()
     {
-        runTest(true,
-                (ssTable, isRepairPrimary) -> {
-                    throw new IOException("Couldn't open Summary.db file");
-                },
-                Range.closed(BigInteger.valueOf(-9223372036854775808L), BigInteger.valueOf(8710962479251732707L)));
+        assertThrows(IOException.class,
+                     () -> runTest(true,
+                                   (ssTable, isRepairPrimary) -> {
+                         throw new IOException("Couldn't open Summary.db file");
+                         },
+                Range.closed(BigInteger.valueOf(-9223372036854775808L), BigInteger.valueOf(8710962479251732707L)))
+        );
     }
 
     @Test

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/data/partitioner/TokenPartitionerTests.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/data/partitioner/TokenPartitionerTests.java
@@ -28,13 +28,13 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import com.google.common.collect.Range;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.apache.cassandra.spark.TestUtils;
 import org.apache.cassandra.spark.utils.RandomUtils;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.quicktheories.QuickTheory.qt;
 import static org.quicktheories.generators.SourceDSL.arbitrary;
 
@@ -76,8 +76,8 @@ public class TokenPartitionerTests
 
         for (Map.Entry<BigInteger, Integer> entry : tokens.entrySet())
         {
-            assertFalse("Token not found in any token partitions: " + entry.getKey(), entry.getValue() < 1);
-            assertFalse("Token exists in more than one token partition: " + entry.getKey(), entry.getValue() > 1);
+            assertFalse(entry.getValue() < 1, "Token not found in any token partitions: " + entry.getKey());
+            assertFalse(entry.getValue() > 1, "Token exists in more than one token partition: " + entry.getKey());
         }
     }
 }

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/reader/CassandraBridgeTests.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/reader/CassandraBridgeTests.java
@@ -19,12 +19,12 @@
 
 package org.apache.cassandra.spark.reader;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.apache.cassandra.spark.TestUtils;
 import org.apache.spark.sql.types.DataTypes;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.quicktheories.QuickTheory.qt;
 
 public class CassandraBridgeTests

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/reader/DataTypeSerializationTests.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/reader/DataTypeSerializationTests.java
@@ -35,7 +35,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.apache.cassandra.bridge.BigNumberConfig;
 import org.apache.cassandra.spark.TestUtils;
@@ -47,12 +47,12 @@ import org.apache.spark.sql.types.Decimal;
 import org.apache.spark.unsafe.types.UTF8String;
 
 import static org.apache.cassandra.spark.TestUtils.runTest;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.quicktheories.QuickTheory.qt;
 import static org.quicktheories.generators.SourceDSL.bigDecimals;
 import static org.quicktheories.generators.SourceDSL.bigIntegers;

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/reader/OverlapTests.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/reader/OverlapTests.java
@@ -22,13 +22,13 @@ package org.apache.cassandra.spark.reader;
 import java.math.BigInteger;
 
 import com.google.common.base.Preconditions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.apache.cassandra.bridge.TokenRange;
 import org.apache.cassandra.spark.data.partitioner.Partitioner;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class OverlapTests
 {

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/reader/PartitionKeyTests.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/reader/PartitionKeyTests.java
@@ -27,14 +27,14 @@ import java.util.Collections;
 import java.util.List;
 
 import com.google.common.collect.ImmutableList;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.apache.cassandra.spark.data.CqlField;
 import org.apache.cassandra.spark.data.CqlTable;
 
 import static org.apache.cassandra.spark.TestUtils.runTest;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/reader/RidTests.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/reader/RidTests.java
@@ -23,13 +23,13 @@ import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class RidTests
 {

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/reader/TombstoneWriterTests.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/reader/TombstoneWriterTests.java
@@ -23,7 +23,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.file.Path;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -31,9 +31,9 @@ import org.apache.cassandra.spark.TestUtils;
 import org.apache.cassandra.spark.data.FileType;
 import org.apache.cassandra.spark.utils.test.TestSchema;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.quicktheories.QuickTheory.qt;
 
 /**

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/reader/common/CompressionInputStreamTests.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/reader/common/CompressionInputStreamTests.java
@@ -29,13 +29,14 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.UUID;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.apache.cassandra.spark.stats.Stats;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class CompressionInputStreamTests
 {
@@ -80,24 +81,32 @@ public class CompressionInputStreamTests
         }
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test()
     public void testBigLongArrayIllegalSize()
     {
-        new BigLongArray(-1);
+        assertThrows(IndexOutOfBoundsException.class,
+                     () -> new BigLongArray(-1)
+        );
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test()
     public void testBigLongArrayEmpty()
     {
-        BigLongArray array = new BigLongArray(0);
-        array.set(0, 0L);
+        assertThrows(IndexOutOfBoundsException.class,
+                     () -> {
+                         BigLongArray array = new BigLongArray(0);
+                         array.set(0, 0L);
+                     });
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test()
     public void testBigLongArrayOutOfRange()
     {
-        BigLongArray array = new BigLongArray(500);
-        array.set(501, 999L);
+        assertThrows(IndexOutOfBoundsException.class,
+                     () -> {
+                         BigLongArray array = new BigLongArray(500);
+                         array.set(501, 999L);
+                     });
     }
 
     @Test

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/utils/BuildInfoTest.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/utils/BuildInfoTest.java
@@ -19,12 +19,12 @@
 
 package org.apache.cassandra.spark.utils;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BuildInfoTest
 {

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/utils/ByteBufferUtilsTests.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/utils/ByteBufferUtilsTests.java
@@ -27,10 +27,10 @@ import java.nio.charset.StandardCharsets;
 
 import com.google.common.io.ByteArrayDataInput;
 import com.google.common.io.ByteStreams;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 @SuppressWarnings("UnstableApiUsage")
 public class ByteBufferUtilsTests

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/utils/FilterUtilsTests.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/utils/FilterUtilsTests.java
@@ -25,23 +25,26 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.apache.spark.sql.sources.EqualTo;
 import org.apache.spark.sql.sources.Filter;
 import org.apache.spark.sql.sources.In;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class FilterUtilsTests
 {
-    @Test(expected = IllegalArgumentException.class)
+    @Test()
     public void testPartialPartitionKeyFilter()
     {
         Filter[] filters = new Filter[]{new EqualTo("a", "1")};
-        Map<String, List<String>> partitionKeyValues = FilterUtils.extractPartitionKeyValues(filters, new HashSet<>(Arrays.asList("a", "b")));
+        assertThrows(IllegalArgumentException.class,
+                     () -> FilterUtils.extractPartitionKeyValues(filters, new HashSet<>(Arrays.asList("a", "b")))
+        );
     }
 
     @Test
@@ -54,11 +57,13 @@ public class FilterUtilsTests
         assertTrue(partitionKeyValues.containsKey("b"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test()
     public void testCartesianProductOfInValidValues()
     {
         List<List<String>> orderedValues = Arrays.asList(Arrays.asList("1", "2"), Arrays.asList("a", "b", "c"), Collections.emptyList());
-        List<List<String>> product = FilterUtils.cartesianProduct(orderedValues);
+        assertThrows(IllegalArgumentException.class,
+                     () -> FilterUtils.cartesianProduct(orderedValues)
+        );
     }
 
     @Test

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/utils/RangeUtilsTest.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/utils/RangeUtilsTest.java
@@ -28,14 +28,14 @@ import java.util.regex.Pattern;
 
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Range;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.apache.cassandra.spark.data.partitioner.CassandraInstance;
 import org.apache.cassandra.spark.data.partitioner.Partitioner;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class RangeUtilsTest
 {
@@ -161,13 +161,14 @@ public class RangeUtilsTest
                 new String[]{"(0,4611686018427387904]"});
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test()
     public void testCalculateTokenRangesRFGreaterThanNodesFails()
     {
-        assertTokenRanges(2, 3,
-                new String[]{"Does Not"},
-                new String[]{"Matter"});
-        fail("Expected failure when RF greater than number of Nodes");
+        assertThrows(IllegalArgumentException.class,
+                     () -> assertTokenRanges(2, 3,
+                                             new String[]{"Does Not"},
+                                             new String[]{"Matter"})
+        );
     }
 
     @Test
@@ -194,8 +195,8 @@ public class RangeUtilsTest
         assertEquals(expectedRanges.length, actual.size());
         for (String expected : expectedRanges)
         {
-            assertTrue(String.format("Expected range %s not found in %s", expected, actual),
-                       actual.contains(range(expected)));
+            assertTrue(actual.contains(range(expected)),
+                       String.format("Expected range %s not found in %s", expected, actual));
         }
     }
 

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/utils/SSTableInputStreamTests.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/utils/SSTableInputStreamTests.java
@@ -34,7 +34,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.common.util.concurrent.Uninterruptibles;
 import org.apache.commons.lang.mutable.MutableInt;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.apache.cassandra.spark.data.FileType;
 import org.apache.cassandra.spark.data.SSTable;
@@ -46,10 +46,11 @@ import org.apache.cassandra.spark.utils.streaming.StreamConsumer;
 import org.jetbrains.annotations.Nullable;
 
 import static org.apache.cassandra.spark.utils.streaming.SSTableInputStream.timeoutLeftNanos;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Test the {@link SSTableInputStream} by mocking the {@link SSTableSource}
@@ -147,8 +148,8 @@ public class SSTableInputStreamTests
         assertEquals(fileSize, is.bytesRead());
     }
 
-    @Test(expected = IOException.class)
-    public void testFailure() throws IOException
+    @Test()
+    public void testFailure()
     {
         int chunksPerRequest = 10;
         int numRequests = 10;
@@ -168,8 +169,9 @@ public class SSTableInputStreamTests
                 writeBuffers(consumer, randomBuffers(chunksPerRequest));
             }
         }, null);
-        readStreamFully(new SSTableInputStream<>(source, STATS));
-        fail("Should have failed with IOException");
+        assertThrows(IOException.class,
+                     () -> readStreamFully(new SSTableInputStream<>(source, STATS))
+        );
     }
 
     @Test
@@ -229,9 +231,9 @@ public class SSTableInputStreamTests
         }
         Duration duration = Duration.ofNanos(System.nanoTime() - startTime);
         Duration maxAcceptable = timeout.plus(Duration.ofMillis(sleepTimeInMillis));
-        assertTrue("Timeout didn't account for activity time. "
-                 + "Took " + duration.toMillis() + "ms should have taken at most " + maxAcceptable.toMillis() + "ms",
-                   duration.minus(maxAcceptable).toMillis() < 100);
+        assertTrue(duration.minus(maxAcceptable).toMillis() < 100,
+                   "Timeout didn't account for activity time. "
+                   + "Took " + duration.toMillis() + "ms should have taken at most " + maxAcceptable.toMillis() + "ms");
     }
 
     @Test

--- a/cassandra-analytics-core/src/test/spark2/org/apache/cassandra/spark/sparksql/PartitionKeyFilterTests.java
+++ b/cassandra-analytics-core/src/test/spark2/org/apache/cassandra/spark/sparksql/PartitionKeyFilterTests.java
@@ -28,7 +28,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import com.google.common.collect.Range;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.apache.cassandra.bridge.TokenRange;
 import org.apache.cassandra.spark.TestUtils;
@@ -39,9 +39,9 @@ import org.apache.cassandra.spark.reader.SparkSSTableReader;
 import org.apache.cassandra.spark.sparksql.filters.PartitionKeyFilter;
 import org.apache.cassandra.spark.utils.RangeUtils;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.quicktheories.QuickTheory.qt;

--- a/cassandra-analytics-core/src/test/spark2/org/apache/cassandra/spark/sparksql/SparkRangeFilterTests.java
+++ b/cassandra-analytics-core/src/test/spark2/org/apache/cassandra/spark/sparksql/SparkRangeFilterTests.java
@@ -21,14 +21,14 @@ package org.apache.cassandra.spark.sparksql;
 
 import java.math.BigInteger;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.apache.cassandra.bridge.TokenRange;
 import org.apache.cassandra.spark.reader.SparkSSTableReader;
 import org.apache.cassandra.spark.sparksql.filters.SparkRangeFilter;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/cassandra-analytics-core/src/test/spark2/org/apache/cassandra/spark/sparksql/SparkRowIteratorTests.java
+++ b/cassandra-analytics-core/src/test/spark2/org/apache/cassandra/spark/sparksql/SparkRowIteratorTests.java
@@ -26,7 +26,7 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.apache.cassandra.bridge.CassandraBridge;
 import org.apache.cassandra.bridge.CassandraBridgeFactory;
@@ -43,7 +43,7 @@ import org.apache.cassandra.spark.stats.Stats;
 import org.apache.cassandra.spark.utils.ColumnTypes;
 import org.apache.cassandra.spark.utils.test.TestSchema;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyListOf;

--- a/cassandra-analytics-core/src/test/spark3/org/apache/cassandra/spark/sparksql/CdcOffsetTests.java
+++ b/cassandra-analytics-core/src/test/spark3/org/apache/cassandra/spark/sparksql/CdcOffsetTests.java
@@ -21,12 +21,12 @@ package org.apache.cassandra.spark.sparksql;
 
 import java.io.IOException;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.apache.cassandra.spark.sparksql.filters.CdcOffset;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class CdcOffsetTests
 {

--- a/cassandra-bridge/build.gradle
+++ b/cassandra-bridge/build.gradle
@@ -27,6 +27,7 @@ project(':cassandra-bridge') {
         testImplementation(group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: "${jacksonVersion}")
         testImplementation(group: 'com.google.guava', name: 'guava', version: '31.1-jre')
         testImplementation(group: 'org.slf4j', name: 'slf4j-simple', version: '1.7.26')
-        testImplementation(group: 'junit', name: 'junit', version: "${project.rootProject.junitVersion}")
-    }
+        testImplementation("org.junit.jupiter:junit-jupiter-api:${project.junitVersion}")
+        testImplementation("org.junit.jupiter:junit-jupiter-params:${project.junitVersion}")
+        testImplementation("org.junit.jupiter:junit-jupiter-engine:${project.junitVersion}")    }
 }

--- a/cassandra-bridge/src/test/java/org/apache/cassandra/bridge/BigNumberConfigImplTest.java
+++ b/cassandra-bridge/src/test/java/org/apache/cassandra/bridge/BigNumberConfigImplTest.java
@@ -23,11 +23,11 @@ import java.io.IOException;
 import java.util.Map;
 
 import com.google.common.collect.ImmutableMap;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Unit tests for {@link BigNumberConfigImpl}

--- a/cassandra-bridge/src/test/java/org/apache/cassandra/spark/utils/ArrayUtilsTest.java
+++ b/cassandra-bridge/src/test/java/org/apache/cassandra/spark/utils/ArrayUtilsTest.java
@@ -21,8 +21,8 @@ package org.apache.cassandra.spark.utils;
 
 import java.util.function.Consumer;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import static org.apache.cassandra.spark.utils.ArrayUtils.retain;
 
@@ -32,7 +32,7 @@ public class ArrayUtilsTest
     public void testRetain()
     {
         Object[] source = new Object[]{1, 2, 3, 4, 5};
-        Assert.assertArrayEquals(new Object[]{1, 2, 3}, retain(source, 0, 3));
+        Assertions.assertArrayEquals(new Object[]{1, 2, 3}, retain(source, 0, 3));
     }
 
     @Test
@@ -40,16 +40,16 @@ public class ArrayUtilsTest
     {
         // Not using JUnit rule ExpectedException in order to assert multiple throwables
         expectedThrows(() -> retain(null, 0, 1),
-                       throwable -> Assert.assertSame(IllegalArgumentException.class, throwable.getClass()));
+                       throwable -> Assertions.assertSame(IllegalArgumentException.class, throwable.getClass()));
 
         expectedThrows(() -> retain(new Object[]{1, 2, 3}, -1, 1),
-                       throwable -> Assert.assertSame(IllegalArgumentException.class, throwable.getClass()));
+                       throwable -> Assertions.assertSame(IllegalArgumentException.class, throwable.getClass()));
 
         expectedThrows(() -> retain(new Object[]{1, 2, 3}, 0, -1),
-                       throwable -> Assert.assertSame(IllegalArgumentException.class, throwable.getClass()));
+                       throwable -> Assertions.assertSame(IllegalArgumentException.class, throwable.getClass()));
 
         expectedThrows(() -> retain(new Object[]{1, 2, 3}, 0, 5),
-                       throwable -> Assert.assertSame(IllegalArgumentException.class, throwable.getClass()));
+                       throwable -> Assertions.assertSame(IllegalArgumentException.class, throwable.getClass()));
     }
 
     private void expectedThrows(Runnable test, Consumer<Throwable> throwableVerifier)

--- a/cassandra-bridge/src/test/java/org/apache/cassandra/spark/utils/LoggerHelperTests.java
+++ b/cassandra-bridge/src/test/java/org/apache/cassandra/spark/utils/LoggerHelperTests.java
@@ -19,12 +19,12 @@
 
 package org.apache.cassandra.spark.utils;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class LoggerHelperTests
 {

--- a/cassandra-bridge/src/test/java/org/apache/cassandra/spark/utils/ThrowableUtilTests.java
+++ b/cassandra-bridge/src/test/java/org/apache/cassandra/spark/utils/ThrowableUtilTests.java
@@ -22,13 +22,13 @@ package org.apache.cassandra.spark.utils;
 import java.io.IOException;
 import java.util.Objects;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.apache.cassandra.spark.exceptions.TransportFailureException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ThrowableUtilTests
 {

--- a/cassandra-four-zero/build.gradle
+++ b/cassandra-four-zero/build.gradle
@@ -40,7 +40,9 @@ project(':cassandra-four-zero') {
 
         testImplementation(project(':cassandra-bridge'))
 
-        testImplementation(group: 'junit', name: 'junit', version: "${project.rootProject.junitVersion}")
+        testImplementation("org.junit.jupiter:junit-jupiter-api:${project.junitVersion}")
+        testImplementation("org.junit.jupiter:junit-jupiter-params:${project.junitVersion}")
+        testImplementation("org.junit.jupiter:junit-jupiter-engine:${project.junitVersion}")
         testImplementation(group: 'org.quicktheories', name: 'quicktheories', version: "${project.rootProject.quickTheoriesVersion}")
         testImplementation("org.mockito:mockito-core:${project.rootProject.mockitoVersion}")
         testImplementation(group: "${sparkGroupId}", name: "spark-core_${scalaMajorVersion}", version: "${project.rootProject.sparkVersion}")

--- a/cassandra-four-zero/src/test/java/org/apache/cassandra/spark/data/types/DateTypeTests.java
+++ b/cassandra-four-zero/src/test/java/org/apache/cassandra/spark/data/types/DateTypeTests.java
@@ -21,13 +21,13 @@ package org.apache.cassandra.spark.data.types;
 
 import java.time.LocalDate;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.apache.cassandra.bridge.CassandraBridgeImplementation;
 import org.apache.cassandra.serializers.SimpleDateSerializer;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class DateTypeTests
 {

--- a/cassandra-four-zero/src/test/java/org/apache/cassandra/spark/reader/CdcScannerTests.java
+++ b/cassandra-four-zero/src/test/java/org/apache/cassandra/spark/reader/CdcScannerTests.java
@@ -25,14 +25,14 @@ import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.apache.cassandra.db.commitlog.PartitionUpdateWrapper;
 import org.apache.cassandra.spark.cdc.watermarker.Watermarker;
 import org.apache.cassandra.spark.stats.Stats;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.eq;

--- a/cassandra-four-zero/src/test/java/org/apache/cassandra/spark/reader/IndexDbTests.java
+++ b/cassandra-four-zero/src/test/java/org/apache/cassandra/spark/reader/IndexDbTests.java
@@ -35,7 +35,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import com.google.common.base.Preconditions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.apache.cassandra.bridge.CassandraBridgeImplementation;
 import org.apache.cassandra.bridge.TokenRange;
@@ -51,10 +51,10 @@ import org.apache.cassandra.spark.utils.test.TestSSTable;
 import org.apache.cassandra.spark.utils.test.TestSchema;
 import org.jetbrains.annotations.NotNull;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.quicktheories.QuickTheory.qt;
 import static org.quicktheories.generators.Generate.constant;
 import static org.quicktheories.generators.SourceDSL.arbitrary;
@@ -110,13 +110,13 @@ public class IndexDbTests
                     Collections.sort(tokens);
 
                     TableMetadata metadata = Schema.instance.getTableMetadata(schema.keyspace, schema.table);
-                    assertNotNull("Could not find table metadata", metadata);
+                    assertNotNull(metadata, "Could not find table metadata");
 
                     Path summaryDb = TestSSTable.firstIn(directory.path(), FileType.SUMMARY);
-                    assertNotNull("Could not find summary", summaryDb);
+                    assertNotNull(summaryDb, "Could not find summary");
 
                     SSTable ssTable = TestSSTable.firstIn(directory.path());
-                    assertNotNull("Could not find SSTable", ssTable);
+                    assertNotNull(ssTable, "Could not find SSTable");
 
                     int rowSize = 39;
                     int sample = 4;

--- a/cassandra-four-zero/src/test/java/org/apache/cassandra/spark/reader/IndexOffsetTests.java
+++ b/cassandra-four-zero/src/test/java/org/apache/cassandra/spark/reader/IndexOffsetTests.java
@@ -27,7 +27,7 @@ import java.util.Collection;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.Multimap;
 import org.apache.commons.lang.mutable.MutableInt;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -45,8 +45,8 @@ import org.apache.cassandra.spark.utils.TemporaryDirectory;
 import org.apache.cassandra.spark.utils.test.TestSSTable;
 import org.apache.cassandra.spark.utils.test.TestSchema;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.quicktheories.QuickTheory.qt;
 import static org.quicktheories.generators.SourceDSL.arbitrary;
 import static org.quicktheories.generators.SourceDSL.booleans;
@@ -97,13 +97,13 @@ public class IndexOffsetTests
                     assertEquals(1, TestSSTable.countIn(directory.path()));
 
                     TableMetadata metadata = Schema.instance.getTableMetadata(schema.keyspace, schema.table);
-                    assertNotNull("Could not find table metadata", metadata);
+                    assertNotNull(metadata, "Could not find table metadata");
 
                     SSTable ssTable = TestSSTable.firstIn(directory.path());
-                    assertNotNull("Could not find SSTable", ssTable);
+                    assertNotNull(ssTable, "Could not find SSTable");
 
                     Collection<TokenRange> ranges = RANGES.get(partitioner);
-                    assertNotNull("Unknown paritioner", ranges);
+                    assertNotNull(ranges, "Unknown paritioner");
 
                     LOGGER.info("Testing index offsets numKeys={} sparkPartitions={} partitioner={} enableCompression={}",
                                 numKeys, ranges.size(), partitioner.name(), enableCompression);
@@ -173,8 +173,8 @@ public class IndexOffsetTests
                                                 .getToken()),
                                          partitioner.name());
                         }
-                        assertEquals(count > 0 ? "Key " + index + " read " + count + " times"
-                                               : "Key not found: " + index, 1, count);
+                        assertEquals(1, count, count > 0 ? "Key " + index + " read " + count + " times"
+                                                         : "Key not found: " + index);
                         index++;
                     }
 

--- a/cassandra-four-zero/src/test/java/org/apache/cassandra/spark/reader/KryoSerializationTests.java
+++ b/cassandra-four-zero/src/test/java/org/apache/cassandra/spark/reader/KryoSerializationTests.java
@@ -25,7 +25,7 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 import com.google.common.collect.ImmutableMap;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.io.Input;
@@ -44,8 +44,8 @@ import org.apache.cassandra.serializers.UTF8Serializer;
 import org.apache.cassandra.serializers.UUIDSerializer;
 import org.apache.cassandra.spark.data.ReplicationFactor;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class KryoSerializationTests
 {

--- a/cassandra-four-zero/src/test/java/org/apache/cassandra/spark/reader/PartitionKeyTests.java
+++ b/cassandra-four-zero/src/test/java/org/apache/cassandra/spark/reader/PartitionKeyTests.java
@@ -24,7 +24,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.apache.cassandra.bridge.CassandraBridgeImplementation;
 import org.apache.cassandra.db.marshal.AbstractType;
@@ -34,8 +34,8 @@ import org.apache.cassandra.spark.data.CqlType;
 import org.apache.cassandra.spark.utils.ComparisonUtils;
 import org.apache.cassandra.spark.utils.test.TestSchema;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.quicktheories.QuickTheory.qt;
 import static org.quicktheories.generators.SourceDSL.arbitrary;
 

--- a/cassandra-four-zero/src/test/java/org/apache/cassandra/spark/reader/ReaderUtilsTests.java
+++ b/cassandra-four-zero/src/test/java/org/apache/cassandra/spark/reader/ReaderUtilsTests.java
@@ -35,7 +35,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.apache.cassandra.bridge.CassandraBridgeImplementation;
 import org.apache.cassandra.db.DecoratedKey;
@@ -60,10 +60,10 @@ import org.apache.cassandra.spark.utils.test.TestSSTable;
 import org.apache.cassandra.spark.utils.test.TestSchema;
 import org.apache.cassandra.utils.Pair;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.quicktheories.QuickTheory.qt;

--- a/cassandra-four-zero/src/test/java/org/apache/cassandra/spark/reader/SSTableCacheTests.java
+++ b/cassandra-four-zero/src/test/java/org/apache/cassandra/spark/reader/SSTableCacheTests.java
@@ -26,7 +26,7 @@ import java.util.Map;
 import java.util.stream.IntStream;
 
 import com.google.common.collect.ImmutableMap;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.apache.cassandra.bridge.CassandraBridgeImplementation;
 import org.apache.cassandra.db.DecoratedKey;
@@ -43,11 +43,11 @@ import org.apache.cassandra.spark.utils.test.TestSchema;
 import org.apache.cassandra.utils.BloomFilter;
 import org.apache.cassandra.utils.Pair;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.quicktheories.QuickTheory.qt;
 import static org.quicktheories.generators.SourceDSL.arbitrary;
 

--- a/cassandra-four-zero/src/test/java/org/apache/cassandra/spark/reader/SSTableReaderTests.java
+++ b/cassandra-four-zero/src/test/java/org/apache/cassandra/spark/reader/SSTableReaderTests.java
@@ -47,7 +47,7 @@ import java.util.stream.Stream;
 
 import com.google.common.collect.ImmutableMap;
 import org.apache.commons.lang.StringUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -84,11 +84,11 @@ import org.apache.cassandra.utils.Pair;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.quicktheories.QuickTheory.qt;
 import static org.quicktheories.generators.SourceDSL.arbitrary;
 

--- a/cassandra-four-zero/src/test/java/org/apache/cassandra/spark/reader/SchemaBuilderTests.java
+++ b/cassandra-four-zero/src/test/java/org/apache/cassandra/spark/reader/SchemaBuilderTests.java
@@ -21,7 +21,7 @@ package org.apache.cassandra.spark.reader;
 
 import java.util.HashMap;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.apache.cassandra.bridge.CassandraBridgeImplementation;
 import org.apache.cassandra.cql3.CQLFragmentParser;
@@ -36,7 +36,7 @@ import org.apache.cassandra.spark.data.ReplicationFactor;
 import org.apache.cassandra.utils.FBUtilities;
 
 import static org.apache.cassandra.spark.reader.SchemaBuilder.rfToMap;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class SchemaBuilderTests
 {

--- a/cassandra-four-zero/src/test/java/org/apache/cassandra/spark/reader/SummaryDbTests.java
+++ b/cassandra-four-zero/src/test/java/org/apache/cassandra/spark/reader/SummaryDbTests.java
@@ -29,7 +29,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.LongStream;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.apache.cassandra.bridge.CassandraBridgeImplementation;
 import org.apache.cassandra.dht.IPartitioner;
@@ -42,9 +42,9 @@ import org.apache.cassandra.spark.utils.TemporaryDirectory;
 import org.apache.cassandra.spark.utils.test.TestSSTable;
 import org.apache.cassandra.spark.utils.test.TestSchema;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.quicktheories.QuickTheory.qt;
 import static org.quicktheories.generators.SourceDSL.arbitrary;
 
@@ -107,13 +107,13 @@ public class SummaryDbTests
                     Collections.sort(tokens);
 
                     TableMetadata metadata = Schema.instance.getTableMetadata(schema.keyspace, schema.table);
-                    assertNotNull("Could not find table metadata", metadata);
+                    assertNotNull(metadata, "Could not find table metadata");
 
                     Path summaryDb = TestSSTable.firstIn(directory.path(), FileType.SUMMARY);
-                    assertNotNull("Could not find summary", summaryDb);
+                    assertNotNull(summaryDb, "Could not find summary");
 
                     SSTable ssTable = TestSSTable.firstIn(directory.path());
-                    assertNotNull("Could not find SSTable", ssTable);
+                    assertNotNull(ssTable, "Could not find SSTable");
 
                     // Binary search Summary.db file in token order and verify offsets are ordered
                     SummaryDbUtils.Summary summary = SummaryDbUtils.readSummary(metadata, ssTable);

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -63,7 +63,7 @@
     <!-- See https://checkstyle.org/config_sizes.html -->
     <module name="FileLength">
         <property name="fileExtensions" value="java, xml, properties, gradle, sh" />
-        <property name="max" value="2400" />
+        <property name="max" value="2500" />
     </module>
     <module name="LineLength">
         <property name="fileExtensions" value="java, xml, properties, gradle, sh" />

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,11 +22,12 @@ description=Apache Cassandra Spark Analytics
 
 analyticsJDKLevel=11
 intellijVersion=9.0.4
-junitVersion=4.13
+junitVersion=5.9.2
 quickTheoriesVersion=0.26
 mockitoVersion=3.12.4
 jnaVersion=5.9.0
 scala=2.12
 spark=3
+vertxVersion=4.2.1
 
 org.gradle.jvmargs=-Xmx4096m


### PR DESCRIPTION
For future work, we’d like to use some features only available in JUnit 5 (TestTemplates being the immediate need).
Upgrade cassandra-analytics dependencies to JUnit 5 and fix any test issues.