### PR TITLE
CASSANDRA-18605 Adding support for TTL & Timestamps for bulk writes

### DIFF
--- a/cassandra-analytics-core-example/src/main/java/org/apache/cassandra/spark/example/SampleCassandraJob.java
+++ b/cassandra-analytics-core-example/src/main/java/org/apache/cassandra/spark/example/SampleCassandraJob.java
@@ -141,9 +141,10 @@ public final class SampleCassandraJob
           .option("local_dc", "datacenter1")
           .option("bulk_writer_cl", "LOCAL_QUORUM")
           .option("number_splits", "-1")
-//          .option(WriterOptions.TTL.name(), TTLOption.constant(20))
+          // A constant timestamp and TTL can be used by setting the following options.
+          // .option(WriterOptions.TIMESTAMP.name(), TimestampOption.constant(System.currentTimeMillis() * 1000))
+          // .option(WriterOptions.TTL.name(), TTLOption.constant(20))
           .option(WriterOptions.TTL.name(), TTLOption.perRow("ttl"))
-//          .option(WriterOptions.TIMESTAMP.name(), TimestampOption.constant(System.currentTimeMillis() * 1000))
           .option(WriterOptions.TIMESTAMP.name(), TimestampOption.perRow("timestamp"))
           .mode("append")
           .save();

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/BulkSparkConf.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/BulkSparkConf.java
@@ -119,6 +119,8 @@ public class BulkSparkConf implements Serializable
     protected final String truststorePath;
     protected final String truststoreBase64Encoded;
     protected final String truststoreType;
+    protected final String ttl;
+    protected final String timestamp;
     protected final SparkConf conf;
     public final boolean validateSSTables;
     public final int commitThreadsPerInstance;
@@ -157,6 +159,8 @@ public class BulkSparkConf implements Serializable
         // else fall back to props, and then default if neither specified
         this.useOpenSsl = getBoolean(USE_OPENSSL, true);
         this.ringRetryCount = getInt(RING_RETRY_COUNT, DEFAULT_RING_RETRY_COUNT);
+        this.ttl = MapUtils.getOrDefault(options, WriterOptions.TTL.name(), null);
+        this.timestamp = MapUtils.getOrDefault(options, WriterOptions.TIMESTAMP.name(), null);
         validateEnvironment();
     }
 
@@ -239,6 +243,16 @@ public class BulkSparkConf implements Serializable
     protected String getTrustStorePath()
     {
         return truststorePath;
+    }
+
+    protected TTLOption getTTLOptions()
+    {
+        return TTLOption.from(ttl);
+    }
+
+    protected TimestampOption getTimestampOptions()
+    {
+        return TimestampOption.from(timestamp);
     }
 
     protected String getTruststoreBase64Encoded()

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/CassandraBulkSourceRelation.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/CassandraBulkSourceRelation.java
@@ -169,6 +169,8 @@ public class CassandraBulkSourceRelation extends BaseRelation implements Inserta
         }
     }
 
+    // Made this function static to avoid capturing reference to CassandraBulkSourceRelation object which cannot be
+    // serialized.
     private static VoidFunction<Iterator<Tuple2<DecoratedKey, Object[]>>> writeRowsInPartition(Broadcast<BulkWriterContext> broadcastContext,
                                                                                                String[] columnNames)
     {

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/CassandraBulkWriterContext.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/CassandraBulkWriterContext.java
@@ -91,7 +91,7 @@ public class CassandraBulkWriterContext implements BulkWriterContext, KryoSerial
         CqlTable cqlTable = bridge.buildSchema(tableSchema, keyspace, replicationFactor, partitioner, udts, null, indexCount);
 
         TableInfoProvider tableInfoProvider = new CqlTableInfoProvider(tableSchema, cqlTable);
-        schemaInfo = new CassandraSchemaInfo(new TableSchema(dfSchema, tableInfoProvider, conf.writeMode));
+        schemaInfo = new CassandraSchemaInfo(new TableSchema(dfSchema, tableInfoProvider, conf.writeMode, conf.getTTLOptions(), conf.getTimestampOptions()));
     }
 
     public static BulkWriterContext fromOptions(@NotNull SparkContext sparkContext,

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/SSTableWriter.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/SSTableWriter.java
@@ -91,15 +91,14 @@ public class SSTableWriter
         return CASSANDRA_VERSION_PREFIX + lowestCassandraVersion;
     }
 
