### PR TITLE
CASSANDRA-18692 Fix bulk writes with Buffered RowBufferMode

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,16 +20,10 @@
 import java.nio.file.Files
 import java.nio.file.Paths
 
-buildscript {
-  dependencies {
-    classpath(group: 'com.github.jengelman.gradle.plugins', name: 'shadow', version: '6.1.0')
-  }
-}
-
 plugins {
   id 'java'
   id 'java-library'
-  id 'com.github.johnrengelman.shadow' version '5.1.0'
+  id 'com.github.johnrengelman.shadow' version '7.1.2'
 
   // Release Audit Tool (RAT) plugin for checking project licenses
   id("org.nosphere.apache.rat") version "0.8.0"

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/BulkSparkConf.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/BulkSparkConf.java
@@ -37,6 +37,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.cassandra.bridge.CassandraBridgeFactory;
+import org.apache.cassandra.bridge.RowBufferMode;
 import org.apache.cassandra.clients.SidecarInstanceImpl;
 import org.apache.cassandra.sidecar.client.SidecarInstance;
 import org.apache.cassandra.spark.bulkwriter.token.ConsistencyLevel;

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/CassandraBulkWriterContext.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/CassandraBulkWriterContext.java
@@ -30,7 +30,6 @@ import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.KryoSerializable;
 import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
-import io.netty.channel.EventLoopGroup;
 import org.apache.cassandra.bridge.CassandraBridge;
 import org.apache.cassandra.bridge.CassandraBridgeFactory;
 import org.apache.cassandra.spark.bulkwriter.token.CassandraRing;
@@ -56,11 +55,6 @@ public class CassandraBulkWriterContext implements BulkWriterContext, KryoSerial
     private transient DataTransferApi dataTransferApi;
     private final CassandraClusterInfo clusterInfo;
     private final SchemaInfo schemaInfo;
-
-    static
-    {
-        configureRelocatedNetty();
-    }
 
     private CassandraBulkWriterContext(@NotNull BulkSparkConf conf,
                                        @NotNull StructType dfSchema,
@@ -116,15 +110,6 @@ public class CassandraBulkWriterContext implements BulkWriterContext, KryoSerial
             {
                 clusterInfo.close();
             }
-        }
-    }
-
-    // If using the shaded JAR, Configure our shaded Netty so it can find the correct native libraries
-    private static void configureRelocatedNetty()
-    {
-        if (EventLoopGroup.class.getName().startsWith("analytics"))
-        {
-            System.setProperty("analytics.io.netty.packagePrefix", "analytics");
         }
     }
 

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/CassandraJobInfo.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/CassandraJobInfo.java
@@ -21,6 +21,7 @@ package org.apache.cassandra.spark.bulkwriter;
 
 import java.util.UUID;
 
+import org.apache.cassandra.bridge.RowBufferMode;
 import org.apache.cassandra.spark.bulkwriter.token.ConsistencyLevel;
 import org.jetbrains.annotations.NotNull;
 
@@ -50,6 +51,7 @@ public class CassandraJobInfo implements JobInfo
         return conf.localDC;
     }
 
+    @NotNull
     @Override
     public RowBufferMode getRowBufferMode()
     {

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/JobInfo.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/JobInfo.java
@@ -22,7 +22,9 @@ package org.apache.cassandra.spark.bulkwriter;
 import java.io.Serializable;
 import java.util.UUID;
 
+import org.apache.cassandra.bridge.RowBufferMode;
 import org.apache.cassandra.spark.bulkwriter.token.ConsistencyLevel;
+import org.jetbrains.annotations.NotNull;
 
 public interface JobInfo extends Serializable
 {
@@ -31,6 +33,7 @@ public interface JobInfo extends Serializable
 
     String getLocalDC();
 
+    @NotNull
     RowBufferMode getRowBufferMode();
 
     int getSstableDataSizeInMB();

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/SSTableWriter.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/SSTableWriter.java
@@ -74,15 +74,14 @@ public class SSTableWriter
         LOGGER.info("Running with version " + packageVersion);
 
         TableSchema tableSchema = writerContext.schema().getTableSchema();
-        boolean sorted = writerContext.job().getRowBufferMode() == RowBufferMode.UNBUFFERED;
         this.cqlSSTableWriter = SSTableWriterFactory.getSSTableWriter(
-                CassandraVersionFeatures.cassandraVersionFeaturesFromCassandraVersion(packageVersion),
-                this.outDir.toString(),
-                writerContext.cluster().getPartitioner().toString(),
-                tableSchema.createStatement,
-                tableSchema.modificationStatement,
-                sorted,
-                writerContext.job().getSstableDataSizeInMB());
+        CassandraVersionFeatures.cassandraVersionFeaturesFromCassandraVersion(packageVersion),
+        this.outDir.toString(),
+        writerContext.cluster().getPartitioner().toString(),
+        tableSchema.createStatement,
+        tableSchema.modificationStatement,
+        writerContext.job().getRowBufferMode(),
+        writerContext.job().getSstableDataSizeInMB());
     }
 
     @NotNull
