### PR TITLE
CASSANDRA-18631: Add Release Audit Tool (RAT) plugin to Analytics

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,3 +1,21 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 github:
   enabled_merge_buttons:
     squash:  true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,10 @@ jobs:
             SCALA_VERSION: "2.11"
             JDK_VERSION: "1.8"
 
+      - store_artifacts:
+          path: build/reports
+          destination: test-reports
+
   cassandra-analytics-core-spark2-2_12-jdk8:
     docker:
       - image: cimg/openjdk:8.0
@@ -49,6 +53,10 @@ jobs:
             SPARK_VERSION: "2"
             SCALA_VERSION: "2.12"
             JDK_VERSION: "1.8"
+
+      - store_artifacts:
+          path: build/reports
+          destination: test-reports
 
   cassandra-analytics-core-spark3-2_12-jdk11:
     docker:
@@ -66,6 +74,10 @@ jobs:
             SCALA_VERSION: "2.12"
             JDK_VERSION: "11"
 
+      - store_artifacts:
+          path: build/reports
+          destination: test-reports
+
   cassandra-analytics-core-spark3-2_13-jdk11:
     docker:
       - image: cimg/openjdk:11.0
@@ -81,6 +93,10 @@ jobs:
             SPARK_VERSION: "3"
             SCALA_VERSION: "2.13"
             JDK_VERSION: "11"
+
+      - store_artifacts:
+          path: build/reports
+          destination: test-reports
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,10 +34,6 @@ jobs:
             SCALA_VERSION: "2.11"
             JDK_VERSION: "1.8"
 
-      - store_artifacts:
-          path: build/reports
-          destination: test-reports
-
   cassandra-analytics-core-spark2-2_12-jdk8:
     docker:
       - image: cimg/openjdk:8.0
@@ -53,10 +49,6 @@ jobs:
             SPARK_VERSION: "2"
             SCALA_VERSION: "2.12"
             JDK_VERSION: "1.8"
-
-      - store_artifacts:
-          path: build/reports
-          destination: test-reports
 
   cassandra-analytics-core-spark3-2_12-jdk11:
     docker:
@@ -74,10 +66,6 @@ jobs:
             SCALA_VERSION: "2.12"
             JDK_VERSION: "11"
 
-      - store_artifacts:
-          path: build/reports
-          destination: test-reports
-
   cassandra-analytics-core-spark3-2_13-jdk11:
     docker:
       - image: cimg/openjdk:11.0
@@ -93,10 +81,6 @@ jobs:
             SPARK_VERSION: "3"
             SCALA_VERSION: "2.13"
             JDK_VERSION: "11"
-
-      - store_artifacts:
-          path: build/reports
-          destination: test-reports
 
 workflows:
   version: 2

--- a/DEV-README.md
+++ b/DEV-README.md
@@ -1,3 +1,23 @@
+<!--
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+-->
+
 # Cassandra Analytics
 
 Cassandra Analytics supports Spark 2 (Scala 2.11 and 2.12) and Spark 3 (Scala 2.12).

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -200,3 +200,26 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
+
+   APACHE CASSANDRA SIDECAR SUBCOMPONENTS:
+
+   Apache Cassandra Sidecar includes a number of subcomponents with
+   separate copyright notices and license terms. Your use of the source
+   code for these subcomponents is subject to the terms and
+   conditions of the following licenses.
+
+   This product bundles a file (FastByteOperations.java) from Guava,
+   copyright The Guava Authors, which is available under an
+   Apache License version 2.
+
+   This product bundles a file (UUIDs.java) from Apache Cassandra,
+   copyright The Apache Cassandra Authors, which is available under an
+   Apache License version 2.
+
+   This product bundles a file (CommitLogReader.java) from Apache Cassandra,
+   copyright The Apache Cassandra Authors, which is available under an
+   Apache License version 2.
+
+   This product bundles a file (CommitLogSegmentReader.java) from Apache
+   Cassandra, copyright The Apache Cassandra Authors, which is available
+   under an Apache License version 2.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,23 @@
+<!--
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+-->
+
 # Cassandra Analytics 
 
 ## Cassandra Spark Bulk Reader

