### PR TITLE
[CASSANDRA-18684] Minor Refactoring to Improve Code Reusability

### DIFF
--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/CassandraClusterInfo.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/CassandraClusterInfo.java
@@ -344,14 +344,8 @@ public class CassandraClusterInfo implements ClusterInfo, Closeable
         return null;
     }
 
-    public String getVersionFromSidecar()
+    protected List<NodeSettings> getAllNodeSettings()
     {
-        NodeSettings nodeSettings = this.nodeSettings.get();
-        if (nodeSettings != null)
-        {
-            return nodeSettings.releaseVersion();
-        }
-
         List<NodeSettings> allNodeSettings = FutureUtils.bestEffortGet(allNodeSettingFutures,
                                                                        conf.getSidecarRequestMaxRetryDelayInSeconds(),
                                                                        TimeUnit.SECONDS);
@@ -367,7 +361,18 @@ public class CassandraClusterInfo implements ClusterInfo, Closeable
                         allNodeSettings.size(), allNodeSettingFutures.size());
         }
 
-        return getLowestVersion(allNodeSettings);
+        return allNodeSettings;
+    }
+
+    public String getVersionFromSidecar()
+    {
+        NodeSettings nodeSettings = this.nodeSettings.get();
+        if (nodeSettings != null)
+        {
+            return nodeSettings.releaseVersion();
+        }
+
+        return getLowestVersion(getAllNodeSettings());
     }
 
     protected RingResponse getRingResponse()


### PR DESCRIPTION
A very minor refactoring is needed in the `CassandraClusterInfo` class to enable reuse of the code block handling retrieval of all `NodeSettings`.