@@ -151,9 +150,9 @@ public class SSTableWriter
     {
         Map<Path, MD5Hash> fileHashes = new HashMap<>();
         try (DirectoryStream<Path> filesToHash =
-                Files.newDirectoryStream(dataFile.getParent(), SSTables.getSSTableBaseName(dataFile) + "*"))
+             Files.newDirectoryStream(dataFile.getParent(), SSTables.getSSTableBaseName(dataFile) + "*"))
         {
-            for (Path path: filesToHash)
+            for (Path path : filesToHash)
             {
                 fileHashes.put(path, calculateFileHash(path));
             }

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/SSTableWriterFactory.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/SSTableWriterFactory.java
@@ -22,6 +22,7 @@ package org.apache.cassandra.spark.bulkwriter;
 import org.apache.cassandra.bridge.CassandraBridge;
 import org.apache.cassandra.bridge.CassandraBridgeFactory;
 import org.apache.cassandra.bridge.CassandraVersionFeatures;
+import org.apache.cassandra.bridge.RowBufferMode;
 import org.apache.cassandra.bridge.SSTableWriter;
 
 public final class SSTableWriterFactory
@@ -36,7 +37,7 @@ public final class SSTableWriterFactory
                                                  String partitioner,
                                                  String createStatement,
                                                  String insertStatement,
-                                                 boolean sorted,
+                                                 RowBufferMode rowBufferMode,
                                                  int bufferSizeMB)
     {
         CassandraBridge cassandraBridge = CassandraBridgeFactory.get(serverVersion);
@@ -44,7 +45,7 @@ public final class SSTableWriterFactory
                                                 partitioner,
                                                 createStatement,
                                                 insertStatement,
-                                                sorted,
+                                                rowBufferMode,
                                                 bufferSizeMB);
     }
 }

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/data/CassandraDataLayer.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/data/CassandraDataLayer.java
@@ -633,6 +633,7 @@ public class CassandraDataLayer extends PartitionedDataLayer implements Serializ
     {
         Collection<CassandraInstance> instances = ring
                                                   .stream()
+                                                  .filter(status -> datacenter == null || datacenter.equalsIgnoreCase(status.datacenter()))
                                                   .map(status -> new CassandraInstance(status.token(), status.fqdn(), status.datacenter()))
                                                   .collect(Collectors.toList());
         return new CassandraRing(partitioner, keyspace, replicationFactor, instances);

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/clients/SidecarNativeLibrariesTest.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/clients/SidecarNativeLibrariesTest.java
@@ -17,10 +17,24 @@
  * under the License.
  */
 
-package org.apache.cassandra.spark.bulkwriter;
+package org.apache.cassandra.clients;
 
-public enum RowBufferMode
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import o.a.c.sidecar.client.shaded.io.vertx.core.net.OpenSSLEngineOptions;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests to ensure that Sidecar client native libraries are loaded correctly
+ */
+public class SidecarNativeLibrariesTest
 {
-    BUFFERED,
-    UNBUFFERED
+    @DisplayName("Ensures that the shading is correct for the vertx-client-shaded project")
+    @Test
+    void openSslIsAvailable()
+    {
+        assertTrue(OpenSSLEngineOptions.isAvailable());
+    }
 }

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/BulkSparkConfTest.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/BulkSparkConfTest.java
@@ -28,6 +28,7 @@ import com.google.common.collect.Maps;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import org.apache.cassandra.bridge.RowBufferMode;
 import org.apache.cassandra.spark.bulkwriter.util.SbwKryoRegistrator;
 import org.apache.cassandra.spark.utils.BuildInfo;
 import org.apache.spark.SparkConf;
@@ -237,7 +238,7 @@ public class BulkSparkConfTest
         options.put(WriterOptions.ROW_BUFFER_MODE.name(), "invalid");
         IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
                                                           () -> new BulkSparkConf(sparkConf, options));
