### PR TITLE
[CASSANDRA-18916] Modified Start-Up Validation to Log a Single Report

### DIFF
--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/validation/StartupValidation.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/validation/StartupValidation.java
@@ -19,31 +19,24 @@
 
 package org.apache.cassandra.spark.validation;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 /**
  * An interface that has to be implemented by all startup validations
  */
 @FunctionalInterface
 public interface StartupValidation
 {
-    Logger LOGGER = LoggerFactory.getLogger(StartupValidation.class);
-
     void validate();
 
-    default void perform()
+    default Throwable perform()
     {
         try
         {
-            LOGGER.info("Performing startup validation with " + getClass());
             validate();
         }
         catch (Throwable throwable)
         {
-            String message = "Failed startup validation with " + getClass();
-            LOGGER.error(message, throwable);
-            throw new RuntimeException(message, throwable);
+            return throwable;
         }
+        return null;
     }
 }

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/validation/KeyStoreValidationTests.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/validation/KeyStoreValidationTests.java
@@ -24,9 +24,9 @@ import org.junit.jupiter.api.Test;
 import org.apache.cassandra.secrets.SecretsProvider;
 import org.apache.cassandra.secrets.TestSecretsProvider;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * Unit tests that cover startup validation of a KeyStore
@@ -39,9 +39,9 @@ public class KeyStoreValidationTests
         SecretsProvider secrets = TestSecretsProvider.notConfigured();
         KeyStoreValidation validation = new KeyStoreValidation(secrets);
 
-        RuntimeException exception = assertThrows(RuntimeException.class, validation::perform);
-        assertTrue(exception.getMessage().startsWith("Failed startup validation"));
-        assertTrue(exception.getCause() instanceof RuntimeException);
+        Throwable throwable = validation.perform();
+        assertInstanceOf(RuntimeException.class, throwable);
+        assertEquals("KeyStore is not configured", throwable.getMessage());
     }
 
     @Test
@@ -50,9 +50,9 @@ public class KeyStoreValidationTests
         SecretsProvider secrets = TestSecretsProvider.forKeyStore("PKCS12", "keystore-missing.p12", "qwerty");
         KeyStoreValidation validation = new KeyStoreValidation(secrets);
 
-        RuntimeException exception = assertThrows(RuntimeException.class, validation::perform);
-        assertTrue(exception.getMessage().startsWith("Failed startup validation"));
-        assertTrue(exception.getCause() instanceof RuntimeException);
+        Throwable throwable = validation.perform();
+        assertInstanceOf(RuntimeException.class, throwable);
+        assertEquals("KeyStore is empty", throwable.getMessage());
     }
 
     @Test
@@ -61,9 +61,9 @@ public class KeyStoreValidationTests
         SecretsProvider secrets = TestSecretsProvider.forKeyStore("PKCS12", "keystore-malformed.p12", "qwerty");
         KeyStoreValidation validation = new KeyStoreValidation(secrets);
 
-        RuntimeException exception = assertThrows(RuntimeException.class, validation::perform);
-        assertTrue(exception.getMessage().startsWith("Failed startup validation"));
-        assertTrue(exception.getCause() instanceof RuntimeException);
+        Throwable throwable = validation.perform();
+        assertInstanceOf(RuntimeException.class, throwable);
+        assertEquals("KeyStore is misconfigured", throwable.getMessage());
     }
 
     @Test
@@ -72,9 +72,9 @@ public class KeyStoreValidationTests
         SecretsProvider secrets = TestSecretsProvider.forKeyStore("PKCS12", "keystore-empty.p12", "qwerty");
         KeyStoreValidation validation = new KeyStoreValidation(secrets);
 
-        RuntimeException exception = assertThrows(RuntimeException.class, validation::perform);
-        assertTrue(exception.getMessage().startsWith("Failed startup validation"));
-        assertTrue(exception.getCause() instanceof RuntimeException);
+        Throwable throwable = validation.perform();
+        assertInstanceOf(RuntimeException.class, throwable);
+        assertEquals("KeyStore is empty", throwable.getMessage());
     }
 
     @Test
@@ -83,9 +83,9 @@ public class KeyStoreValidationTests
         SecretsProvider secrets = TestSecretsProvider.forKeyStore("PKCS12", "keystore-secret.p12", "qwerty");
         KeyStoreValidation validation = new KeyStoreValidation(secrets);
 
-        RuntimeException exception = assertThrows(RuntimeException.class, validation::perform);
-        assertTrue(exception.getMessage().startsWith("Failed startup validation"));
-        assertTrue(exception.getCause() instanceof RuntimeException);
+        Throwable throwable = validation.perform();
+        assertInstanceOf(RuntimeException.class, throwable);
+        assertEquals("KeyStore contains no private keys", throwable.getMessage());
     }
 
     @Test
@@ -94,6 +94,7 @@ public class KeyStoreValidationTests
         SecretsProvider secrets = TestSecretsProvider.forKeyStore("PKCS12", "keystore-private.p12", "qwerty");
         KeyStoreValidation validation = new KeyStoreValidation(secrets);
 