-    public void addRow(BigInteger token, Object[] values) throws IOException
+    public void addRow(BigInteger token, Map<String, Object> boundValues) throws IOException
     {
         if (minToken == null)
         {
             minToken = token;
         }
         maxToken = token;
-
-        cqlSSTableWriter.addRow(values);
+        cqlSSTableWriter.addRow(boundValues);
     }
 
     public void close(BulkWriterContext writerContext, int partitionId) throws IOException

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/SqlToCqlTypeConverter.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/SqlToCqlTypeConverter.java
@@ -171,6 +171,16 @@ public final class SqlToCqlTypeConverter implements Serializable
         }
     }
 
+    public static Converter<?> getIntegerConverter()
+    {
+        return INTEGER_CONVERTER;
+    }
+
+    public static Converter<?> getLongConverter()
+    {
+        return LONG_CONVERTER;
+    }
+
     private static Converter<?> determineCustomConvert(CqlField.CqlCustom customType)
     {
         Preconditions.checkArgument(customType.name().equalsIgnoreCase(CUSTOM), "Non-custom types are not supported");

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/TTLOption.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/TTLOption.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cassandra.spark.bulkwriter;
+
+
+import java.io.Serializable;
+import java.time.Duration;
+
+public final class TTLOption implements Serializable
+{
+    private static final TTLOption FOREVER = new TTLOption(0);
+    private final String ttlColumnName;
+    private final Integer ttlInSeconds;
+
+    private TTLOption(String ttlColumnName)
+    {
+        this.ttlColumnName = ttlColumnName;
+        this.ttlInSeconds = null;
+    }
+
+    private TTLOption(int ttlInSeconds)
+    {
+        this.ttlInSeconds = ttlInSeconds;
+        this.ttlColumnName = null;
+    }
+
+    public static TTLOption from(String ttl)
+    {
+        if (ttl == null)
+        {
+            return FOREVER;
+        }
+        try
+        {
+            return new TTLOption(Integer.parseInt(ttl));
+        }
+        catch (Exception e)
+        {
+
+            return new TTLOption(ttl);
+        }
+    }
+
+    /**
+     * TTL option for write with a constant TTL. When same values for TTL should be used for all rows in a bulk write
+     * call use this option.
+     *
+     * @param ttlInSeconds ttl value in seconds
+     * @return TTLOption
+     */
+    public static String constant(int ttlInSeconds)
+    {
+        return String.valueOf(ttlInSeconds);
+    }
+
+    /**
+     * TTL option for write with a constant TTL. When same values for TTL should be used for all rows in a bulk write
+     * call use this option.
+     *
+     * @param duration ttl value in Duration
+     * @return TTLOption
+     */
+    public static String constant(Duration duration)
+    {
+        return String.valueOf(duration.getSeconds());
+    }
+
+    /**
+     * TTL option for writes with TTL per Row. When different TTL has to be used for different rows in a bulk write
+     * call use this option. The RDD should have additional column with TTL values in seconds for each row.
+     *
+     * @param ttlColumnName column name which has TTL values for each row
+     * @return TTLOption
+     */
+    public static String perRow(String ttlColumnName)
+    {
+        return ttlColumnName;
+    }
+
+    public static TTLOption forever()
+    {
+        return FOREVER;
+    }
+
+    public String columnName()
+    {
+        return ttlColumnName;
+    }
+
+    public boolean withTTl()
+    {
+        return !this.equals(FOREVER)
+                && (ttlColumnName != null || ttlInSeconds != null);
+    }
+
+    @Override
+    public String toString()
+    {
+        if (ttlColumnName != null && !ttlColumnName.isEmpty())
+        {
+            return ":" + ttlColumnName;
+        }
+        if (ttlInSeconds != null)
+        {
+            return Integer.toString(ttlInSeconds);
+        }
+        return null;
+    }
+}

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/TTLOption.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/TTLOption.java
@@ -84,7 +84,8 @@ public final class TTLOption implements Serializable
 
     /**
      * TTL option for writes with TTL per Row. When different TTL has to be used for different rows in a bulk write
-     * call use this option. The RDD should have additional column with TTL values in seconds for each row.
+     * call use this option. It expects the input RDD to supply the TTL values as an additional column at each row of
+     * the RDD. The TTL value provider column is selected by {@param ttlColumnName}
      *
      * @param ttlColumnName column name which has TTL values for each row
      * @return TTLOption

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/TTLOption.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/TTLOption.java
@@ -85,7 +85,7 @@ public final class TTLOption implements Serializable
     /**
      * TTL option for writes with TTL per Row. When different TTL has to be used for different rows in a bulk write
      * call use this option. It expects the input RDD to supply the TTL values as an additional column at each row of
-     * the RDD. The TTL value provider column is selected by {@param ttlColumnName}
+     * the RDD. The TTL value provider column is selected by {@code  ttlColumnName}
      *
      * @param ttlColumnName column name which has TTL values for each row
      * @return TTLOption

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/TimestampOption.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/TimestampOption.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cassandra.spark.bulkwriter;
+
+import java.io.Serializable;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+
+public final class TimestampOption implements Serializable
+{
+    private static final TimestampOption NOW = new TimestampOption(System.nanoTime() / 1000);
+    private String timestampColumnName;
+    private Long timeStampInMicroSeconds;
+
+    private TimestampOption(String timestampColumnName)
+    {
+        this.timestampColumnName = timestampColumnName;
+    }
+
+    private TimestampOption(Long timeStampInMicroSeconds)
+    {
+        this.timeStampInMicroSeconds = timeStampInMicroSeconds;
+    }
+
+    public static TimestampOption from(String timestamp)
+    {
+        if (timestamp == null)
+        {
+            return NOW;
+        }
+        try
+        {
+            return new TimestampOption(Long.parseLong(timestamp));
+        }
+        catch (Exception e)
+        {
+
+            return new TimestampOption(timestamp);
+        }
+    }
+
+    /**
+     * Timestamp option for write with a constant timestamp. When same values for timestamp should be used for all rows in
+     * a bulk write call use this option.
+     *
+     * @param timestampInMicroSeconds timestamp value in microseconds
+     * @return timestamp option
+     */
+    public static String constant(long timestampInMicroSeconds)
+    {
+        return String.valueOf(timestampInMicroSeconds);
+    }
+
+    /**
+     * Timestamp option for write with a constant timestamp. When same values for timestamp should be used for all rows in
+     * a bulk write call use this option.
+     *
+     * @param duration timestamp value in Duration
+     * @return timestamp option
+     */
+    public static String constant(Duration duration)
+    {
+        return String.valueOf(duration.get(ChronoUnit.MICROS));
+    }
+
+    /**
+     * Timestamp option for writes with timestamp per Row. When different timestamp has to be used for different rows in
+     * a bulk write call use this option. The RDD should have additional column with timestamp values in microseconds
+     * for each row.
+     *
+     * @param timeStampColumnName column name which has timestamp values for each row
+     * @return timestamp option
+     */
+    public static String perRow(String timeStampColumnName)
+    {
+        return timeStampColumnName;
+    }
+
+    public static TimestampOption now()
+    {
+        return NOW;
+    }
+
+    public String columnName()
+    {
+        return timestampColumnName;
+    }
+
+    public boolean withTimestamp()
+    {
+        return !this.equals(NOW)
+                && (timestampColumnName != null || timeStampInMicroSeconds != null);
+    }
+
+    @Override
+    public String toString()
+    {
+        if (timestampColumnName != null && !timestampColumnName.isEmpty())
+        {
+            return ":" + timestampColumnName;
+        }
+        if (timeStampInMicroSeconds != null)
+        {
+            return Long.toString(timeStampInMicroSeconds);
+        }
+        return null;
+    }
+}

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/TimestampOption.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/TimestampOption.java
@@ -25,7 +25,7 @@ import java.time.temporal.ChronoUnit;
 
 public final class TimestampOption implements Serializable
 {
-    private static final TimestampOption NOW = new TimestampOption(System.nanoTime() / 1000);
+    private static final TimestampOption NOW = new TimestampOption(System.currentTimeMillis() * 1000);
     private String timestampColumnName;
     private Long timeStampInMicroSeconds;
 
@@ -82,8 +82,8 @@ public final class TimestampOption implements Serializable
 
     /**
      * Timestamp option for writes with timestamp per Row. When different timestamp has to be used for different rows in
-     * a bulk write call use this option. The RDD should have additional column with timestamp values in microseconds
-     * for each row.
+     * a bulk write call use this option. It expects the input RDD to supply the timestamp values as an additional
+     * column at each row of the RDD. The timestamp value provider column is selected by {@param timeStampColumnName}
      *
      * @param timeStampColumnName column name which has timestamp values for each row
      * @return timestamp option

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/TimestampOption.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/TimestampOption.java
@@ -83,7 +83,7 @@ public final class TimestampOption implements Serializable
     /**
      * Timestamp option for writes with timestamp per Row. When different timestamp has to be used for different rows in
      * a bulk write call use this option. It expects the input RDD to supply the timestamp values as an additional
-     * column at each row of the RDD. The timestamp value provider column is selected by {@param timeStampColumnName}
+     * column at each row of the RDD. The timestamp value provider column is selected by {@code  timeStampColumnName}
      *
      * @param timeStampColumnName column name which has timestamp values for each row
      * @return timestamp option

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/WriterOptions.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/WriterOptions.java
@@ -43,5 +43,7 @@ public enum WriterOptions implements WriterOption
     TRUSTSTORE_BASE64_ENCODED,
     SIDECAR_PORT,
     ROW_BUFFER_MODE,
-    SSTABLE_DATA_SIZE_IN_MB
+    SSTABLE_DATA_SIZE_IN_MB,
+    TTL,
+    TIMESTAMP
 }

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/MockBulkWriterContext.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/MockBulkWriterContext.java
@@ -85,6 +85,7 @@ public class MockBulkWriterContext implements BulkWriterContext, ClusterInfo, Jo
     private CommitResultSupplier crSupplier = (uuids, dc) -> new RemoteCommitResult(true, Collections.emptyList(), uuids, null);
 
     private Predicate<CassandraInstance> uploadRequestConsumer = instance -> true;
+    private TTLOption ttlOption = TTLOption.forever();
 
     public MockBulkWriterContext(CassandraRing<RingInstance> ring,
                                  String cassandraVersion,
@@ -111,6 +112,7 @@ public class MockBulkWriterContext implements BulkWriterContext, ClusterInfo, Jo
                       .withPartitionKeyColumnTypes(partitionKeyColumnTypes)
                       .withWriteMode(WriteMode.INSERT)
                       .withDataFrameSchema(validDataFrameSchema)
+                      .withTTLSetting(ttlOption)
                       .build();
         this.jobId = java.util.UUID.randomUUID();
     }

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/MockTableWriter.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/MockTableWriter.java
@@ -24,6 +24,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Map;
 
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.commons.io.FileUtils;
@@ -64,13 +65,13 @@ public class MockTableWriter implements SSTableWriter
     }
 
     @Override
-    public void addRow(Object... values)
+    public void addRow(Map<String, Object> values) throws IOException
     {
         if (addRowThrows)
         {
             throw new RuntimeException("Failed to write because addRow throws");
         }
-        rows.add(values);
+        rows.add(values.values().toArray());
     }
 
     @Override

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/SSTableWriterTest.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/SSTableWriterTest.java
@@ -27,6 +27,7 @@ import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
+import com.google.common.collect.ImmutableMap;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Rule;
@@ -90,7 +91,7 @@ public class SSTableWriterTest
     {
         MockBulkWriterContext writerContext = new MockBulkWriterContext(ring, version, ConsistencyLevel.CL.LOCAL_QUORUM);
         SSTableWriter tw = new SSTableWriter(writerContext, tmpDir.getRoot().toPath());
-        tw.addRow(BigInteger.ONE, new Object[]{1, 1, "foo", 1});
+        tw.addRow(BigInteger.ONE, ImmutableMap.of("id", 1, "date", 1, "course", "foo", "marks", 1));
         tw.close(writerContext, 1);
         try (DirectoryStream<Path> dataFileStream = Files.newDirectoryStream(tw.getOutDir(), "*Data.db"))
         {

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/StreamSessionConsistencyTest.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/StreamSessionConsistencyTest.java
@@ -24,6 +24,7 @@ import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
@@ -67,6 +68,7 @@ public class StreamSessionConsistencyTest
                                                                                 ImmutableMap.of("DC1", 3, "DC2", 3),
                                                                                 "test",
                                                                                 6);
+    private static final Map<String, Object> COLUMN_BIND_VALUES = ImmutableMap.of("id", 0, "date", 1, "course", "course", "marks", 2);
 
     @Rule
     public TemporaryFolder folder = new TemporaryFolder();
@@ -119,8 +121,7 @@ public class StreamSessionConsistencyTest
             }
         });
         SSTableWriter tr = new NonValidatingTestSSTableWriter(tableWriter, folder.getRoot().toPath());
-        Object[] row = {0, 1, "course", 2};
-        tr.addRow(BigInteger.valueOf(102L), row);
+        tr.addRow(BigInteger.valueOf(102L), COLUMN_BIND_VALUES);
         tr.close(writerContext, 1);
         streamSession.scheduleStream(tr);
         if (shouldFail)
@@ -157,8 +158,7 @@ public class StreamSessionConsistencyTest
         boolean shouldFail = calculateFailure(dc1Failures.get(), dc2Failures.get());
         writerContext.setUploadSupplier(instance -> dcFailures.get(instance.getDataCenter()).getAndDecrement() <= 0);
         SSTableWriter tr = new NonValidatingTestSSTableWriter(tableWriter, folder.getRoot().toPath());
-        Object[] row = {0, 1, "course", 2};
-        tr.addRow(BigInteger.valueOf(102L), row);
+        tr.addRow(BigInteger.valueOf(102L), COLUMN_BIND_VALUES);
         tr.close(writerContext, 1);
         streamSession.scheduleStream(tr);
         if (shouldFail)

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/StreamSessionTest.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/StreamSessionTest.java
@@ -23,11 +23,13 @@ import java.io.IOException;
 import java.math.BigInteger;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
 import com.google.common.collect.BoundType;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Range;
 import org.junit.Before;
@@ -52,6 +54,7 @@ import static org.junit.Assert.assertTrue;
 public class StreamSessionTest
 {
     public static final String LOAD_RANGE_ERROR_PREFIX = "Failed to load 1 ranges with LOCAL_QUORUM";
+    private static final Map<String, Object> COLUMN_BOUND_VALUES = ImmutableMap.of("id", 0, "date", 1, "course", "course", "marks", 2);
     @Rule
     public TemporaryFolder folder = new TemporaryFolder();
     private static final int FILES_PER_SSTABLE = 8;
@@ -90,8 +93,7 @@ public class StreamSessionTest
             ) throws IOException, ExecutionException, InterruptedException
     {
         SSTableWriter tr = new NonValidatingTestSSTableWriter(tableWriter, folder.getRoot().toPath());
-        Object[] row = {0, 1, "course", 2};
-        tr.addRow(BigInteger.valueOf(102L), row);
+        tr.addRow(BigInteger.valueOf(102L), COLUMN_BOUND_VALUES);
         tr.close(writerContext, 1);
         ss.scheduleStream(tr);
         ss.close();  // Force "execution" of futures
@@ -121,8 +123,7 @@ public class StreamSessionTest
     public void testMismatchedTokenRangeFails() throws IOException
     {
         SSTableWriter tr = new NonValidatingTestSSTableWriter(tableWriter, folder.getRoot().toPath());
-        Object[] row = {0, 1, "course", 2};
-        tr.addRow(BigInteger.valueOf(9999L), row);
+        tr.addRow(BigInteger.valueOf(9999L), COLUMN_BOUND_VALUES);
         tr.close(writerContext, 1);
         IllegalStateException illegalStateException = assertThrows(IllegalStateException.class,
                                                       () -> ss.scheduleStream(tr));
@@ -170,8 +171,7 @@ public class StreamSessionTest
     {
         assertThrows(RuntimeException.class, () -> {
             SSTableWriter tr = new NonValidatingTestSSTableWriter(tableWriter, tableWriter.getOutDir());
-            Object[] row = {0, 1, "course", 2};
-            tr.addRow(BigInteger.valueOf(102L), row);
+            tr.addRow(BigInteger.valueOf(102L), COLUMN_BOUND_VALUES);
             tr.close(writerContext, 1);
             tableWriter.removeOutDir();
             ss.scheduleStream(tr);
@@ -190,8 +190,7 @@ public class StreamSessionTest
         writerContext.setInstancesAreAvailable(false);
         ss = new StreamSession(writerContext, "sessionId", range, executor);
         SSTableWriter tr = new NonValidatingTestSSTableWriter(tableWriter, folder.getRoot().toPath());
-        Object[] row = {0, 1, "course", 2};
-        tr.addRow(BigInteger.valueOf(102L), row);
+        tr.addRow(BigInteger.valueOf(102L), COLUMN_BOUND_VALUES);
         tr.close(writerContext, 1);
         ss.scheduleStream(tr);
         assertThrows(LOAD_RANGE_ERROR_PREFIX, RuntimeException.class, () -> ss.close());
@@ -234,8 +233,7 @@ public class StreamSessionTest
             }
         });
         SSTableWriter tr = new NonValidatingTestSSTableWriter(tableWriter, folder.getRoot().toPath());
-        Object[] row = {0, 1, "course", 2};
-        tr.addRow(BigInteger.valueOf(102L), row);
+        tr.addRow(BigInteger.valueOf(102L), COLUMN_BOUND_VALUES);
         tr.close(writerContext, 1);
         ss.scheduleStream(tr);
         ss.close();  // Force "execution" of futures
@@ -267,8 +265,7 @@ public class StreamSessionTest
             }
         });
         SSTableWriter tr = new NonValidatingTestSSTableWriter(tableWriter, folder.getRoot().toPath());
-        Object[] row = {0, 1, "course", 2};
-        tr.addRow(BigInteger.valueOf(102L), row);
+        tr.addRow(BigInteger.valueOf(102L), COLUMN_BOUND_VALUES);
         tr.close(writerContext, 1);
         ss.scheduleStream(tr);
         RuntimeException exception = assertThrows(RuntimeException.class, () -> ss.close());  // Force "execution" of futures
@@ -289,8 +286,7 @@ public class StreamSessionTest
     {
         writerContext.setUploadSupplier(instance -> false);
         SSTableWriter tr = new NonValidatingTestSSTableWriter(tableWriter, folder.getRoot().toPath());
-        Object[] row = {0, 1, "course", 2};
-        tr.addRow(BigInteger.valueOf(102L), row);
+        tr.addRow(BigInteger.valueOf(102L), COLUMN_BOUND_VALUES);
         tr.close(writerContext, 1);
         ss.scheduleStream(tr);
         assertThrows(LOAD_RANGE_ERROR_PREFIX, RuntimeException.class, () -> ss.close());

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/TableSchemaTest.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/TableSchemaTest.java
@@ -72,7 +72,44 @@ public class TableSchemaTest
         TableSchema schema = getValidSchemaBuilder()
                 .build();
         assertThat(schema.modificationStatement,
-                   is(equalTo("INSERT INTO test.test (id,date,course,marks) VALUES (?,?,?,?);")));
+                   is(equalTo("INSERT INTO test.test (id,date,course,marks) VALUES (:id,:date,:course,:marks);")));
+    }
+
+    @Test
+    public void testInsertStatementWithConstantTTL()
+    {
+        TableSchema schema = getValidSchemaBuilder().withTTLSetting(TTLOption.from("1000")).build();
+        assertThat(schema.modificationStatement, is(equalTo("INSERT INTO test.test (id,date,course,marks) VALUES (:id,:date,:course,:marks) USING TTL 1000;")));
+    }
+
+    @Test
+    public void testInsertStatementWithTTLColumn()
+    {
+        TableSchema schema = getValidSchemaBuilder().withTTLSetting(TTLOption.from("ttl")).build();
+        assertThat(schema.modificationStatement, is(equalTo("INSERT INTO test.test (id,date,course,marks) VALUES (:id,:date,:course,:marks) USING TTL :ttl;")));
+    }
+
+    @Test
+    public void testInsertStatementWithConstantTimestamp()
+    {
+        TableSchema schema = getValidSchemaBuilder().withTimeStampSetting(TimestampOption.from("1000")).build();
+        String expectedQuery = "INSERT INTO test.test (id,date,course,marks) VALUES (:id,:date,:course,:marks) USING TIMESTAMP 1000;";
+        assertThat(schema.modificationStatement, is(equalTo(expectedQuery)));
+    }
+
+    @Test
+    public void testInsertStatementWithTimestampColumn()
+    {
+        TableSchema schema = getValidSchemaBuilder().withTimeStampSetting(TimestampOption.from("timestamp")).build();
+        String expectedQuery = "INSERT INTO test.test (id,date,course,marks) VALUES (:id,:date,:course,:marks) USING TIMESTAMP :timestamp;";
+        assertThat(schema.modificationStatement, is(equalTo(expectedQuery)));
+    }
+    @Test
+    public void testInsertStatementWithTTLAndTimestampColumn()
+    {
+        TableSchema schema = getValidSchemaBuilder().withTTLSetting(TTLOption.from("ttl")).withTimeStampSetting(TimestampOption.from("timestamp")).build();
+        String expectedQuery = "INSERT INTO test.test (id,date,course,marks) VALUES (:id,:date,:course,:marks) USING TIMESTAMP :timestamp AND TTL :ttl;";
+        assertThat(schema.modificationStatement, is(equalTo(expectedQuery)));
     }
 
     @Test

--- a/cassandra-bridge/src/main/java/org/apache/cassandra/bridge/SSTableWriter.java
+++ b/cassandra-bridge/src/main/java/org/apache/cassandra/bridge/SSTableWriter.java
@@ -21,8 +21,9 @@ package org.apache.cassandra.bridge;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.util.Map;
 
 public interface SSTableWriter extends Closeable
 {
-    void addRow(Object... values) throws IOException;
+    void addRow(Map<String, Object> values) throws IOException;
 }

--- a/cassandra-four-zero/src/main/java/org/apache/cassandra/bridge/SSTableWriterImplementation.java
+++ b/cassandra-four-zero/src/main/java/org/apache/cassandra/bridge/SSTableWriterImplementation.java
@@ -20,6 +20,7 @@
 package org.apache.cassandra.bridge;
 
 import java.io.IOException;
+import java.util.Map;
 
 import org.apache.cassandra.config.Config;
 import org.apache.cassandra.dht.IPartitioner;
@@ -62,7 +63,7 @@ public class SSTableWriterImplementation implements SSTableWriter
     }
 
     @Override
-    public void addRow(Object... values) throws IOException
+    public void addRow(Map<String, Object> values)  throws IOException
     {
         try
         {


### PR DESCRIPTION
This commit introduces a new feature in Spark Bulk Writer to support writes with constant/per_row based TTL & Timestamps.