-        assertEquals("Key row buffering mode with value invalid is not a valid Enum of type class org.apache.cassandra.spark.bulkwriter.RowBufferMode.",
+        assertEquals("Key row buffering mode with value invalid is not a valid Enum of type class org.apache.cassandra.bridge.RowBufferMode.",
                      exception.getMessage());
     }
 

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/CassandraRingMonitorTest.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/CassandraRingMonitorTest.java
@@ -132,6 +132,6 @@ public class CassandraRingMonitorTest
 
     private CassandraRing<RingInstance> buildRing(int initialToken)
     {
-        return RingUtils.buildRing(initialToken, "dev3", "dev3", "DEV", "test", 3);
+        return RingUtils.buildRing(initialToken, "DEV", "test", 3);
     }
 }

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/NonValidatingTestSSTableWriter.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/NonValidatingTestSSTableWriter.java
@@ -21,6 +21,8 @@ package org.apache.cassandra.spark.bulkwriter;
 
 import java.nio.file.Path;
 
+import org.jetbrains.annotations.NotNull;
+
 class NonValidatingTestSSTableWriter extends SSTableWriter
 {
     NonValidatingTestSSTableWriter(MockTableWriter tableWriter, Path path)
@@ -29,7 +31,7 @@ class NonValidatingTestSSTableWriter extends SSTableWriter
     }
 
     @Override
-    public void validateSSTables(BulkWriterContext writerContext, int partitionId)
+    public void validateSSTables(@NotNull BulkWriterContext writerContext, int partitionId)
     {
         // Skip validation for these tests
     }

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/RingUtils.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/RingUtils.java
@@ -40,30 +40,24 @@ public final class RingUtils
 
     @NotNull
     static CassandraRing<RingInstance> buildRing(int initialToken,
-                                                 String app,
-                                                 String cluster,
                                                  String dataCenter,
                                                  String keyspace)
     {
-        return buildRing(initialToken, app, cluster, dataCenter, keyspace, 3);
+        return buildRing(initialToken, dataCenter, keyspace, 3);
     }
 
     @NotNull
     public static CassandraRing<RingInstance> buildRing(int initialToken,
-                                                        String app,
-                                                        String cluster,
                                                         String dataCenter,
                                                         String keyspace,
                                                         int instancesPerDC)
     {
         ImmutableMap<String, Integer> rfByDC = ImmutableMap.of(dataCenter, 3);
-        return buildRing(initialToken, app, cluster, rfByDC, keyspace, instancesPerDC);
+        return buildRing(initialToken, rfByDC, keyspace, instancesPerDC);
     }
 
     @NotNull
     static CassandraRing<RingInstance> buildRing(int initialToken,
-                                                 String app,
-                                                 String cluster,
                                                  ImmutableMap<String, Integer> rfByDC,
                                                  String keyspace,
                                                  int instancesPerDC)
@@ -77,7 +71,7 @@ public final class RingUtils
     private static ReplicationFactor getReplicationFactor(Map<String, Integer> rfByDC)
     {
         ImmutableMap.Builder<String, String> optionsBuilder = ImmutableMap.<String, String>builder()
-                .put("class", "org.apache.cassandra.locator.NetworkTopologyStrategy");
+                                                                          .put("class", "org.apache.cassandra.locator.NetworkTopologyStrategy");
         rfByDC.forEach((key, value) -> optionsBuilder.put(key, value.toString()));
         return new ReplicationFactor(optionsBuilder.build());
     }