-        assertDoesNotThrow(validation::perform);
+        Throwable throwable = validation.perform();
+        assertNull(throwable);
     }
 }

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/validation/StartupValidatorTests.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/validation/StartupValidatorTests.java
@@ -24,8 +24,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Unit tests that cover basic functioning of the startup validation logic
@@ -62,8 +62,7 @@ public class StartupValidatorTests
         StartupValidator.instance().register(TestValidation.succeeding());
 
         RuntimeException exception = assertThrows(RuntimeException.class, StartupValidator.instance()::perform);
-        assertTrue(exception.getMessage().startsWith("Failed startup validation"));
-        assertTrue(exception.getCause() instanceof RuntimeException);
+        assertEquals("Failed some of startup validations", exception.getMessage());
     }
 
     @AfterAll

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/validation/TrustStoreValidationTests.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/validation/TrustStoreValidationTests.java
@@ -24,9 +24,9 @@ import org.junit.jupiter.api.Test;
 import org.apache.cassandra.secrets.SecretsProvider;
 import org.apache.cassandra.secrets.TestSecretsProvider;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * Unit tests that cover startup validation of a TrustStore
@@ -39,7 +39,8 @@ public class TrustStoreValidationTests
         SecretsProvider secrets = TestSecretsProvider.notConfigured();
         TrustStoreValidation validation = new TrustStoreValidation(secrets);
 
-        assertDoesNotThrow(validation::perform);  // TrustStore is optional
+        Throwable throwable = validation.perform();
+        assertNull(throwable);  // TrustStore is optional
     }
 
     @Test
@@ -48,9 +49,9 @@ public class TrustStoreValidationTests
         SecretsProvider secrets = TestSecretsProvider.forTrustStore("PKCS12", "keystore-missing.p12", "qwerty");
         TrustStoreValidation validation = new TrustStoreValidation(secrets);
 
-        RuntimeException exception = assertThrows(RuntimeException.class, validation::perform);
-        assertTrue(exception.getMessage().startsWith("Failed startup validation"));
-        assertTrue(exception.getCause() instanceof RuntimeException);
+        Throwable throwable = validation.perform();
+        assertInstanceOf(RuntimeException.class, throwable);
+        assertEquals("TrustStore is empty", throwable.getMessage());
     }
 
     @Test
@@ -59,9 +60,9 @@ public class TrustStoreValidationTests
         SecretsProvider secrets = TestSecretsProvider.forTrustStore("PKCS12", "keystore-malformed.p12", "qwerty");
         TrustStoreValidation validation = new TrustStoreValidation(secrets);
 
-        RuntimeException exception = assertThrows(RuntimeException.class, validation::perform);
-        assertTrue(exception.getMessage().startsWith("Failed startup validation"));
-        assertTrue(exception.getCause() instanceof RuntimeException);
+        Throwable throwable = validation.perform();
+        assertInstanceOf(RuntimeException.class, throwable);
+        assertEquals("TrustStore is misconfigured", throwable.getMessage());
     }
 
     @Test
@@ -70,9 +71,9 @@ public class TrustStoreValidationTests
         SecretsProvider secrets = TestSecretsProvider.forTrustStore("PKCS12", "keystore-empty.p12", "qwerty");
         TrustStoreValidation validation = new TrustStoreValidation(secrets);
 
-        RuntimeException exception = assertThrows(RuntimeException.class, validation::perform);
-        assertTrue(exception.getMessage().startsWith("Failed startup validation"));
-        assertTrue(exception.getCause() instanceof RuntimeException);
+        Throwable throwable = validation.perform();
+        assertInstanceOf(RuntimeException.class, throwable);
+        assertEquals("TrustStore is empty", throwable.getMessage());
     }
 
     @Test
@@ -81,9 +82,9 @@ public class TrustStoreValidationTests
         SecretsProvider secrets = TestSecretsProvider.forTrustStore("PKCS12", "keystore-secret.p12", "qwerty");
         TrustStoreValidation validation = new TrustStoreValidation(secrets);
 
-        RuntimeException exception = assertThrows(RuntimeException.class, validation::perform);
-        assertTrue(exception.getMessage().startsWith("Failed startup validation"));
-        assertTrue(exception.getCause() instanceof RuntimeException);
+        Throwable throwable = validation.perform();
+        assertInstanceOf(RuntimeException.class, throwable);
+        assertEquals("TrustStore contains no certificates", throwable.getMessage());
     }
 
     @Test
@@ -92,6 +93,7 @@ public class TrustStoreValidationTests
         SecretsProvider secrets = TestSecretsProvider.forTrustStore("PKCS12", "keystore-certificate.p12", "qwerty");
         TrustStoreValidation validation = new TrustStoreValidation(secrets);
 
-        assertDoesNotThrow(validation::perform);
+        Throwable throwable = validation.perform();
+        assertNull(throwable);
     }
 }


### PR DESCRIPTION
In order to improve readability of the log, start-up validation now produces a complete report and emits it as a single event upon completion