--- a/build.gradle
+++ b/build.gradle
@@ -87,6 +87,9 @@ rat {
   excludes.add("**/org.apache.spark.sql.sources.DataSourceRegister")
   excludes.add("**/resources/cassandra-analytics-build.properties")
 
+  // Sidecar for build process
+  excludes.add("**/cassandra-sidecar/**")
+
   // Documentation files
   excludes.add("**/docs/src/**")
   // gradle files

--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,10 @@ plugins {
   id("org.nosphere.apache.rat") version "0.8.0"
 }
 
+repositories {
+  mavenCentral()
+}
+
 ext.scalaLabel = System.getenv("SCALA_VERSION") ?: "${scala}"
 println("Scala version: ${ext.scalaLabel}")
 

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,9 @@ plugins {
   id 'java'
   id 'java-library'
   id 'com.github.johnrengelman.shadow' version '5.1.0'
+
+  // Release Audit Tool (RAT) plugin for checking project licenses
+  id("org.nosphere.apache.rat") version "0.8.0"
 }
 
 ext.scalaLabel = System.getenv("SCALA_VERSION") ?: "${scala}"
@@ -49,18 +52,61 @@ apply(from: profile)
 
 apply(plugin: 'idea')
 
-task copyCodeStyle(type: Copy) {
+tasks.register('copyCodeStyle', Copy) {
   from('ide/idea/codeStyleSettings.xml')
   into('.idea')
 }
 
 tasks.idea.dependsOn(tasks.copyCodeStyle)
 
-task copyInspections(type: Copy) {
+tasks.register('copyInspections', Copy) {
   from('ide/idea/Project_Default.xml')
   into('.idea/inspectionProfiles')
 }
 tasks.idea.dependsOn(tasks.copyInspections)
+
+tasks.register('buildIgnoreRatList', Exec) {
+  description 'Builds a list of ignored files for the rat task from the unversioned git files'
+  commandLine 'bash', '-c', 'git clean --force --dry-run -x | cut -c 14-'
+  doFirst {
+    standardOutput new FileOutputStream("${buildDir}/.rat-excludes.txt")
+  }
+  // allows task to fail when git/cut commands are unavailable or fail
+  ignoreExitValue = true
+}
+
+rat {
+  // List of Gradle exclude directives, defaults to ['**/.gradle/**']
+  excludes.add("**/build/**")
+  excludes.add("**/.out/**")
+  excludes.add("CHANGES.txt")
+  excludes.add("**/org.apache.spark.sql.sources.DataSourceRegister")
+  excludes.add("**/resources/cassandra-analytics-build.properties")
+
+  // Documentation files
+  excludes.add("**/docs/src/**")
+  // gradle files
+  excludes.add("gradle/**")
+  excludes.add("gradlew")
+  excludes.add("gradlew.bat")
+
+  // idea generated files
+  excludes.add("**/.idea/**")
+
+  // resource files for test
+  excludes.add("**/test**/resources/**")
+
+  // resources
+  excludes.add("**/resources/sidecar.version")
+
+  // Rat excludes file, one directive per line
+  excludeFile.set(layout.projectDirectory.file("build/.rat-excludes.txt"))
+
+  // XML, TXT and HTML reports directory, defaults to 'build/reports/rat'
+  reportDir.set(file("build/reports/rat"))
+}
+
+rat.dependsOn buildIgnoreRatList
 
 subprojects {
   apply(plugin: 'java-library')

--- a/build.gradle
+++ b/build.gradle
@@ -71,7 +71,7 @@ tasks.idea.dependsOn(tasks.copyInspections)
 
 tasks.register('buildIgnoreRatList', Exec) {
   description 'Builds a list of ignored files for the rat task from the unversioned git files'
-  commandLine 'bash', '-c', 'git clean --force --dry-run -x | cut -c 14-'
+  commandLine 'bash', '-c', 'git clean --force -d --dry-run -x | cut -c 14-'
   doFirst {
     standardOutput new FileOutputStream("${buildDir}/.rat-excludes.txt")
   }

--- a/cassandra-analytics-core-example/README.md
+++ b/cassandra-analytics-core-example/README.md
@@ -1,3 +1,23 @@
+<!--
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+-->
+
 # Sample Cassandra Data with Spark Bulk Analytics Job
 
 This sub-project showcases the Cassandra Spark Bulk Analytics read and write functionality. The job writes data to a

--- a/cassandra-analytics-core/build.gradle
+++ b/cassandra-analytics-core/build.gradle
@@ -65,8 +65,7 @@ project(':cassandra-analytics-core') {
             exclude(group: 'com.fasterxml.jackson.core', module: 'jackson-annotations') // use provided annotations from spark
         }
 
-        if ("${scalaMajorVersion}" == "2.11")
-        {
+        if ("${scalaMajorVersion}" == "2.11") {
             implementation(group: 'org.scala-lang.modules', name: "scala-java8-compat_2.11", version: '1.0.1', transitive: false)
         }
 

--- a/cassandra-bridge/src/main/java/org/apache/cassandra/spark/utils/streaming/SSTableInputStream.java
+++ b/cassandra-bridge/src/main/java/org/apache/cassandra/spark/utils/streaming/SSTableInputStream.java
@@ -367,20 +367,20 @@ public class SSTableInputStream<T extends SSTable> extends InputStream implement
         }
     }
 
-    // Copied from JDK11 jdk.internal.util.Preconditions.checkFromIndexSize()
-    private static <X extends RuntimeException> void checkFromIndexSize(int fromIndex, int size, int length)
+    public static void ensureOffsetWithinBounds(int offset, int length, int bufferLength)
     {
-        if ((length | fromIndex | size) < 0 || size > length - fromIndex)
+        if (offset < 0 || length < 0 || bufferLength < 0 || (length + offset) > bufferLength)
         {
-            throw new IndexOutOfBoundsException(String.format("Index out of bounds fromIndex=%d, size=%d, length=%d",
-                                                              fromIndex, size, length));
+            throw new IndexOutOfBoundsException(String.format("Out of bounds, offset=%d, length=%d, bufferLength=%d",
+                                                              offset, length, bufferLength));
         }
     }
 
     @Override
     public int read(byte[] buffer, int offset, int length) throws IOException
     {
-        SSTableInputStream.checkFromIndexSize(offset, length, buffer.length);
+        // Objects.checkFromIndexSize is not available in Java 1.8, so we provide our own implementation
+        ensureOffsetWithinBounds(offset, length, buffer.length);
         if (length == 0)
         {
             return 0;

--- a/cassandra-three-zero/TODO.md
+++ b/cassandra-three-zero/TODO.md
@@ -1,3 +1,23 @@
+<!--
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+-->
+
 ### Note
 
 Cassandra Bridge implementation for Cassandra-all of version 3.0 is done and mostly working.

--- a/githooks/pre-push
+++ b/githooks/pre-push
@@ -1,4 +1,22 @@
 #!/usr/bin/env bash
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 set -e
 
 PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"


### PR DESCRIPTION
This commit adds the Release Audit Tool (RAT) plugin to `build.gradle` which adds a new task `rat`. This new task makes sure that the license headers are valid and present in the source files during the `check` task.

To run the RAT plugin, you can run:

```
./gradlew rat
```