@@ -93,17 +87,17 @@ public final class RingUtils
             for (int instance = 0; instance < instancesPerDc; instance++)
             {
                 instances.add(new RingInstance(new RingEntry.Builder()
-                        .address("127.0." + dcOffset + "." + instance)
-                        .datacenter(datacenter)
-                        .load("0")
-                        .token(Integer.toString(initialToken + dcOffset + 100_000 * instance))
-                        .fqdn(datacenter + "-i" + instance)
-                        .rack("Rack")
-                        .hostId("")
-                        .status("UP")
-                        .state("NORMAL")
-                        .owns("")
-                        .build()));
+                                               .address("127.0." + dcOffset + "." + instance)
+                                               .datacenter(datacenter)
+                                               .load("0")
+                                               .token(Integer.toString(initialToken + dcOffset + 100_000 * instance))
+                                               .fqdn(datacenter + "-i" + instance)
+                                               .rack("Rack")
+                                               .hostId("")
+                                               .status("UP")
+                                               .state("NORMAL")
+                                               .owns("")
+                                               .build()));
             }
             dcOffset++;
         }

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/SSTableWriterTest.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/SSTableWriterTest.java
@@ -74,7 +74,7 @@ public class SSTableWriterTest
     }
 
     @NotNull
-    public CassandraRing<RingInstance> ring = RingUtils.buildRing(0, "app", "cluster", "DC1", "test", 12);  // CHECKSTYLE IGNORE: Public mutable field
+    public CassandraRing<RingInstance> ring = RingUtils.buildRing(0, "DC1", "test", 12);  // CHECKSTYLE IGNORE: Public mutable field
 
     @TempDir
     public Path tmpDir; // CHECKSTYLE IGNORE: Public mutable field for testing
@@ -91,8 +91,8 @@ public class SSTableWriterTest
         try (DirectoryStream<Path> dataFileStream = Files.newDirectoryStream(tw.getOutDir(), "*Data.db"))
         {
             dataFileStream.forEach(dataFilePath ->
-                    assertEquals(CassandraVersionFeatures.cassandraVersionFeaturesFromCassandraVersion(version).getMajorVersion(),
-                                 SSTables.cassandraVersionFromTable(dataFilePath).getMajorVersion()));
+                                   assertEquals(CassandraVersionFeatures.cassandraVersionFeaturesFromCassandraVersion(version).getMajorVersion(),
+                                                SSTables.cassandraVersionFromTable(dataFilePath).getMajorVersion()));
         }
         tw.validateSSTables(writerContext, 1);
     }

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/StreamSessionConsistencyTest.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/StreamSessionConsistencyTest.java
@@ -60,8 +60,6 @@ public class StreamSessionConsistencyTest
     private static final Range<BigInteger> RANGE = Range.range(BigInteger.valueOf(101L), BoundType.CLOSED,
                                                                BigInteger.valueOf(199L), BoundType.CLOSED);
     private static final CassandraRing<RingInstance> RING = RingUtils.buildRing(0,
-                                                                                "app",
-                                                                                "cluster",
                                                                                 ImmutableMap.of("DC1", 3, "DC2", 3),
                                                                                 "test",
                                                                                 6);

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/StreamSessionTest.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/StreamSessionTest.java
@@ -72,7 +72,7 @@ public class StreamSessionTest
     public void setup()
     {
         range = Range.range(BigInteger.valueOf(101L), BoundType.CLOSED, BigInteger.valueOf(199L), BoundType.CLOSED);
-        ring = RingUtils.buildRing(0, "app", "cluster", "DC1", "test", 12);
+        ring = RingUtils.buildRing(0, "DC1", "test", 12);
         writerContext = getBulkWriterContext();
         tableWriter = new MockTableWriter(folder);
         executor = new MockScheduledExecutorService();

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/TokenPartitionerTest.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/TokenPartitionerTest.java
@@ -44,7 +44,7 @@ public class TokenPartitionerTest
     @Test
     public void testOneSplit()
     {
-        CassandraRing<RingInstance> ring = RingUtils.buildRing(0, "app", "cluster", "DC1", "test");
+        CassandraRing<RingInstance> ring = RingUtils.buildRing(0, "DC1", "test");
         partitioner = new TokenPartitioner(ring, 1, 2, 1, false);
         assertEquals(4, partitioner.numPartitions());
         assertEquals(0, getPartitionForToken(new BigInteger("-9223372036854775808")));
@@ -58,7 +58,7 @@ public class TokenPartitionerTest
     @Test
     public void testTwoSplits()
     {
-        CassandraRing<RingInstance> ring = RingUtils.buildRing(0, "app", "cluster", "DC1", "test");
+        CassandraRing<RingInstance> ring = RingUtils.buildRing(0, "DC1", "test");
         partitioner = new TokenPartitioner(ring, 2, 2, 1, false);
         assertEquals(10, partitioner.numPartitions());
         assertEquals(0, getPartitionForToken(new BigInteger("-4611686018427387905")));
@@ -90,7 +90,7 @@ public class TokenPartitionerTest
     @Test
     public void testReplicationFactorInOneDCOnly()
     {
-        CassandraRing<RingInstance> ring = RingUtils.buildRing(0, "app", "cluster", ImmutableMap.of("DC1", 3, "DC2", 0), "test", 3);
+        CassandraRing<RingInstance> ring = RingUtils.buildRing(0, ImmutableMap.of("DC1", 3, "DC2", 0), "test", 3);
         partitioner = new TokenPartitioner(ring, 1, 2, 1, false);
         assertEquals(4, partitioner.numPartitions());
         assertEquals(0, getPartitionForToken(new BigInteger("-9223372036854775808")));
@@ -104,7 +104,7 @@ public class TokenPartitionerTest
     @Test
     public void testSplitCalculationsUsingCores()
     {
-        CassandraRing<RingInstance> ring = RingUtils.buildRing(0, "app", "cluster", "DC1", "test");
+        CassandraRing<RingInstance> ring = RingUtils.buildRing(0, "DC1", "test");
         // When passed "-1" for numberSplits, the token partitioner should calculate it on its own based on
         // the number of cores. This ring has 4 ranges when no splits are used, therefore we expect the number
         // of splits to be 25 for 100 cores and a default parallelism of 50 (as we take the max of the two).
@@ -117,7 +117,7 @@ public class TokenPartitionerTest
     @Test
     public void testSplitCalculationsUsingDefaultParallelism()
     {
-        CassandraRing<RingInstance> ring = RingUtils.buildRing(0, "app", "cluster", "DC1", "test");
+        CassandraRing<RingInstance> ring = RingUtils.buildRing(0, "DC1", "test");
         // When passed "-1" for numberSplits, the token partitioner should calculate it on its own based on
         // the number of cores. This ring has 4 ranges when no splits are used, therefore we expect the number
         // of splits to be 50 for 100 cores and a default parallelism of 200 (as we take the max of the two).
@@ -136,7 +136,7 @@ public class TokenPartitionerTest
                                                                 .put("DC3", 3)
                                                                 .put("DC4", 3)
                                                                 .build();
-        CassandraRing<RingInstance> ring = RingUtils.buildRing(0, "app", "cluster", dcMap, "test", 20);
+        CassandraRing<RingInstance> ring = RingUtils.buildRing(0, dcMap, "test", 20);
         assertEquals(80, ring.getInstances().size());
         partitioner = new TokenPartitioner(ring, -1, 1, 750, false);
         assertEquals(10, partitioner.numSplits());

--- a/cassandra-bridge/src/main/java/org/apache/cassandra/bridge/CassandraBridge.java
+++ b/cassandra-bridge/src/main/java/org/apache/cassandra/bridge/CassandraBridge.java
@@ -385,7 +385,7 @@ public abstract class CassandraBridge
                                                    String partitioner,
                                                    String createStatement,
                                                    String insertStatement,
-                                                   boolean isSorted,
+                                                   RowBufferMode rowBufferMode,
                                                    int bufferSizeMB);
 
     // CDC Configuration

--- a/cassandra-bridge/src/main/java/org/apache/cassandra/bridge/RowBufferMode.java
+++ b/cassandra-bridge/src/main/java/org/apache/cassandra/bridge/RowBufferMode.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cassandra.bridge;
+
+/**
+ * Configures how data is flushed to an SSTable
+ */
+public enum RowBufferMode
+{
+    /**
+     * In this mode, Cassandra will flush an SSTable to disk once it reaches the configured BufferSizeInMB.
+     * This parameter is configured by the user-configurable SSTABLE_DATA_SIZE_IN_MB WriterOption. Note:
+     * This is the uncompressed size of data before being written to disk, and the actual size of an SSTable
+     * can be smaller based on the compression configuration for the SSTable and how compressible the data is.
+     */
+    BUFFERED,
+
+    /**
+     * Cassandra expects rows in sorted order and will not flush an SSTable automatically. The size of an
+     * SSTable is based on the number of rows we write to the SSTable. This parameter is configured by the
+     * user-configurable BATCH_SIZE WriterOption.
+     */
+    UNBUFFERED
+}

--- a/cassandra-four-zero/build.gradle
+++ b/cassandra-four-zero/build.gradle
@@ -77,9 +77,14 @@ project(':cassandra-four-zero') {
         exclude('com/google/common/collect/Range*')
     }
 
-    task javadocJar(type: Jar, dependsOn: javadoc) {
-      classifier = 'javadoc'
-      from javadoc.destinationDir
+    tasks.register('javadocJar', Jar) {
+        dependsOn javadoc
+        classifier = 'javadoc'
+        from javadoc.destinationDir
+    }
+
+    test {
+        useJUnitPlatform()
     }
 
     artifacts {

--- a/cassandra-four-zero/src/main/java/org/apache/cassandra/bridge/CassandraBridgeImplementation.java
+++ b/cassandra-four-zero/src/main/java/org/apache/cassandra/bridge/CassandraBridgeImplementation.java
@@ -623,10 +623,10 @@ public class CassandraBridgeImplementation extends CassandraBridge
                                           String partitioner,
                                           String createStatement,
                                           String insertStatement,
-                                          boolean isSorted,
+                                          RowBufferMode rowBufferMode,
                                           int bufferSizeMB)
     {
-        return new SSTableWriterImplementation(inDirectory, partitioner, createStatement, insertStatement, isSorted, bufferSizeMB);
+        return new SSTableWriterImplementation(inDirectory, partitioner, createStatement, insertStatement, rowBufferMode, bufferSizeMB);
     }
 
     // CDC Configuration

--- a/cassandra-four-zero/src/test/java/org/apache/cassandra/bridge/SSTableWriterImplementationTest.java
+++ b/cassandra-four-zero/src/test/java/org/apache/cassandra/bridge/SSTableWriterImplementationTest.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cassandra.bridge;
+
+import java.io.File;
+import java.lang.reflect.Field;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import org.apache.cassandra.dht.Murmur3Partitioner;
+import org.apache.cassandra.io.sstable.CQLSSTableWriter;
+import org.apache.cassandra.utils.ReflectionUtils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for configuring {@link SSTableWriterImplementation}
+ */
+class SSTableWriterImplementationTest
+{
+    public static final String CREATE_STATEMENT = "CREATE TABLE test_keyspace.test_table (a int, b text)";
+    public static final String INSERT_STATEMENT = "INSERT INTO test_keyspace.test_table (a, b) VALUES (?, ?)";
+
+    @TempDir
+    File writeDirectory;
+
+    @Test
+    void testUnbufferedRowBufferModeConfiguration() throws NoSuchFieldException, IllegalAccessException
+    {
+        CQLSSTableWriter.Builder builder = SSTableWriterImplementation.configureBuilder(writeDirectory.getAbsolutePath(),
+                                                                                        CREATE_STATEMENT,
+                                                                                        INSERT_STATEMENT,
+                                                                                        RowBufferMode.UNBUFFERED,
+                                                                                        250,
+                                                                                        new Murmur3Partitioner());
+
+
+        assertTrue(peekSorted(builder));
+        assertNotEquals(250, peekBufferSizeInMB(builder)); // 250 should not be set
+    }
+
+    @Test
+    void testBufferedRowBufferModeConfiguration() throws NoSuchFieldException, IllegalAccessException
+    {
+        CQLSSTableWriter.Builder builder = SSTableWriterImplementation.configureBuilder(writeDirectory.getAbsolutePath(),
+                                                                                        CREATE_STATEMENT,
+                                                                                        INSERT_STATEMENT,
+                                                                                        RowBufferMode.BUFFERED,
+                                                                                        250,
+                                                                                        new Murmur3Partitioner());
+
+
+        assertFalse(peekSorted(builder));
+        assertEquals(250, peekBufferSizeInMB(builder));
+    }
+
+    static boolean peekSorted(CQLSSTableWriter.Builder builder) throws NoSuchFieldException, IllegalAccessException
+    {
+        Field sortedField = ReflectionUtils.getField(builder.getClass(), "sorted");
+        sortedField.setAccessible(true);
+        return (boolean) sortedField.get(builder);
+    }
+
+    static long peekBufferSizeInMB(CQLSSTableWriter.Builder builder) throws NoSuchFieldException, IllegalAccessException
+    {
+        Field bufferSizeInMBField;
+        try
+        {
+            bufferSizeInMBField = ReflectionUtils.getField(builder.getClass(), "bufferSizeInMB");
+        }
+        catch (NoSuchFieldException noSuchFieldException)
+        {
+            // The bufferSizeInMB field has been renamed to bufferSizeInMiB in trunk, so we expect this to
+            // fail at some point, and we have a way to recover from the failure without causing the test
+            // to fail.
+            bufferSizeInMBField = ReflectionUtils.getField(builder.getClass(), "bufferSizeInMiB");
+        }
+
+        bufferSizeInMBField.setAccessible(true);
+        return (long) bufferSizeInMBField.get(builder);
+    }
+}

--- a/cassandra-four-zero/src/test/java/org/apache/cassandra/utils/ReflectionUtils.java
+++ b/cassandra-four-zero/src/test/java/org/apache/cassandra/utils/ReflectionUtils.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cassandra.utils;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+/**
+ * Reflection utilities used for testing
+ */
+public class ReflectionUtils
+{
+    public static Field getField(Class<?> clazz, String fieldName) throws NoSuchFieldException
+    {
+        // below code works before Java 12
+        try
+        {
+            return clazz.getDeclaredField(fieldName);
+        }
+        catch (NoSuchFieldException e)
+        {
+            // this is mitigation for JDK 17 (https://bugs.openjdk.org/browse/JDK-8210522)
+            try
+            {
+                Method getDeclaredFields0 = Class.class.getDeclaredMethod("getDeclaredFields0", boolean.class);
+                getDeclaredFields0.setAccessible(true);
+                Field[] fields = (Field[]) getDeclaredFields0.invoke(clazz, false);
+                for (Field field : fields)
+                {
+                    if (fieldName.equals(field.getName()))
+                    {
+                        return field;
+                    }
+                }
+            }
+            catch (ReflectiveOperationException ex)
+            {
+                e.addSuppressed(ex);
+            }
+            throw e;
+        }
+    }
+}

--- a/cassandra-four-zero/src/test/java/org/apache/cassandra/utils/ReflectionUtils.java
+++ b/cassandra-four-zero/src/test/java/org/apache/cassandra/utils/ReflectionUtils.java
@@ -25,8 +25,13 @@ import java.lang.reflect.Method;
 /**
  * Reflection utilities used for testing
  */
-public class ReflectionUtils
+public final class ReflectionUtils
 {
+    private ReflectionUtils()
+    {
+        throw new IllegalStateException(getClass() + " is static utility class and shall not be instantiated");
+    }
+
     public static Field getField(Class<?> clazz, String fieldName) throws NoSuchFieldException
     {
         // below code works before Java 12


### PR DESCRIPTION
When setting Buffered RowBufferMode as part of the `WriterOption`s, `org.apache.cassandra.spark.bulkwriter.RecordWriter` ignores that configuration and instead uses the batch size to determine when to finalize an SSTable and start writing a new SSTable, if more rows are available.

In this commit, we fix `org.apache.cassandra.spark.bulkwriter.RecordWriter#checkBatchSize` to take into account the configured `RowBufferMode`. And in specific to the case of the `UNBUFFERED` RowBufferMode, we check then the batchSize of the SSTable during writes, and for the case of `BUFFERED` that check will take no effect.

Co-authored-by: Doug Rohrer <doug@therohrers.org>