### PR TITLE
CASSANDRA-19024 Fix bulk reading when using identifiers that need quotes

### DIFF
--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/clients/SidecarInstanceImpl.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/clients/SidecarInstanceImpl.java
@@ -90,14 +90,14 @@ public class SidecarInstanceImpl implements Serializable, SidecarInstance
 
     private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException
     {
-        LOGGER.warn("Falling back to JDK deserialization");
+        LOGGER.debug("Falling back to JDK deserialization");
         hostname = in.readUTF();
         port = in.readInt();
     }
 
     private void writeObject(ObjectOutputStream out) throws IOException, ClassNotFoundException
     {
-        LOGGER.warn("Falling back to JDK serialization");
+        LOGGER.debug("Falling back to JDK serialization");
         out.writeUTF(hostname);
         out.writeInt(port);
     }

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/secrets/SslConfig.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/secrets/SslConfig.java
@@ -152,7 +152,7 @@ public class SslConfig implements Serializable
 
     private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException
     {
-        LOGGER.warn("Falling back to JDK deserialization");
+        LOGGER.debug("Falling back to JDK deserialization");
         this.secretsPath = readNullableString(in);
         this.keyStorePath = readNullableString(in);
         this.base64EncodedKeyStore = readNullableString(in);
@@ -166,7 +166,7 @@ public class SslConfig implements Serializable
 
     private void writeObject(ObjectOutputStream out) throws IOException
     {
-        LOGGER.warn("Falling back to JDK serialization");
+        LOGGER.debug("Falling back to JDK serialization");
         writeNullableString(out, secretsPath);
         writeNullableString(out, keyStorePath);
         writeNullableString(out, base64EncodedKeyStore);

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/BulkSparkConf.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/BulkSparkConf.java
@@ -56,21 +56,21 @@ public class BulkSparkConf implements Serializable
     private static final Logger LOGGER = LoggerFactory.getLogger(BulkSparkConf.class);
 
     public static final String JDK11_OPTIONS = " -Djdk.attach.allowAttachSelf=true"
-                                             + " --add-exports java.base/jdk.internal.misc=ALL-UNNAMED"
-                                             + " --add-exports java.base/jdk.internal.ref=ALL-UNNAMED"
-                                             + " --add-exports java.base/sun.nio.ch=ALL-UNNAMED"
-                                             + " --add-exports java.management.rmi/com.sun.jmx.remote.internal.rmi=ALL-UNNAMED"
-                                             + " --add-exports java.rmi/sun.rmi.registry=ALL-UNNAMED"
-                                             + " --add-exports java.rmi/sun.rmi.server=ALL-UNNAMED"
-                                             + " --add-exports java.sql/java.sql=ALL-UNNAMED"
-                                             + " --add-opens java.base/java.lang.module=ALL-UNNAMED"
-                                             + " --add-opens java.base/jdk.internal.loader=ALL-UNNAMED"
-                                             + " --add-opens java.base/jdk.internal.ref=ALL-UNNAMED"
-                                             + " --add-opens java.base/jdk.internal.reflect=ALL-UNNAMED"
-                                             + " --add-opens java.base/jdk.internal.math=ALL-UNNAMED"
-                                             + " --add-opens java.base/jdk.internal.module=ALL-UNNAMED"
-                                             + " --add-opens java.base/jdk.internal.util.jar=ALL-UNNAMED"
-                                             + " --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED";
+                                               + " --add-exports java.base/jdk.internal.misc=ALL-UNNAMED"
+                                               + " --add-exports java.base/jdk.internal.ref=ALL-UNNAMED"
+                                               + " --add-exports java.base/sun.nio.ch=ALL-UNNAMED"
+                                               + " --add-exports java.management.rmi/com.sun.jmx.remote.internal.rmi=ALL-UNNAMED"
+                                               + " --add-exports java.rmi/sun.rmi.registry=ALL-UNNAMED"
+                                               + " --add-exports java.rmi/sun.rmi.server=ALL-UNNAMED"
+                                               + " --add-exports java.sql/java.sql=ALL-UNNAMED"
+                                               + " --add-opens java.base/java.lang.module=ALL-UNNAMED"
+                                               + " --add-opens java.base/jdk.internal.loader=ALL-UNNAMED"
+                                               + " --add-opens java.base/jdk.internal.ref=ALL-UNNAMED"
+                                               + " --add-opens java.base/jdk.internal.reflect=ALL-UNNAMED"
+                                               + " --add-opens java.base/jdk.internal.math=ALL-UNNAMED"
+                                               + " --add-opens java.base/jdk.internal.module=ALL-UNNAMED"
+                                               + " --add-opens java.base/jdk.internal.util.jar=ALL-UNNAMED"
+                                               + " --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED";
 
     public static final int DEFAULT_NUM_SPLITS = -1;
     public static final int DEFAULT_HTTP_CONNECTION_TIMEOUT = 100_000;
@@ -128,6 +128,7 @@ public class BulkSparkConf implements Serializable
     public final int commitThreadsPerInstance;
     protected final int effectiveSidecarPort;
     protected final int userProvidedSidecarPort;
+    public boolean quoteIdentifiers;
     protected boolean useOpenSsl;
     protected int ringRetryCount;
 
@@ -166,6 +167,7 @@ public class BulkSparkConf implements Serializable
         this.ringRetryCount = getInt(RING_RETRY_COUNT, DEFAULT_RING_RETRY_COUNT);
         this.ttl = MapUtils.getOrDefault(options, WriterOptions.TTL.name(), null);
         this.timestamp = MapUtils.getOrDefault(options, WriterOptions.TIMESTAMP.name(), null);
+        this.quoteIdentifiers = MapUtils.getBoolean(options, WriterOptions.QUOTE_IDENTIFIERS.name(), false, "quote identifiers");
         validateEnvironment();
     }
 

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/BulkSparkConf.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/BulkSparkConf.java
@@ -56,21 +56,21 @@ public class BulkSparkConf implements Serializable
     private static final Logger LOGGER = LoggerFactory.getLogger(BulkSparkConf.class);
 
     public static final String JDK11_OPTIONS = " -Djdk.attach.allowAttachSelf=true"
-                                               + " --add-exports java.base/jdk.internal.misc=ALL-UNNAMED"
-                                               + " --add-exports java.base/jdk.internal.ref=ALL-UNNAMED"
-                                               + " --add-exports java.base/sun.nio.ch=ALL-UNNAMED"
-                                               + " --add-exports java.management.rmi/com.sun.jmx.remote.internal.rmi=ALL-UNNAMED"
-                                               + " --add-exports java.rmi/sun.rmi.registry=ALL-UNNAMED"
-                                               + " --add-exports java.rmi/sun.rmi.server=ALL-UNNAMED"
-                                               + " --add-exports java.sql/java.sql=ALL-UNNAMED"
-                                               + " --add-opens java.base/java.lang.module=ALL-UNNAMED"
-                                               + " --add-opens java.base/jdk.internal.loader=ALL-UNNAMED"
-                                               + " --add-opens java.base/jdk.internal.ref=ALL-UNNAMED"
-                                               + " --add-opens java.base/jdk.internal.reflect=ALL-UNNAMED"
-                                               + " --add-opens java.base/jdk.internal.math=ALL-UNNAMED"
-                                               + " --add-opens java.base/jdk.internal.module=ALL-UNNAMED"
-                                               + " --add-opens java.base/jdk.internal.util.jar=ALL-UNNAMED"
-                                               + " --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED";
+                                             + " --add-exports java.base/jdk.internal.misc=ALL-UNNAMED"
+                                             + " --add-exports java.base/jdk.internal.ref=ALL-UNNAMED"
+                                             + " --add-exports java.base/sun.nio.ch=ALL-UNNAMED"
+                                             + " --add-exports java.management.rmi/com.sun.jmx.remote.internal.rmi=ALL-UNNAMED"
+                                             + " --add-exports java.rmi/sun.rmi.registry=ALL-UNNAMED"
+                                             + " --add-exports java.rmi/sun.rmi.server=ALL-UNNAMED"
+                                             + " --add-exports java.sql/java.sql=ALL-UNNAMED"
+                                             + " --add-opens java.base/java.lang.module=ALL-UNNAMED"
+                                             + " --add-opens java.base/jdk.internal.loader=ALL-UNNAMED"
+                                             + " --add-opens java.base/jdk.internal.ref=ALL-UNNAMED"
+                                             + " --add-opens java.base/jdk.internal.reflect=ALL-UNNAMED"
+                                             + " --add-opens java.base/jdk.internal.math=ALL-UNNAMED"
+                                             + " --add-opens java.base/jdk.internal.module=ALL-UNNAMED"
+                                             + " --add-opens java.base/jdk.internal.util.jar=ALL-UNNAMED"
+                                             + " --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED";
 
     public static final int DEFAULT_NUM_SPLITS = -1;
     public static final int DEFAULT_HTTP_CONNECTION_TIMEOUT = 100_000;
@@ -128,7 +128,6 @@ public class BulkSparkConf implements Serializable
     public final int commitThreadsPerInstance;
     protected final int effectiveSidecarPort;
     protected final int userProvidedSidecarPort;
-    public boolean quoteIdentifiers;
     protected boolean useOpenSsl;
     protected int ringRetryCount;
 
@@ -167,7 +166,6 @@ public class BulkSparkConf implements Serializable
         this.ringRetryCount = getInt(RING_RETRY_COUNT, DEFAULT_RING_RETRY_COUNT);
         this.ttl = MapUtils.getOrDefault(options, WriterOptions.TTL.name(), null);
         this.timestamp = MapUtils.getOrDefault(options, WriterOptions.TIMESTAMP.name(), null);
-        this.quoteIdentifiers = MapUtils.getBoolean(options, WriterOptions.QUOTE_IDENTIFIERS.name(), false, "quote identifiers");
         validateEnvironment();
     }
 

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/WriterOptions.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/WriterOptions.java
@@ -45,5 +45,10 @@ public enum WriterOptions implements WriterOption
     ROW_BUFFER_MODE,
     SSTABLE_DATA_SIZE_IN_MB,
     TTL,
-    TIMESTAMP
+    TIMESTAMP,
+    /**
+     * Option that specifies whether the identifiers (i.e. keyspace, table name, column names) should be quoted to
+     * support mixed case and reserved keyword names for these fields.
+     */
+    QUOTE_IDENTIFIERS,
 }

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/WriterOptions.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/WriterOptions.java
@@ -45,10 +45,5 @@ public enum WriterOptions implements WriterOption
     ROW_BUFFER_MODE,
     SSTABLE_DATA_SIZE_IN_MB,
     TTL,
-    TIMESTAMP,
-    /**
-     * Option that specifies whether the identifiers (i.e. keyspace, table name, column names) should be quoted to
-     * support mixed case and reserved keyword names for these fields.
-     */
-    QUOTE_IDENTIFIERS,
+    TIMESTAMP
 }

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/data/CassandraDataSourceHelper.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/data/CassandraDataSourceHelper.java
@@ -55,8 +55,8 @@ public final class CassandraDataSourceHelper
     }
 
     public static DataLayer getDataLayer(
-    Map<String, String> options,
-    BiConsumer<CassandraDataLayer, ClientConfig> initializeDataLayerFn)
+            Map<String, String> options,
+            BiConsumer<CassandraDataLayer, ClientConfig> initializeDataLayerFn)
     {
         ClientConfig config = ClientConfig.create(options);
 
@@ -72,13 +72,9 @@ public final class CassandraDataSourceHelper
             CassandraDataLayer cached;
             try
             {
-                cached = cassandraDataLayerCache.get(key, () -> {
-                    // First thread wins
-                    return createAndInitCassandraDataLayer(config,
-                                                           options,
-                                                           initializeDataLayerFn,
-                                                           SparkContext.getOrCreate().getConf());
-                });
+                cached = cassandraDataLayerCache.get(key, () ->
+                        // First thread wins
+                        createAndInitCassandraDataLayer(config, options, initializeDataLayerFn, SparkContext.getOrCreate().getConf()));
             }
             catch (ExecutionException exception)
             {
@@ -94,7 +90,7 @@ public final class CassandraDataSourceHelper
         }
     }
 
-    public static Cache<Map<String, String>, CassandraDataLayer> getCassandraDataLayerCache()
+    protected static Cache<Map<String, String>, CassandraDataLayer> getCassandraDataLayerCache()
     {
         if (cassandraDataLayerCache == null)
         {
@@ -109,23 +105,22 @@ public final class CassandraDataSourceHelper
      *
      * @param ticker the ticker to use for the cache
      */
-    public static void initCassandraDataSourceCache(Ticker ticker)
+    protected static void initCassandraDataSourceCache(Ticker ticker)
     {
         cassandraDataLayerCache = CacheBuilder
-                                  .newBuilder()
-                                  .ticker(ticker)
-                                  .expireAfterWrite(CACHE_HOURS, TimeUnit.HOURS)
-                                  .removalListener((RemovalListener<Map<String, String>, CassandraDataLayer>) notification -> {
-                                      LOGGER.debug("Removed entry '{}' from CassandraDataSourceCache", notification.getValue());
-                                  })
-                                  .build();
+                .newBuilder()
+                .ticker(ticker)
+                .expireAfterWrite(CACHE_HOURS, TimeUnit.HOURS)
+                .removalListener((RemovalListener<Map<String, String>, CassandraDataLayer>) notification ->
+                        LOGGER.debug("Removed entry '{}' from CassandraDataSourceCache", notification.getValue()))
+                .build();
     }
 
-    public static CassandraDataLayer createAndInitCassandraDataLayer(
-    ClientConfig config,
-    Map<String, String> options,
-    BiConsumer<CassandraDataLayer, ClientConfig> initializeDataLayerFn,
-    SparkConf conf)
+    protected static CassandraDataLayer createAndInitCassandraDataLayer(
+            ClientConfig config,
+            Map<String, String> options,
+            BiConsumer<CassandraDataLayer, ClientConfig> initializeDataLayerFn,
+            SparkConf conf)
     {
         CassandraDataLayer dataLayer = new CassandraDataLayer(config,
                                                               Sidecar.ClientConfig.create(options),

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/data/ClientConfig.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/data/ClientConfig.java
@@ -1,0 +1,240 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cassandra.spark.data;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.apache.cassandra.bridge.BigNumberConfigImpl;
+import org.apache.cassandra.spark.config.SchemaFeature;
+import org.apache.cassandra.spark.config.SchemaFeatureSet;
+import org.apache.cassandra.spark.data.partitioner.ConsistencyLevel;
+import org.apache.cassandra.spark.utils.MapUtils;
+import org.jetbrains.annotations.Nullable;
+
+import static org.apache.cassandra.spark.data.CassandraDataLayer.aliasLastModifiedTimestamp;
+
+public final class ClientConfig
+{
+    public static final String SIDECAR_INSTANCES = "sidecar_instances";
+    public static final String KEYSPACE_KEY = "keyspace";
+    public static final String TABLE_KEY = "table";
+    public static final String SNAPSHOT_NAME_KEY = "snapshotName";
+    public static final String DC_KEY = "dc";
+    public static final String CREATE_SNAPSHOT_KEY = "createSnapshot";
+    public static final String CLEAR_SNAPSHOT_KEY = "clearSnapshot";
+    public static final String DEFAULT_PARALLELISM_KEY = "defaultParallelism";
+    public static final String NUM_CORES_KEY = "numCores";
+    public static final String CONSISTENCY_LEVEL_KEY = "consistencyLevel";
+    public static final String ENABLE_STATS_KEY = "enableStats";
+    public static final String LAST_MODIFIED_COLUMN_NAME_KEY = "lastModifiedColumnName";
+    public static final String READ_INDEX_OFFSET_KEY = "readIndexOffset";
+    public static final String SIZING_KEY = "sizing";
+    public static final String SIZING_DEFAULT = "default";
+    public static final String MAX_PARTITION_SIZE_KEY = "maxPartitionSize";
+    public static final String USE_INCREMENTAL_REPAIR = "useIncrementalRepair";
+    public static final String ENABLE_EXPANSION_SHRINK_CHECK_KEY = "enableExpansionShrinkCheck";
+    public static final String SIDECAR_PORT = "sidecar_port";
+    public static final String QUOTE_IDENTIFIERS = "quote_identifiers";
+    public static final int DEFAULT_SIDECAR_PORT = 9043;
+
+    private final String sidecarInstances;
+    @Nullable
+    private final String keyspace;
+    @Nullable
+    private final String table;
+    private final String snapshotName;
+    private final String datacenter;
+    private final boolean createSnapshot;
+    private final boolean clearSnapshot;
+    private final int defaultParallelism;
+    private final int numCores;
+    private final ConsistencyLevel consistencyLevel;
+    private final Map<String, BigNumberConfigImpl> bigNumberConfigMap;
+    private final boolean enableStats;
+    private final boolean readIndexOffset;
+    private final String sizing;
+    private final int maxPartitionSize;
+    private final boolean useIncrementalRepair;
+    private final List<SchemaFeature> requestedFeatures;
+    private final String lastModifiedTimestampField;
+    private final Boolean enableExpansionShrinkCheck;
+    private final int sidecarPort;
+    private final boolean quoteIdentifiers;
+
+    private ClientConfig(Map<String, String> options)
+    {
+        this.sidecarInstances = MapUtils.getOrThrow(options, SIDECAR_INSTANCES, "sidecar_instances");
+        this.keyspace = MapUtils.getOrThrow(options, KEYSPACE_KEY, "keyspace");
+        this.table = MapUtils.getOrThrow(options, TABLE_KEY, "table");
+        this.snapshotName = MapUtils.getOrDefault(options, SNAPSHOT_NAME_KEY, "sbr_" + UUID.randomUUID().toString().replace("-", ""));
+        this.datacenter = options.get(MapUtils.lowerCaseKey(DC_KEY));
+        this.createSnapshot = MapUtils.getBoolean(options, CREATE_SNAPSHOT_KEY, true);
+        this.clearSnapshot = MapUtils.getBoolean(options, CLEAR_SNAPSHOT_KEY, createSnapshot);
+        this.defaultParallelism = MapUtils.getInt(options, DEFAULT_PARALLELISM_KEY, 1);
+        this.numCores = MapUtils.getInt(options, NUM_CORES_KEY, 1);
+        this.consistencyLevel = Optional.ofNullable(options.get(MapUtils.lowerCaseKey(CONSISTENCY_LEVEL_KEY)))
+                                        .map(ConsistencyLevel::valueOf)
+                                        .orElse(null);
+        this.bigNumberConfigMap = BigNumberConfigImpl.build(options);
+        this.enableStats = MapUtils.getBoolean(options, ENABLE_STATS_KEY, true);
+        this.readIndexOffset = MapUtils.getBoolean(options, READ_INDEX_OFFSET_KEY, true);
+        this.sizing = MapUtils.getOrDefault(options, SIZING_KEY, SIZING_DEFAULT);
+        this.maxPartitionSize = MapUtils.getInt(options, MAX_PARTITION_SIZE_KEY, 1);
+        this.useIncrementalRepair = MapUtils.getBoolean(options, USE_INCREMENTAL_REPAIR, true);
+        this.lastModifiedTimestampField = MapUtils.getOrDefault(options, LAST_MODIFIED_COLUMN_NAME_KEY, null);
+        this.enableExpansionShrinkCheck = MapUtils.getBoolean(options, ENABLE_EXPANSION_SHRINK_CHECK_KEY, false);
+        this.requestedFeatures = initRequestedFeatures(options);
+        this.sidecarPort = MapUtils.getInt(options, SIDECAR_PORT, DEFAULT_SIDECAR_PORT);
+        this.quoteIdentifiers = MapUtils.getBoolean(options, QUOTE_IDENTIFIERS, false);
+    }
+
+    public String sidecarInstances()
+    {
+        return sidecarInstances;
+    }
+
+    @Nullable
+    public String keyspace()
+    {
+        return keyspace;
+    }
+
+    @Nullable
+    public String table()
+    {
+        return table;
+    }
+
+    public String snapshotName()
+    {
+        return snapshotName;
+    }
+
+    public String datacenter()
+    {
+        return datacenter;
+    }
+
+    public boolean createSnapshot()
+    {
+        return createSnapshot;
+    }
+
+    public boolean clearSnapshot()
+    {
+        return clearSnapshot;
+    }
+
+    public int defaultParallelism()
+    {
+        return defaultParallelism;
+    }
+
+    public int numCores()
+    {
+        return numCores;
+    }
+
+    public ConsistencyLevel consistencyLevel()
+    {
+        return consistencyLevel;
+    }
+
+    public Map<String, BigNumberConfigImpl> bigNumberConfigMap()
+    {
+        return bigNumberConfigMap;
+    }
+
+    public boolean enableStats()
+    {
+        return enableStats;
+    }
+
+    public boolean readIndexOffset()
+    {
+        return readIndexOffset;
+    }
+
+    public String sizing()
+    {
+        return sizing;
+    }
+
+    public int maxPartitionSize()
+    {
+        return maxPartitionSize;
+    }
+
+    public boolean useIncrementalRepair()
+    {
+        return useIncrementalRepair;
+    }
+
+    public List<SchemaFeature> requestedFeatures()
+    {
+        return requestedFeatures;
+    }
+
+    public String lastModifiedTimestampField()
+    {
+        return lastModifiedTimestampField;
+    }
+
+    public Boolean enableExpansionShrinkCheck()
+    {
+        return enableExpansionShrinkCheck;
+    }
+
+    public int sidecarPort()
+    {
+        return sidecarPort;
+    }
+
+    public boolean quoteIdentifiers()
+    {
+        return quoteIdentifiers;
+    }
+
+    public static ClientConfig create(Map<String, String> options)
+    {
+        return new ClientConfig(options);
+    }
+
+    private List<SchemaFeature> initRequestedFeatures(Map<String, String> options)
+    {
+        Map<String, String> optionsCopy = new HashMap<>(options);
+        String lastModifiedColumnName = MapUtils.getOrDefault(options, LAST_MODIFIED_COLUMN_NAME_KEY, null);
+        if (lastModifiedColumnName != null)
+        {
+            optionsCopy.put(SchemaFeatureSet.LAST_MODIFIED_TIMESTAMP.optionName(), "true");
+        }
+        List<SchemaFeature> requestedFeatures = SchemaFeatureSet.initializeFromOptions(optionsCopy);
+        if (lastModifiedColumnName != null)
+        {
+            // Create alias to LAST_MODIFICATION_TIMESTAMP
+            aliasLastModifiedTimestamp(requestedFeatures, lastModifiedColumnName);
+        }
+        return requestedFeatures;
+    }
+}

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/data/partitioner/CassandraRing.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/data/partitioner/CassandraRing.java
@@ -268,7 +268,7 @@ public class CassandraRing implements Serializable
 
     private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException
     {
-        LOGGER.warn("Falling back to JDK deserialization");
+        LOGGER.debug("Falling back to JDK deserialization");
         this.partitioner = in.readByte() == 0 ? Partitioner.RandomPartitioner : Partitioner.Murmur3Partitioner;
         this.keyspace = in.readUTF();
 
@@ -292,7 +292,7 @@ public class CassandraRing implements Serializable
 
     private void writeObject(ObjectOutputStream out) throws IOException, ClassNotFoundException
     {
-        LOGGER.warn("Falling back to JDK serialization");
+        LOGGER.debug("Falling back to JDK serialization");
         out.writeByte(this.partitioner == Partitioner.RandomPartitioner ? 0 : 1);
         out.writeUTF(this.keyspace);
 

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/data/partitioner/TokenPartitioner.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/data/partitioner/TokenPartitioner.java
@@ -239,7 +239,7 @@ public class TokenPartitioner implements Serializable
     @SuppressWarnings("unchecked")
     private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException
     {
-        LOGGER.warn("Falling back to JDK deserialization");
+        LOGGER.debug("Falling back to JDK deserialization");
         this.partitionMap = TreeRangeMap.create();
         this.reversePartitionMap = new HashMap<>();
         this.ring = (CassandraRing) in.readObject();
@@ -249,7 +249,7 @@ public class TokenPartitioner implements Serializable
 
     private void writeObject(ObjectOutputStream out) throws IOException, ClassNotFoundException
     {
-        LOGGER.warn("Falling back to JDK serialization");
+        LOGGER.debug("Falling back to JDK serialization");
         out.writeObject(this.ring);
         out.writeObject(this.subRanges);
     }

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/sparksql/SparkCellIterator.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/sparksql/SparkCellIterator.java
@@ -194,7 +194,7 @@ public class SparkCellIterator implements Iterator<Cell>, AutoCloseable
             // Deserialize CQL field column name
             ByteBuffer component = ColumnTypes.extractComponent(columnNameBuf, cqlTable.numClusteringKeys());
             String columnName = component != null ? ByteBufferUtils.stringThrowRuntime(component) : null;
-            if (columnName == null || columnName.length() == 0)
+            if (columnName == null || columnName.isEmpty())
             {
                 if (noValueColumns)
                 {

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/utils/CqlUtils.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/utils/CqlUtils.java
@@ -37,7 +37,6 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.cassandra.spark.data.ReplicationFactor;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 /**
  * CQL-related utility methods
@@ -99,25 +98,6 @@ public final class CqlUtils
             throw new RuntimeException("Found unbalanced parentheses in table schema " + schema);
         }
         return schema.substring(0, index + 1);
-    }
-
-    /**
-     * The schema might contain quotes, but on-disk the table path doesn't have quotes, so causes problems for create/list snapshot
-     *
-     * @param table table name
-     * @return return a cleaned table table without quotes
-     */
-    public static String cleanTableName(@Nullable String table)
-    {
-        if (table == null)
-        {
-            return null;
-        }
-        while (table.startsWith("\"") && table.endsWith("\""))
-        {
-            table = table.substring(1, table.length() - 1);
-        }
-        return table;
     }
 
     public static Set<String> extractKeyspaceNames(@NotNull String schemaStr)
@@ -191,14 +171,7 @@ public final class CqlUtils
         if (matcher.find())
         {
             String fullSchema = createStatementToClean.substring(matcher.start(0), matcher.end(0));
-            String tableOnly = removeTableProps(fullSchema);
-            String quotedTableName = String.format("\"%s\"", table);
-            if (tableOnly.contains(quotedTableName))
-            {
-                // Remove quoted table name from schema
-                tableOnly = tableOnly.replaceFirst(quotedTableName, table);
-            }
-            String redactedSchema = tableOnly;
+            String redactedSchema = removeTableProps(fullSchema);
             String clustering = extractClustering(fullSchema);
             String separator = " WITH ";
             if (clustering != null)

--- a/cassandra-analytics-core/src/main/spark2/org/apache/cassandra/spark/sparksql/CassandraDataSource.java
+++ b/cassandra-analytics-core/src/main/spark2/org/apache/cassandra/spark/sparksql/CassandraDataSource.java
@@ -39,6 +39,7 @@ import org.slf4j.LoggerFactory;
 import org.apache.cassandra.bridge.CassandraBridgeFactory;
 import org.apache.cassandra.spark.data.CassandraDataLayer;
 import org.apache.cassandra.spark.data.CassandraDataSourceHelper;
+import org.apache.cassandra.spark.data.ClientConfig;
 import org.apache.cassandra.spark.data.CqlField;
 import org.apache.cassandra.spark.data.DataLayer;
 import org.apache.cassandra.spark.sparksql.filters.PartitionKeyFilter;
@@ -94,7 +95,7 @@ public class CassandraDataSource implements DataSourceV2, ReadSupport, DataSourc
     }
 
     @VisibleForTesting
-    void initializeDataLayer(CassandraDataLayer dataLayer, CassandraDataLayer.ClientConfig config)
+    void initializeDataLayer(CassandraDataLayer dataLayer, ClientConfig config)
     {
         dataLayer.initialize(config);
     }

--- a/cassandra-analytics-core/src/main/spark3/org/apache/cassandra/spark/sparksql/CassandraDataSource.java
+++ b/cassandra-analytics-core/src/main/spark3/org/apache/cassandra/spark/sparksql/CassandraDataSource.java
@@ -23,6 +23,7 @@ import com.google.common.annotations.VisibleForTesting;
 
 import org.apache.cassandra.spark.data.CassandraDataLayer;
 import org.apache.cassandra.spark.data.CassandraDataSourceHelper;
+import org.apache.cassandra.spark.data.ClientConfig;
 import org.apache.cassandra.spark.data.DataLayer;
 
 public class CassandraDataSource extends CassandraTableProvider
@@ -40,7 +41,7 @@ public class CassandraDataSource extends CassandraTableProvider
     }
 
     @VisibleForTesting
-    protected void initializeDataLayer(CassandraDataLayer dataLayer, CassandraDataLayer.ClientConfig config)
+    protected void initializeDataLayer(CassandraDataLayer dataLayer, ClientConfig config)
     {
         dataLayer.initialize(config);
     }

--- a/cassandra-analytics-core/src/main/spark3/org/apache/cassandra/spark/sparksql/CassandraScanBuilder.java
+++ b/cassandra-analytics-core/src/main/spark3/org/apache/cassandra/spark/sparksql/CassandraScanBuilder.java
@@ -24,6 +24,7 @@ import java.nio.ByteBuffer;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -108,8 +109,8 @@ class CassandraScanBuilder implements ScanBuilder, Scan, Batch, SupportsPushDown
     public InputPartition[] planInputPartitions()
     {
         return IntStream.range(0, dataLayer.partitionCount())
-                .mapToObj(CassandraInputPartition::new)
-                .toArray(InputPartition[]::new);
+                        .mapToObj(CassandraInputPartition::new)
+                        .toArray(InputPartition[]::new);
     }
 
     @Override
@@ -128,17 +129,16 @@ class CassandraScanBuilder implements ScanBuilder, Scan, Batch, SupportsPushDown
     {
         List<String> partitionKeyColumnNames = dataLayer.cqlTable().partitionKeys().stream().map(CqlField::name).collect(Collectors.toList());
         Map<String, List<String>> partitionKeyValues = FilterUtils.extractPartitionKeyValues(pushedFilters, new HashSet<>(partitionKeyColumnNames));
-        if (partitionKeyValues.size() > 0)
+
+        if (partitionKeyValues.isEmpty())
         {
-            List<List<String>> orderedValues = partitionKeyColumnNames.stream().map(partitionKeyValues::get).collect(Collectors.toList());
-            return FilterUtils.cartesianProduct(orderedValues).stream()
-                .map(this::buildFilter)
-                .collect(Collectors.toList());
+            return Collections.emptyList();
         }
-        else
-        {
-            return new ArrayList<>();
-        }
+
+        List<List<String>> orderedValues = partitionKeyColumnNames.stream().map(partitionKeyValues::get).collect(Collectors.toList());
+        return FilterUtils.cartesianProduct(orderedValues).stream()
+                          .map(this::buildFilter)
+                          .collect(Collectors.toList());
     }
 
     private PartitionKeyFilter buildFilter(List<String> keys)

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/clients/SidecarClientConfigTest.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/clients/SidecarClientConfigTest.java
@@ -22,7 +22,7 @@ package org.apache.cassandra.clients;
 import com.google.common.collect.ImmutableMap;
 import org.junit.jupiter.api.Test;
 
-import static org.apache.cassandra.spark.data.CassandraDataLayer.ClientConfig.DEFAULT_SIDECAR_PORT;
+import static org.apache.cassandra.spark.bulkwriter.BulkSparkConf.DEFAULT_SIDECAR_PORT;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/EndToEndTests.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/EndToEndTests.java
@@ -154,15 +154,15 @@ public class EndToEndTests
     public void testSingleClusteringKeyOrderBy(CassandraBridge bridge)
     {
         qt().forAll(TestUtils.cql3Type(bridge), TestUtils.sortOrder())
-            .checkAssert((clusteringKeyType, sortOrder) -> {
+            .checkAssert((clusteringKeyType, sortOrder) ->
                 Tester.builder(TestSchema.builder()
                                          .withPartitionKey("a", bridge.bigint())
                                          .withClusteringKey("b", clusteringKeyType)
                                          .withColumn("c", bridge.bigint())
                                          .withSortOrder(sortOrder))
                       .withExpectedRowCountPerSSTable(Tester.DEFAULT_NUM_ROWS)
-                      .run();
-            });
+                      .run()
+            );
     }
 
     @ParameterizedTest
@@ -224,14 +224,14 @@ public class EndToEndTests
     {
         // Test value column can be read for all data types
         qt().forAll(TestUtils.cql3Type(bridge))
-            .checkAssert(valueType -> {
+            .checkAssert(valueType ->
                 Tester.builder(TestSchema.builder()
                                          .withPartitionKey("a", bridge.bigint())
                                          .withColumn("b", valueType))
                       .withNumRandomSSTables(1)
                       .withExpectedRowCountPerSSTable(Tester.DEFAULT_NUM_ROWS)
-                      .run();
-            });
+                      .run()
+            );
     }
 
     /* Compaction */
@@ -493,15 +493,15 @@ public class EndToEndTests
                                  .withColumn("d", bridge.aInt()))
               .withNumRandomRows(0)
               .dontCheckNumSSTables()
-              .withSSTableWriter(writer -> {
+              .withSSTableWriter(writer ->
                   IntStream.range(0, Tester.DEFAULT_NUM_ROWS)
                            .forEach(row -> {
                                UUID pk = UUID.randomUUID();
                                IntStream.range(0, numClusteringKeys)
                                         .forEach(clusteringKey ->
-                                                 writer.write(pk, clusteringKey, row % 2 == 0 ? null : "Non-null", row));
-                           });
-              })
+                                                writer.write(pk, clusteringKey, row % 2 == 0 ? null : "Non-null", row));
+                           })
+              )
               .withReadListener(row -> {
                   String staticCol = row.isNull("c") ? null : row.getString("c");
                   if (row.getInteger("d") % 2 == 0)
@@ -570,7 +570,7 @@ public class EndToEndTests
               .withReadListener(actualRow -> assertTrue(rows.containsKey(actualRow.getUUID("a"))))
               .withReadListener(actualRow -> assertEquals(rows.get(actualRow.getUUID("a")), actualRow))
               .withReadListener(actualRow -> assertEquals(rows.get(actualRow.getUUID("a")).getLong("e"),
-                                                          actualRow.getLong("e")))
+                                                                   actualRow.getLong("e")))
               // Verify Spark aggregations match expected
               .withCheck(dataset -> assertEquals(total.get(), dataset.groupBy().sum("e").first().getLong(0)))
               .withCheck(dataset -> assertEquals(rows.size(), dataset.groupBy().count().first().getLong(0)))
@@ -639,7 +639,7 @@ public class EndToEndTests
         int numColumns = 10;
         qt().withExamples(20)
             .forAll(integers().between(0, numColumns - 1))
-            .checkAssert(colNum -> {
+            .checkAssert(colNum ->
                 Tester.builder(TestSchema.basicBuilder(bridge)
                                          .withDeleteFields("a =", "b ="))
                       .withVersions(TestUtils.tombstoneTestableVersions())
@@ -672,8 +672,8 @@ public class EndToEndTests
                           }
                           assertEquals(numRows * (numColumns - 1), count);
                       })
-                      .run();
-            });
+                      .run()
+            );
     }
 
     @ParameterizedTest
@@ -884,13 +884,13 @@ public class EndToEndTests
     public void testSet(CassandraBridge bridge)
     {
         qt().forAll(TestUtils.cql3Type(bridge))
-            .checkAssert(type -> {
+            .checkAssert(type ->
                 Tester.builder(TestSchema.builder()
                                          .withPartitionKey("pk", bridge.uuid())
                                          .withColumn("a", bridge.set(type)))
                       .withExpectedRowCountPerSSTable(Tester.DEFAULT_NUM_ROWS)
-                      .run();
-            });
+                      .run()
+            );
     }
 
     @ParameterizedTest
@@ -898,13 +898,13 @@ public class EndToEndTests
     public void testList(CassandraBridge bridge)
     {
         qt().forAll(TestUtils.cql3Type(bridge))
-            .checkAssert(type -> {
+            .checkAssert(type ->
                 Tester.builder(TestSchema.builder()
                                          .withPartitionKey("pk", bridge.uuid())
                                          .withColumn("a", bridge.list(type)))
                       .withExpectedRowCountPerSSTable(Tester.DEFAULT_NUM_ROWS)
-                      .run();
-            });
+                      .run()
+            );
     }
 
     @ParameterizedTest
@@ -913,13 +913,13 @@ public class EndToEndTests
     {
         qt().withExamples(50)  // Limit number of tests otherwise n x n tests takes too long
             .forAll(TestUtils.cql3Type(bridge), TestUtils.cql3Type(bridge))
-            .checkAssert((keyType, valueType) -> {
+            .checkAssert((keyType, valueType) ->
                 Tester.builder(TestSchema.builder()
                                          .withPartitionKey("pk", bridge.uuid())
                                          .withColumn("a", bridge.map(keyType, valueType)))
                       .withExpectedRowCountPerSSTable(Tester.DEFAULT_NUM_ROWS)
-                      .run();
-            });
+                      .run()
+            );
     }
 
     @ParameterizedTest
@@ -942,13 +942,13 @@ public class EndToEndTests
     {
         // pk -> a frozen<set<?>>
         qt().forAll(TestUtils.cql3Type(bridge))
-            .checkAssert(type -> {
+            .checkAssert(type ->
                 Tester.builder(TestSchema.builder()
                                          .withPartitionKey("pk", bridge.uuid())
                                          .withColumn("a", bridge.set(type).frozen()))
                       .withExpectedRowCountPerSSTable(Tester.DEFAULT_NUM_ROWS)
-                      .run();
-            });
+                      .run()
+            );
     }
 
     @ParameterizedTest
@@ -957,13 +957,13 @@ public class EndToEndTests
     {
         // pk -> a frozen<list<?>>
         qt().forAll(TestUtils.cql3Type(bridge))
-            .checkAssert(type -> {
+            .checkAssert(type ->
                 Tester.builder(TestSchema.builder()
                                          .withPartitionKey("pk", bridge.uuid())
                                          .withColumn("a", bridge.list(type).frozen()))
                       .withExpectedRowCountPerSSTable(Tester.DEFAULT_NUM_ROWS)
-                      .run();
-            });
+                      .run()
+            );
     }
 
     @ParameterizedTest
@@ -973,13 +973,13 @@ public class EndToEndTests
         // pk -> a frozen<map<?, ?>>
         qt().withExamples(50)  // Limit number of tests otherwise n x n tests takes too long
             .forAll(TestUtils.cql3Type(bridge), TestUtils.cql3Type(bridge))
-            .checkAssert((keyType, valueType) -> {
+            .checkAssert((keyType, valueType) ->
                 Tester.builder(TestSchema.builder()
                                          .withPartitionKey("pk", bridge.uuid())
                                          .withColumn("a", bridge.map(keyType, valueType).frozen()))
                       .withExpectedRowCountPerSSTable(Tester.DEFAULT_NUM_ROWS)
-                      .run();
-            });
+                      .run()
+            );
     }
 
     @ParameterizedTest
@@ -1016,7 +1016,7 @@ public class EndToEndTests
         Tester.builder(TestSchema.builder()
                                  .withPartitionKey("pk", bridge.uuid())
                                  .withColumn("a", bridge.map(bridge.text(),
-                                                             bridge.map(bridge.bigint(), bridge.varchar()).frozen())))
+                                                  bridge.map(bridge.bigint(), bridge.varchar()).frozen())))
               .withNumRandomRows(32)
               .withExpectedRowCountPerSSTable(32)
               .dontCheckNumSSTables()
@@ -1158,16 +1158,17 @@ public class EndToEndTests
     public void testUdtNativeTypes(CassandraBridge bridge)
     {
         // pk -> a testudt<b text, c type, d int>
-        qt().forAll(TestUtils.cql3Type(bridge)).checkAssert(type -> {
-            Tester.builder(TestSchema.builder()
-                                     .withPartitionKey("pk", bridge.uuid())
-                                     .withColumn("a", bridge.udt("keyspace", "testudt")
-                                                            .withField("b", bridge.text())
-                                                            .withField("c", type)
-                                                            .withField("d", bridge.aInt())
-                                                            .build()))
-                  .run();
-        });
+        qt().forAll(TestUtils.cql3Type(bridge))
+            .checkAssert(type ->
+                Tester.builder(TestSchema.builder()
+                              .withPartitionKey("pk", bridge.uuid())
+                              .withColumn("a", bridge.udt("keyspace", "testudt")
+                                                     .withField("b", bridge.text())
+                                                     .withField("c", type)
+                                                     .withField("d", bridge.aInt())
+                                                     .build()))
+                      .run()
+            );
     }
 
     @ParameterizedTest
@@ -1175,16 +1176,17 @@ public class EndToEndTests
     public void testUdtInnerSet(CassandraBridge bridge)
     {
         // pk -> a testudt<b text, c frozen<type>, d int>
-        qt().forAll(TestUtils.cql3Type(bridge)).checkAssert(type -> {
-            Tester.builder(TestSchema.builder()
-                                     .withPartitionKey("pk", bridge.uuid())
-                                     .withColumn("a", bridge.udt("keyspace", "testudt")
-                                                            .withField("b", bridge.text())
-                                                            .withField("c", bridge.set(type).frozen())
-                                                            .withField("d", bridge.aInt())
-                                                            .build()))
-                  .run();
-        });
+        qt().forAll(TestUtils.cql3Type(bridge))
+            .checkAssert(type ->
+                Tester.builder(TestSchema.builder()
+                                         .withPartitionKey("pk", bridge.uuid())
+                                         .withColumn("a", bridge.udt("keyspace", "testudt")
+                                                                .withField("b", bridge.text())
+                                                                .withField("c", bridge.set(type).frozen())
+                                                                .withField("d", bridge.aInt())
+                                                                .build()))
+                      .run()
+            );
     }
 
     @ParameterizedTest
@@ -1192,16 +1194,17 @@ public class EndToEndTests
     public void testUdtInnerList(CassandraBridge bridge)
     {
         // pk -> a testudt<b bigint, c frozen<list<type>>, d boolean>
-        qt().forAll(TestUtils.cql3Type(bridge)).checkAssert(type -> {
-            Tester.builder(TestSchema.builder()
-                                     .withPartitionKey("pk", bridge.uuid())
-                                     .withColumn("a", bridge.udt("keyspace", "testudt")
-                                                            .withField("b", bridge.bigint())
-                                                            .withField("c", bridge.list(type).frozen())
-                                                            .withField("d", bridge.bool())
-                                                            .build()))
-                  .run();
-        });
+        qt().forAll(TestUtils.cql3Type(bridge))
+            .checkAssert(type ->
+                Tester.builder(TestSchema.builder()
+                                         .withPartitionKey("pk", bridge.uuid())
+                                         .withColumn("a", bridge.udt("keyspace", "testudt")
+                                                                .withField("b", bridge.bigint())
+                                                                .withField("c", bridge.list(type).frozen())
+                                                                .withField("d", bridge.bool())
+                                                                .build()))
+                      .run()
+            );
     }
 
     @ParameterizedTest
@@ -1211,7 +1214,7 @@ public class EndToEndTests
         // pk -> a testudt<b float, c frozen<set<uuid>>, d frozen<map<type1, type2>>, e boolean>
         qt().withExamples(50)
             .forAll(TestUtils.cql3Type(bridge), TestUtils.cql3Type(bridge))
-            .checkAssert((type1, type2) -> {
+            .checkAssert((type1, type2) ->
                 Tester.builder(TestSchema.builder()
                                          .withPartitionKey("pk", bridge.uuid())
                                          .withColumn("a", bridge.udt("keyspace", "testudt")
@@ -1220,8 +1223,8 @@ public class EndToEndTests
                                                                 .withField("d", bridge.map(type1, type2).frozen())
                                                                 .withField("e", bridge.bool())
                                                                 .build()))
-                      .run();
-            });
+                      .run()
+            );
     }
 
     @ParameterizedTest
@@ -1231,7 +1234,7 @@ public class EndToEndTests
         // pk -> col1 udt1<a float, b frozen<set<uuid>>, c frozen<set<type>>, d boolean>,
         //       col2 udt2<a text, b bigint, g varchar>, col3 udt3<int, type, ascii>
         qt().forAll(TestUtils.cql3Type(bridge))
-            .checkAssert(type -> {
+            .checkAssert(type ->
                 Tester.builder(TestSchema.builder()
                                          .withPartitionKey("pk", bridge.uuid())
                                          .withColumn("col1", bridge.udt("keyspace", "udt1")
@@ -1250,8 +1253,8 @@ public class EndToEndTests
                                                                    .withField("b", bridge.list(type).frozen())
                                                                    .withField("c", bridge.ascii())
                                                                    .build()))
-                      .run();
-            });
+                      .run()
+            );
     }
 
     @ParameterizedTest
@@ -1260,7 +1263,7 @@ public class EndToEndTests
     {
         // pk -> a test_udt<b float, c frozen<set<uuid>>, d frozen<nested_udt<x int, y type, z int>>, e boolean>
         qt().forAll(TestUtils.cql3Type(bridge))
-            .checkAssert(type -> {
+            .checkAssert(type ->
                 Tester.builder(TestSchema.builder()
                                          .withPartitionKey("pk", bridge.uuid())
                                          .withColumn("a", bridge.udt("keyspace", "test_udt")
@@ -1273,8 +1276,8 @@ public class EndToEndTests
                                                                                       .build().frozen())
                                                                 .withField("e", bridge.bool())
                                                                 .build()))
-                      .run();
-            });
+                      .run()
+            );
     }
 
     /* Tuples */
@@ -1286,12 +1289,12 @@ public class EndToEndTests
         // pk -> a tuple<int, type1, bigint, type2>
         qt().withExamples(10)
             .forAll(TestUtils.cql3Type(bridge), TestUtils.cql3Type(bridge))
-            .checkAssert((type1, type2) -> {
+            .checkAssert((type1, type2) ->
                 Tester.builder(TestSchema.builder()
                                          .withPartitionKey("pk", bridge.uuid())
                                          .withColumn("a", bridge.tuple(bridge.aInt(), type1, bridge.bigint(), type2)))
-                      .run();
-            });
+                      .run()
+            );
     }
 
     @ParameterizedTest
@@ -1301,13 +1304,13 @@ public class EndToEndTests
         // pk -> col1 type1 -> a tuple<int, type2, bigint>
         qt().withExamples(10)
             .forAll(TestUtils.cql3Type(bridge), TestUtils.cql3Type(bridge))
-            .checkAssert((type1, type2) -> {
+            .checkAssert((type1, type2) ->
                 Tester.builder(TestSchema.builder()
                                          .withPartitionKey("pk", bridge.uuid())
                                          .withClusteringKey("col1", type1)
                                          .withColumn("a", bridge.tuple(bridge.aInt(), type2, bridge.bigint())))
-                      .run();
-            });
+                      .run()
+            );
     }
 
     @ParameterizedTest
@@ -1318,7 +1321,7 @@ public class EndToEndTests
         // Test tuples nested within tuple
         qt().withExamples(10)
             .forAll(TestUtils.cql3Type(bridge), TestUtils.cql3Type(bridge))
-            .checkAssert((type1, type2) -> {
+            .checkAssert((type1, type2) ->
                 Tester.builder(TestSchema.builder()
                                          .withPartitionKey("pk", bridge.uuid())
                                          .withColumn("a", bridge.tuple(bridge.varchar(),
@@ -1330,8 +1333,8 @@ public class EndToEndTests
                                                                                                  bridge.bool(),
                                                                                                  type2)),
                                                                        bridge.timeuuid())))
-                      .run();
-            });
+                      .run()
+            );
     }
 
     @ParameterizedTest
@@ -1342,7 +1345,7 @@ public class EndToEndTests
         // Test set nested within tuple
         qt().withExamples(10)
             .forAll(TestUtils.cql3Type(bridge))
-            .checkAssert(type -> {
+            .checkAssert(type ->
                 Tester.builder(TestSchema.builder()
                                          .withPartitionKey("pk", bridge.uuid())
                                          .withColumn("a", bridge.tuple(bridge.varchar(),
@@ -1352,8 +1355,8 @@ public class EndToEndTests
                                                                                     bridge.varchar(),
                                                                                     bridge.set(type)),
                                                                        bridge.timeuuid())))
-                      .run();
-            });
+                      .run()
+            );
     }
 
     @ParameterizedTest
@@ -1364,7 +1367,7 @@ public class EndToEndTests
         // Test list nested within tuple
         qt().withExamples(10)
             .forAll(TestUtils.cql3Type(bridge))
-            .checkAssert(type -> {
+            .checkAssert(type ->
                 Tester.builder(TestSchema.builder()
                                          .withPartitionKey("pk", bridge.uuid())
                                          .withColumn("a", bridge.tuple(bridge.varchar(),
@@ -1374,8 +1377,8 @@ public class EndToEndTests
                                                                                     bridge.varchar(),
                                                                                     bridge.list(type)),
                                                                        bridge.timeuuid())))
-                      .run();
-            });
+                      .run()
+            );
     }
 
     @ParameterizedTest
@@ -1386,18 +1389,18 @@ public class EndToEndTests
         // Test map nested within tuple
         qt().withExamples(10)
             .forAll(TestUtils.cql3Type(bridge), TestUtils.cql3Type(bridge))
-            .checkAssert((type1, type2) -> {
+            .checkAssert((type1, type2) ->
                 Tester.builder(TestSchema.builder()
-                                         .withPartitionKey("pk", bridge.uuid())
-                                         .withColumn("a", bridge.tuple(bridge.varchar(),
-                                                                       bridge.tuple(bridge.aInt(),
-                                                                                    bridge.varchar(),
-                                                                                    bridge.aFloat(),
-                                                                                    bridge.varchar(),
-                                                                                    bridge.map(type1, type2)),
-                                                                       bridge.timeuuid())))
-                      .run();
-            });
+                                        .withPartitionKey("pk", bridge.uuid())
+                                        .withColumn("a", bridge.tuple(bridge.varchar(),
+                                                                      bridge.tuple(bridge.aInt(),
+                                                                                   bridge.varchar(),
+                                                                                   bridge.aFloat(),
+                                                                                   bridge.varchar(),
+                                                                                   bridge.map(type1, type2)),
+                                                                                   bridge.timeuuid())))
+                      .run()
+            );
     }
 
     @ParameterizedTest
@@ -1408,15 +1411,15 @@ public class EndToEndTests
         // Test tuple nested within map
         qt().withExamples(10)
             .forAll(TestUtils.cql3Type(bridge))
-            .checkAssert(type -> {
+            .checkAssert(type ->
                 Tester.builder(TestSchema.builder()
                                          .withPartitionKey("pk", bridge.uuid())
                                          .withColumn("a", bridge.map(bridge.timeuuid(),
                                                                      bridge.tuple(bridge.bool(),
                                                                                   type,
                                                                                   bridge.timestamp()).frozen())))
-                      .run();
-            });
+                      .run()
+            );
     }
 
     @ParameterizedTest
@@ -1427,14 +1430,14 @@ public class EndToEndTests
         // Test tuple nested within set
         qt().withExamples(10)
             .forAll(TestUtils.cql3Type(bridge))
-            .checkAssert(type -> {
+            .checkAssert(type ->
                 Tester.builder(TestSchema.builder()
                                          .withPartitionKey("pk", bridge.uuid())
                                          .withColumn("a", bridge.set(bridge.tuple(type,
                                                                                   bridge.aFloat(),
                                                                                   bridge.text()).frozen())))
-                      .run();
-            });
+                      .run()
+            );
     }
 
     @ParameterizedTest
@@ -1445,15 +1448,15 @@ public class EndToEndTests
         // Test tuple nested within map
         qt().withExamples(10)
             .forAll(TestUtils.cql3Type(bridge))
-            .checkAssert(type -> {
+            .checkAssert(type ->
                 Tester.builder(TestSchema.builder()
                                          .withPartitionKey("pk", bridge.uuid())
                                          .withColumn("a", bridge.list(bridge.tuple(bridge.aInt(),
                                                                                    bridge.inet(),
                                                                                    bridge.decimal(),
                                                                                    type).frozen())))
-                      .run();
-            });
+                      .run()
+            );
     }
 
     @ParameterizedTest
@@ -1464,7 +1467,7 @@ public class EndToEndTests
         // Test tuple with inner UDT
         qt().withExamples(10)
             .forAll(TestUtils.cql3Type(bridge))
-            .checkAssert(type -> {
+            .checkAssert(type ->
                 Tester.builder(TestSchema.builder()
                                          .withPartitionKey("pk", bridge.uuid())
                                          .withColumn("a", bridge.tuple(bridge.varchar(),
@@ -1474,8 +1477,8 @@ public class EndToEndTests
                                                                              .withField("z", bridge.aInt())
                                                                              .build().frozen(),
                                                                        bridge.timeuuid())))
-                      .run();
-            });
+                      .run()
+            );
     }
 
     @ParameterizedTest
@@ -1486,7 +1489,7 @@ public class EndToEndTests
         // Test UDT with inner tuple
         qt().withExamples(10)
             .forAll(TestUtils.cql3Type(bridge))
-            .checkAssert(type -> {
+            .checkAssert(type ->
                 Tester.builder(TestSchema.builder()
                                          .withPartitionKey("pk", bridge.uuid())
                                          .withColumn("a", bridge.udt("keyspace", "nested_udt")
@@ -1497,8 +1500,8 @@ public class EndToEndTests
                                                                                              bridge.timestamp()))
                                                                 .withField("z", bridge.ascii())
                                                                 .build()))
-                      .run();
-            });
+                      .run()
+            );
     }
 
     @ParameterizedTest
@@ -1506,7 +1509,7 @@ public class EndToEndTests
     public void testTupleClusteringKey(CassandraBridge bridge)
     {
         qt().forAll(TestUtils.cql3Type(bridge))
-            .checkAssert(type -> {
+            .checkAssert(type ->
                 Tester.builder(TestSchema.builder()
                                          .withPartitionKey("pk", bridge.uuid())
                                          .withClusteringKey("ck", bridge.tuple(bridge.aInt(),
@@ -1516,8 +1519,8 @@ public class EndToEndTests
                                          .withColumn("a", bridge.text())
                                          .withColumn("b", bridge.aInt())
                                          .withColumn("c", bridge.ascii()))
-                      .run();
-            });
+                      .run()
+            );
     }
 
     @ParameterizedTest
@@ -1525,7 +1528,7 @@ public class EndToEndTests
     public void testUdtClusteringKey(CassandraBridge bridge)
     {
         qt().forAll(TestUtils.cql3Type(bridge))
-            .checkAssert(type -> {
+            .checkAssert(type ->
                 Tester.builder(TestSchema.builder()
                                          .withPartitionKey("pk", bridge.uuid())
                                          .withClusteringKey("ck", bridge.udt("keyspace", "udt1")
@@ -1536,8 +1539,8 @@ public class EndToEndTests
                                          .withColumn("a", bridge.text())
                                          .withColumn("b", bridge.aInt())
                                          .withColumn("c", bridge.ascii()))
-                      .run();
-            });
+                      .run()
+            );
     }
 
     @ParameterizedTest
@@ -1629,7 +1632,7 @@ public class EndToEndTests
                                      .withField("c", bridge.uuid())
                                      .withField("d", bridge.list(bridge.tuple(bridge.text(),
                                                                               bridge.bigint()).frozen()
-                                     ).frozen())
+                                                                             ).frozen())
                                      .build();
         CqlField.CqlUdt udt5 = bridge.udt(keyspace, "udt5")
                                      .withField("a", bridge.text())
@@ -1788,8 +1791,8 @@ public class EndToEndTests
                   for (UUID pk : udtSetValues.keySet())
                   {
                       Set<Object> udtSet = udtSetValues.get(pk).stream()
-                                                       .map(map -> bridge.toUserTypeValue(udtType, map))
-                                                       .collect(Collectors.toSet());
+                                                               .map(map ->  bridge.toUserTypeValue(udtType, map))
+                                                               .collect(Collectors.toSet());
                       Object tuple = bridge.toTupleValue(tupleType, tupleValues.get(pk));
 
                       writer.write(pk, udtSet, tuple);
@@ -1848,19 +1851,19 @@ public class EndToEndTests
                   for (long pk = 0; pk < Tester.DEFAULT_NUM_ROWS; pk++)
                   {
                       Map<String, Object> value = ImmutableMap.of(
-                      pk < midPoint ? "a" : "b", RandomUtils.randomValue(bridge.text()).toString(),
-                      "c", RandomUtils.randomValue(bridge.text()).toString());
+                            pk < midPoint ? "a" : "b", RandomUtils.randomValue(bridge.text()).toString(),
+                            "c", RandomUtils.randomValue(bridge.text()).toString());
                       values.put(pk, value);
                       writer.write(pk, bridge.toUserTypeValue(type, value),
-                                   RandomUtils.randomValue(bridge.text()),
-                                   RandomUtils.randomValue(bridge.timestamp()),
-                                   RandomUtils.randomValue(bridge.aInt()));
+                                       RandomUtils.randomValue(bridge.text()),
+                                       RandomUtils.randomValue(bridge.timestamp()),
+                                       RandomUtils.randomValue(bridge.aInt()));
                   }
               })
               .withCheck(dataset -> {
                   Map<Long, Row> rows = dataset.collectAsList().stream()
-                                               .collect(Collectors.toMap(row -> row.getLong(0),
-                                                                         row -> row.getStruct(1)));
+                                                               .collect(Collectors.toMap(row -> row.getLong(0),
+                                                                                         row -> row.getStruct(1)));
                   assertEquals(values.size(), rows.size());
                   for (Map.Entry<Long, Row> pk : rows.entrySet())
                   {
@@ -1968,7 +1971,7 @@ public class EndToEndTests
     public void testLargeBlobExclude(CassandraBridge bridge)
     {
         qt().forAll(booleans().all())
-            .checkAssert(enableCompression -> {
+            .checkAssert(enableCompression ->
                 Tester.builder(TestSchema.builder()
                                          .withPartitionKey("pk", bridge.uuid())
                                          .withClusteringKey("ck", bridge.aInt())
@@ -2002,8 +2005,8 @@ public class EndToEndTests
                           assertTrue(skippedRangeBytes.get() > 5_000_000);
                       })
                       .withReset(EndToEndTests::resetStats)
-                      .run();
-            });
+                      .run()
+            );
     }
 
     @ParameterizedTest

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/EndToEndTests.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/EndToEndTests.java
@@ -154,15 +154,15 @@ public class EndToEndTests
     public void testSingleClusteringKeyOrderBy(CassandraBridge bridge)
     {
         qt().forAll(TestUtils.cql3Type(bridge), TestUtils.sortOrder())
-            .checkAssert((clusteringKeyType, sortOrder) ->
+            .checkAssert((clusteringKeyType, sortOrder) -> {
                 Tester.builder(TestSchema.builder()
                                          .withPartitionKey("a", bridge.bigint())
                                          .withClusteringKey("b", clusteringKeyType)
                                          .withColumn("c", bridge.bigint())
                                          .withSortOrder(sortOrder))
                       .withExpectedRowCountPerSSTable(Tester.DEFAULT_NUM_ROWS)
-                      .run()
-            );
+                      .run();
+            });
     }
 
     @ParameterizedTest
@@ -224,14 +224,14 @@ public class EndToEndTests
     {
         // Test value column can be read for all data types
         qt().forAll(TestUtils.cql3Type(bridge))
-            .checkAssert(valueType ->
+            .checkAssert(valueType -> {
                 Tester.builder(TestSchema.builder()
                                          .withPartitionKey("a", bridge.bigint())
                                          .withColumn("b", valueType))
                       .withNumRandomSSTables(1)
                       .withExpectedRowCountPerSSTable(Tester.DEFAULT_NUM_ROWS)
-                      .run()
-            );
+                      .run();
+            });
     }
 
     /* Compaction */
@@ -493,15 +493,15 @@ public class EndToEndTests
                                  .withColumn("d", bridge.aInt()))
               .withNumRandomRows(0)
               .dontCheckNumSSTables()
-              .withSSTableWriter(writer ->
+              .withSSTableWriter(writer -> {
                   IntStream.range(0, Tester.DEFAULT_NUM_ROWS)
                            .forEach(row -> {
                                UUID pk = UUID.randomUUID();
                                IntStream.range(0, numClusteringKeys)
                                         .forEach(clusteringKey ->
-                                                writer.write(pk, clusteringKey, row % 2 == 0 ? null : "Non-null", row));
-                           })
-              )
+                                                 writer.write(pk, clusteringKey, row % 2 == 0 ? null : "Non-null", row));
+                           });
+              })
               .withReadListener(row -> {
                   String staticCol = row.isNull("c") ? null : row.getString("c");
                   if (row.getInteger("d") % 2 == 0)
@@ -570,7 +570,7 @@ public class EndToEndTests
               .withReadListener(actualRow -> assertTrue(rows.containsKey(actualRow.getUUID("a"))))
               .withReadListener(actualRow -> assertEquals(rows.get(actualRow.getUUID("a")), actualRow))
               .withReadListener(actualRow -> assertEquals(rows.get(actualRow.getUUID("a")).getLong("e"),
-                                                                   actualRow.getLong("e")))
+                                                          actualRow.getLong("e")))
               // Verify Spark aggregations match expected
               .withCheck(dataset -> assertEquals(total.get(), dataset.groupBy().sum("e").first().getLong(0)))
               .withCheck(dataset -> assertEquals(rows.size(), dataset.groupBy().count().first().getLong(0)))
@@ -639,7 +639,7 @@ public class EndToEndTests
         int numColumns = 10;
         qt().withExamples(20)
             .forAll(integers().between(0, numColumns - 1))
-            .checkAssert(colNum ->
+            .checkAssert(colNum -> {
                 Tester.builder(TestSchema.basicBuilder(bridge)
                                          .withDeleteFields("a =", "b ="))
                       .withVersions(TestUtils.tombstoneTestableVersions())
@@ -672,8 +672,8 @@ public class EndToEndTests
                           }
                           assertEquals(numRows * (numColumns - 1), count);
                       })
-                      .run()
-            );
+                      .run();
+            });
     }
 
     @ParameterizedTest
@@ -884,13 +884,13 @@ public class EndToEndTests
     public void testSet(CassandraBridge bridge)
     {
         qt().forAll(TestUtils.cql3Type(bridge))
-            .checkAssert(type ->
+            .checkAssert(type -> {
                 Tester.builder(TestSchema.builder()
                                          .withPartitionKey("pk", bridge.uuid())
                                          .withColumn("a", bridge.set(type)))
                       .withExpectedRowCountPerSSTable(Tester.DEFAULT_NUM_ROWS)
-                      .run()
-            );
+                      .run();
+            });
     }
 
     @ParameterizedTest
@@ -898,13 +898,13 @@ public class EndToEndTests
     public void testList(CassandraBridge bridge)
     {
         qt().forAll(TestUtils.cql3Type(bridge))
-            .checkAssert(type ->
+            .checkAssert(type -> {
                 Tester.builder(TestSchema.builder()
                                          .withPartitionKey("pk", bridge.uuid())
                                          .withColumn("a", bridge.list(type)))
                       .withExpectedRowCountPerSSTable(Tester.DEFAULT_NUM_ROWS)
-                      .run()
-            );
+                      .run();
+            });
     }
 
     @ParameterizedTest
@@ -913,13 +913,13 @@ public class EndToEndTests
     {
         qt().withExamples(50)  // Limit number of tests otherwise n x n tests takes too long
             .forAll(TestUtils.cql3Type(bridge), TestUtils.cql3Type(bridge))
-            .checkAssert((keyType, valueType) ->
+            .checkAssert((keyType, valueType) -> {
                 Tester.builder(TestSchema.builder()
                                          .withPartitionKey("pk", bridge.uuid())
                                          .withColumn("a", bridge.map(keyType, valueType)))
                       .withExpectedRowCountPerSSTable(Tester.DEFAULT_NUM_ROWS)
-                      .run()
-            );
+                      .run();
+            });
     }
 
     @ParameterizedTest
@@ -942,13 +942,13 @@ public class EndToEndTests
     {
         // pk -> a frozen<set<?>>
         qt().forAll(TestUtils.cql3Type(bridge))
-            .checkAssert(type ->
+            .checkAssert(type -> {
                 Tester.builder(TestSchema.builder()
                                          .withPartitionKey("pk", bridge.uuid())
                                          .withColumn("a", bridge.set(type).frozen()))
                       .withExpectedRowCountPerSSTable(Tester.DEFAULT_NUM_ROWS)
-                      .run()
-            );
+                      .run();
+            });
     }
 
     @ParameterizedTest
@@ -957,13 +957,13 @@ public class EndToEndTests
     {
         // pk -> a frozen<list<?>>
         qt().forAll(TestUtils.cql3Type(bridge))
-            .checkAssert(type ->
+            .checkAssert(type -> {
                 Tester.builder(TestSchema.builder()
                                          .withPartitionKey("pk", bridge.uuid())
                                          .withColumn("a", bridge.list(type).frozen()))
                       .withExpectedRowCountPerSSTable(Tester.DEFAULT_NUM_ROWS)
-                      .run()
-            );
+                      .run();
+            });
     }
 
     @ParameterizedTest
@@ -973,13 +973,13 @@ public class EndToEndTests
         // pk -> a frozen<map<?, ?>>
         qt().withExamples(50)  // Limit number of tests otherwise n x n tests takes too long
             .forAll(TestUtils.cql3Type(bridge), TestUtils.cql3Type(bridge))
-            .checkAssert((keyType, valueType) ->
+            .checkAssert((keyType, valueType) -> {
                 Tester.builder(TestSchema.builder()
                                          .withPartitionKey("pk", bridge.uuid())
                                          .withColumn("a", bridge.map(keyType, valueType).frozen()))
                       .withExpectedRowCountPerSSTable(Tester.DEFAULT_NUM_ROWS)
-                      .run()
-            );
+                      .run();
+            });
     }
 
     @ParameterizedTest
@@ -1016,7 +1016,7 @@ public class EndToEndTests
         Tester.builder(TestSchema.builder()
                                  .withPartitionKey("pk", bridge.uuid())
                                  .withColumn("a", bridge.map(bridge.text(),
-                                                  bridge.map(bridge.bigint(), bridge.varchar()).frozen())))
+                                                             bridge.map(bridge.bigint(), bridge.varchar()).frozen())))
               .withNumRandomRows(32)
               .withExpectedRowCountPerSSTable(32)
               .dontCheckNumSSTables()
@@ -1158,17 +1158,16 @@ public class EndToEndTests
     public void testUdtNativeTypes(CassandraBridge bridge)
     {
         // pk -> a testudt<b text, c type, d int>
-        qt().forAll(TestUtils.cql3Type(bridge))
-            .checkAssert(type ->
-                Tester.builder(TestSchema.builder()
-                              .withPartitionKey("pk", bridge.uuid())
-                              .withColumn("a", bridge.udt("keyspace", "testudt")
-                                                     .withField("b", bridge.text())
-                                                     .withField("c", type)
-                                                     .withField("d", bridge.aInt())
-                                                     .build()))
-                      .run()
-            );
+        qt().forAll(TestUtils.cql3Type(bridge)).checkAssert(type -> {
+            Tester.builder(TestSchema.builder()
+                                     .withPartitionKey("pk", bridge.uuid())
+                                     .withColumn("a", bridge.udt("keyspace", "testudt")
+                                                            .withField("b", bridge.text())
+                                                            .withField("c", type)
+                                                            .withField("d", bridge.aInt())
+                                                            .build()))
+                  .run();
+        });
     }
 
     @ParameterizedTest
@@ -1176,17 +1175,16 @@ public class EndToEndTests
     public void testUdtInnerSet(CassandraBridge bridge)
     {
         // pk -> a testudt<b text, c frozen<type>, d int>
-        qt().forAll(TestUtils.cql3Type(bridge))
-            .checkAssert(type ->
-                Tester.builder(TestSchema.builder()
-                                         .withPartitionKey("pk", bridge.uuid())
-                                         .withColumn("a", bridge.udt("keyspace", "testudt")
-                                                                .withField("b", bridge.text())
-                                                                .withField("c", bridge.set(type).frozen())
-                                                                .withField("d", bridge.aInt())
-                                                                .build()))
-                      .run()
-            );
+        qt().forAll(TestUtils.cql3Type(bridge)).checkAssert(type -> {
+            Tester.builder(TestSchema.builder()
+                                     .withPartitionKey("pk", bridge.uuid())
+                                     .withColumn("a", bridge.udt("keyspace", "testudt")
+                                                            .withField("b", bridge.text())
+                                                            .withField("c", bridge.set(type).frozen())
+                                                            .withField("d", bridge.aInt())
+                                                            .build()))
+                  .run();
+        });
     }
 
     @ParameterizedTest
@@ -1194,17 +1192,16 @@ public class EndToEndTests
     public void testUdtInnerList(CassandraBridge bridge)
     {
         // pk -> a testudt<b bigint, c frozen<list<type>>, d boolean>
-        qt().forAll(TestUtils.cql3Type(bridge))
-            .checkAssert(type ->
-                Tester.builder(TestSchema.builder()
-                                         .withPartitionKey("pk", bridge.uuid())
-                                         .withColumn("a", bridge.udt("keyspace", "testudt")
-                                                                .withField("b", bridge.bigint())
-                                                                .withField("c", bridge.list(type).frozen())
-                                                                .withField("d", bridge.bool())
-                                                                .build()))
-                      .run()
-            );
+        qt().forAll(TestUtils.cql3Type(bridge)).checkAssert(type -> {
+            Tester.builder(TestSchema.builder()
+                                     .withPartitionKey("pk", bridge.uuid())
+                                     .withColumn("a", bridge.udt("keyspace", "testudt")
+                                                            .withField("b", bridge.bigint())
+                                                            .withField("c", bridge.list(type).frozen())
+                                                            .withField("d", bridge.bool())
+                                                            .build()))
+                  .run();
+        });
     }
 
     @ParameterizedTest
@@ -1214,7 +1211,7 @@ public class EndToEndTests
         // pk -> a testudt<b float, c frozen<set<uuid>>, d frozen<map<type1, type2>>, e boolean>
         qt().withExamples(50)
             .forAll(TestUtils.cql3Type(bridge), TestUtils.cql3Type(bridge))
-            .checkAssert((type1, type2) ->
+            .checkAssert((type1, type2) -> {
                 Tester.builder(TestSchema.builder()
                                          .withPartitionKey("pk", bridge.uuid())
                                          .withColumn("a", bridge.udt("keyspace", "testudt")
@@ -1223,8 +1220,8 @@ public class EndToEndTests
                                                                 .withField("d", bridge.map(type1, type2).frozen())
                                                                 .withField("e", bridge.bool())
                                                                 .build()))
-                      .run()
-            );
+                      .run();
+            });
     }
 
     @ParameterizedTest
@@ -1234,7 +1231,7 @@ public class EndToEndTests
         // pk -> col1 udt1<a float, b frozen<set<uuid>>, c frozen<set<type>>, d boolean>,
         //       col2 udt2<a text, b bigint, g varchar>, col3 udt3<int, type, ascii>
         qt().forAll(TestUtils.cql3Type(bridge))
-            .checkAssert(type ->
+            .checkAssert(type -> {
                 Tester.builder(TestSchema.builder()
                                          .withPartitionKey("pk", bridge.uuid())
                                          .withColumn("col1", bridge.udt("keyspace", "udt1")
@@ -1253,8 +1250,8 @@ public class EndToEndTests
                                                                    .withField("b", bridge.list(type).frozen())
                                                                    .withField("c", bridge.ascii())
                                                                    .build()))
-                      .run()
-            );
+                      .run();
+            });
     }
 
     @ParameterizedTest
@@ -1263,7 +1260,7 @@ public class EndToEndTests
     {
         // pk -> a test_udt<b float, c frozen<set<uuid>>, d frozen<nested_udt<x int, y type, z int>>, e boolean>
         qt().forAll(TestUtils.cql3Type(bridge))
-            .checkAssert(type ->
+            .checkAssert(type -> {
                 Tester.builder(TestSchema.builder()
                                          .withPartitionKey("pk", bridge.uuid())
                                          .withColumn("a", bridge.udt("keyspace", "test_udt")
@@ -1276,8 +1273,8 @@ public class EndToEndTests
                                                                                       .build().frozen())
                                                                 .withField("e", bridge.bool())
                                                                 .build()))
-                      .run()
-            );
+                      .run();
+            });
     }
 
     /* Tuples */
@@ -1289,12 +1286,12 @@ public class EndToEndTests
         // pk -> a tuple<int, type1, bigint, type2>
         qt().withExamples(10)
             .forAll(TestUtils.cql3Type(bridge), TestUtils.cql3Type(bridge))
-            .checkAssert((type1, type2) ->
+            .checkAssert((type1, type2) -> {
                 Tester.builder(TestSchema.builder()
                                          .withPartitionKey("pk", bridge.uuid())
                                          .withColumn("a", bridge.tuple(bridge.aInt(), type1, bridge.bigint(), type2)))
-                      .run()
-            );
+                      .run();
+            });
     }
 
     @ParameterizedTest
@@ -1304,13 +1301,13 @@ public class EndToEndTests
         // pk -> col1 type1 -> a tuple<int, type2, bigint>
         qt().withExamples(10)
             .forAll(TestUtils.cql3Type(bridge), TestUtils.cql3Type(bridge))
-            .checkAssert((type1, type2) ->
+            .checkAssert((type1, type2) -> {
                 Tester.builder(TestSchema.builder()
                                          .withPartitionKey("pk", bridge.uuid())
                                          .withClusteringKey("col1", type1)
                                          .withColumn("a", bridge.tuple(bridge.aInt(), type2, bridge.bigint())))
-                      .run()
-            );
+                      .run();
+            });
     }
 
     @ParameterizedTest
@@ -1321,7 +1318,7 @@ public class EndToEndTests
         // Test tuples nested within tuple
         qt().withExamples(10)
             .forAll(TestUtils.cql3Type(bridge), TestUtils.cql3Type(bridge))
-            .checkAssert((type1, type2) ->
+            .checkAssert((type1, type2) -> {
                 Tester.builder(TestSchema.builder()
                                          .withPartitionKey("pk", bridge.uuid())
                                          .withColumn("a", bridge.tuple(bridge.varchar(),
@@ -1333,8 +1330,8 @@ public class EndToEndTests
                                                                                                  bridge.bool(),
                                                                                                  type2)),
                                                                        bridge.timeuuid())))
-                      .run()
-            );
+                      .run();
+            });
     }
 
     @ParameterizedTest
@@ -1345,7 +1342,7 @@ public class EndToEndTests
         // Test set nested within tuple
         qt().withExamples(10)
             .forAll(TestUtils.cql3Type(bridge))
-            .checkAssert(type ->
+            .checkAssert(type -> {
                 Tester.builder(TestSchema.builder()
                                          .withPartitionKey("pk", bridge.uuid())
                                          .withColumn("a", bridge.tuple(bridge.varchar(),
@@ -1355,8 +1352,8 @@ public class EndToEndTests
                                                                                     bridge.varchar(),
                                                                                     bridge.set(type)),
                                                                        bridge.timeuuid())))
-                      .run()
-            );
+                      .run();
+            });
     }
 
     @ParameterizedTest
@@ -1367,7 +1364,7 @@ public class EndToEndTests
         // Test list nested within tuple
         qt().withExamples(10)
             .forAll(TestUtils.cql3Type(bridge))
-            .checkAssert(type ->
+            .checkAssert(type -> {
                 Tester.builder(TestSchema.builder()
                                          .withPartitionKey("pk", bridge.uuid())
                                          .withColumn("a", bridge.tuple(bridge.varchar(),
@@ -1377,8 +1374,8 @@ public class EndToEndTests
                                                                                     bridge.varchar(),
                                                                                     bridge.list(type)),
                                                                        bridge.timeuuid())))
-                      .run()
-            );
+                      .run();
+            });
     }
 
     @ParameterizedTest
@@ -1389,18 +1386,18 @@ public class EndToEndTests
         // Test map nested within tuple
         qt().withExamples(10)
             .forAll(TestUtils.cql3Type(bridge), TestUtils.cql3Type(bridge))
-            .checkAssert((type1, type2) ->
+            .checkAssert((type1, type2) -> {
                 Tester.builder(TestSchema.builder()
-                                        .withPartitionKey("pk", bridge.uuid())
-                                        .withColumn("a", bridge.tuple(bridge.varchar(),
-                                                                      bridge.tuple(bridge.aInt(),
-                                                                                   bridge.varchar(),
-                                                                                   bridge.aFloat(),
-                                                                                   bridge.varchar(),
-                                                                                   bridge.map(type1, type2)),
-                                                                                   bridge.timeuuid())))
-                      .run()
-            );
+                                         .withPartitionKey("pk", bridge.uuid())
+                                         .withColumn("a", bridge.tuple(bridge.varchar(),
+                                                                       bridge.tuple(bridge.aInt(),
+                                                                                    bridge.varchar(),
+                                                                                    bridge.aFloat(),
+                                                                                    bridge.varchar(),
+                                                                                    bridge.map(type1, type2)),
+                                                                       bridge.timeuuid())))
+                      .run();
+            });
     }
 
     @ParameterizedTest
@@ -1411,15 +1408,15 @@ public class EndToEndTests
         // Test tuple nested within map
         qt().withExamples(10)
             .forAll(TestUtils.cql3Type(bridge))
-            .checkAssert(type ->
+            .checkAssert(type -> {
                 Tester.builder(TestSchema.builder()
                                          .withPartitionKey("pk", bridge.uuid())
                                          .withColumn("a", bridge.map(bridge.timeuuid(),
                                                                      bridge.tuple(bridge.bool(),
                                                                                   type,
                                                                                   bridge.timestamp()).frozen())))
-                      .run()
-            );
+                      .run();
+            });
     }
 
     @ParameterizedTest
@@ -1430,14 +1427,14 @@ public class EndToEndTests
         // Test tuple nested within set
         qt().withExamples(10)
             .forAll(TestUtils.cql3Type(bridge))
-            .checkAssert(type ->
+            .checkAssert(type -> {
                 Tester.builder(TestSchema.builder()
                                          .withPartitionKey("pk", bridge.uuid())
                                          .withColumn("a", bridge.set(bridge.tuple(type,
                                                                                   bridge.aFloat(),
                                                                                   bridge.text()).frozen())))
-                      .run()
-            );
+                      .run();
+            });
     }
 
     @ParameterizedTest
@@ -1448,15 +1445,15 @@ public class EndToEndTests
         // Test tuple nested within map
         qt().withExamples(10)
             .forAll(TestUtils.cql3Type(bridge))
-            .checkAssert(type ->
+            .checkAssert(type -> {
                 Tester.builder(TestSchema.builder()
                                          .withPartitionKey("pk", bridge.uuid())
                                          .withColumn("a", bridge.list(bridge.tuple(bridge.aInt(),
                                                                                    bridge.inet(),
                                                                                    bridge.decimal(),
                                                                                    type).frozen())))
-                      .run()
-            );
+                      .run();
+            });
     }
 
     @ParameterizedTest
@@ -1467,7 +1464,7 @@ public class EndToEndTests
         // Test tuple with inner UDT
         qt().withExamples(10)
             .forAll(TestUtils.cql3Type(bridge))
-            .checkAssert(type ->
+            .checkAssert(type -> {
                 Tester.builder(TestSchema.builder()
                                          .withPartitionKey("pk", bridge.uuid())
                                          .withColumn("a", bridge.tuple(bridge.varchar(),
@@ -1477,8 +1474,8 @@ public class EndToEndTests
                                                                              .withField("z", bridge.aInt())
                                                                              .build().frozen(),
                                                                        bridge.timeuuid())))
-                      .run()
-            );
+                      .run();
+            });
     }
 
     @ParameterizedTest
@@ -1489,7 +1486,7 @@ public class EndToEndTests
         // Test UDT with inner tuple
         qt().withExamples(10)
             .forAll(TestUtils.cql3Type(bridge))
-            .checkAssert(type ->
+            .checkAssert(type -> {
                 Tester.builder(TestSchema.builder()
                                          .withPartitionKey("pk", bridge.uuid())
                                          .withColumn("a", bridge.udt("keyspace", "nested_udt")
@@ -1500,8 +1497,8 @@ public class EndToEndTests
                                                                                              bridge.timestamp()))
                                                                 .withField("z", bridge.ascii())
                                                                 .build()))
-                      .run()
-            );
+                      .run();
+            });
     }
 
     @ParameterizedTest
@@ -1509,7 +1506,7 @@ public class EndToEndTests
     public void testTupleClusteringKey(CassandraBridge bridge)
     {
         qt().forAll(TestUtils.cql3Type(bridge))
-            .checkAssert(type ->
+            .checkAssert(type -> {
                 Tester.builder(TestSchema.builder()
                                          .withPartitionKey("pk", bridge.uuid())
                                          .withClusteringKey("ck", bridge.tuple(bridge.aInt(),
@@ -1519,8 +1516,8 @@ public class EndToEndTests
                                          .withColumn("a", bridge.text())
                                          .withColumn("b", bridge.aInt())
                                          .withColumn("c", bridge.ascii()))
-                      .run()
-            );
+                      .run();
+            });
     }
 
     @ParameterizedTest
@@ -1528,7 +1525,7 @@ public class EndToEndTests
     public void testUdtClusteringKey(CassandraBridge bridge)
     {
         qt().forAll(TestUtils.cql3Type(bridge))
-            .checkAssert(type ->
+            .checkAssert(type -> {
                 Tester.builder(TestSchema.builder()
                                          .withPartitionKey("pk", bridge.uuid())
                                          .withClusteringKey("ck", bridge.udt("keyspace", "udt1")
@@ -1539,8 +1536,8 @@ public class EndToEndTests
                                          .withColumn("a", bridge.text())
                                          .withColumn("b", bridge.aInt())
                                          .withColumn("c", bridge.ascii()))
-                      .run()
-            );
+                      .run();
+            });
     }
 
     @ParameterizedTest
@@ -1550,32 +1547,32 @@ public class EndToEndTests
         String keyspace = "complex_schema2";
         CqlField.CqlUdt udt1 = bridge.udt(keyspace, "udt1")
                                      .withField("time", bridge.bigint())
-                                     .withField("\"time_offset_minutes\"", bridge.aInt())
+                                     .withField("time_offset_minutes", bridge.aInt())
                                      .build();
         CqlField.CqlUdt udt2 = bridge.udt(keyspace, "udt2")
-                                     .withField("\"version\"", bridge.text())
-                                     .withField("\"id\"", bridge.text())
+                                     .withField("version", bridge.text())
+                                     .withField("id", bridge.text())
                                      .withField("platform", bridge.text())
                                      .withField("time_range", bridge.text())
                                      .build();
         CqlField.CqlUdt udt3 = bridge.udt(keyspace, "udt3")
                                      .withField("field", bridge.text())
-                                     .withField("\"time_with_zone\"", udt1)
+                                     .withField("time_with_zone", udt1)
                                      .build();
         CqlField.CqlUdt udt4 = bridge.udt(keyspace, "udt4")
-                                     .withField("\"first_seen\"", udt3.frozen())
-                                     .withField("\"last_seen\"", udt3.frozen())
-                                     .withField("\"first_transaction\"", udt3.frozen())
-                                     .withField("\"last_transaction\"", udt3.frozen())
-                                     .withField("\"first_listening\"", udt3.frozen())
-                                     .withField("\"last_listening\"", udt3.frozen())
-                                     .withField("\"first_reading\"", udt3.frozen())
-                                     .withField("\"last_reading\"", udt3.frozen())
-                                     .withField("\"output_event\"", bridge.text())
-                                     .withField("\"event_history\"", bridge.map(bridge.bigint(),
-                                                                                bridge.map(bridge.text(),
-                                                                                           bridge.bool()).frozen()
-                                                                               ).frozen())
+                                     .withField("first_seen", udt3.frozen())
+                                     .withField("last_seen", udt3.frozen())
+                                     .withField("first_transaction", udt3.frozen())
+                                     .withField("last_transaction", udt3.frozen())
+                                     .withField("first_listening", udt3.frozen())
+                                     .withField("last_listening", udt3.frozen())
+                                     .withField("first_reading", udt3.frozen())
+                                     .withField("last_reading", udt3.frozen())
+                                     .withField("output_event", bridge.text())
+                                     .withField("event_history", bridge.map(bridge.bigint(),
+                                                                            bridge.map(bridge.text(),
+                                                                                       bridge.bool()).frozen()
+                                     ).frozen())
                                      .build();
 
         Tester.builder(keyspace1 -> TestSchema.builder()
@@ -1632,7 +1629,7 @@ public class EndToEndTests
                                      .withField("c", bridge.uuid())
                                      .withField("d", bridge.list(bridge.tuple(bridge.text(),
                                                                               bridge.bigint()).frozen()
-                                                                             ).frozen())
+                                     ).frozen())
                                      .build();
         CqlField.CqlUdt udt5 = bridge.udt(keyspace, "udt5")
                                      .withField("a", bridge.text())
@@ -1791,8 +1788,8 @@ public class EndToEndTests
                   for (UUID pk : udtSetValues.keySet())
                   {
                       Set<Object> udtSet = udtSetValues.get(pk).stream()
-                                                               .map(map ->  bridge.toUserTypeValue(udtType, map))
-                                                               .collect(Collectors.toSet());
+                                                       .map(map -> bridge.toUserTypeValue(udtType, map))
+                                                       .collect(Collectors.toSet());
                       Object tuple = bridge.toTupleValue(tupleType, tupleValues.get(pk));
 
                       writer.write(pk, udtSet, tuple);
@@ -1851,19 +1848,19 @@ public class EndToEndTests
                   for (long pk = 0; pk < Tester.DEFAULT_NUM_ROWS; pk++)
                   {
                       Map<String, Object> value = ImmutableMap.of(
-                            pk < midPoint ? "a" : "b", RandomUtils.randomValue(bridge.text()).toString(),
-                            "c", RandomUtils.randomValue(bridge.text()).toString());
+                      pk < midPoint ? "a" : "b", RandomUtils.randomValue(bridge.text()).toString(),
+                      "c", RandomUtils.randomValue(bridge.text()).toString());
                       values.put(pk, value);
                       writer.write(pk, bridge.toUserTypeValue(type, value),
-                                       RandomUtils.randomValue(bridge.text()),
-                                       RandomUtils.randomValue(bridge.timestamp()),
-                                       RandomUtils.randomValue(bridge.aInt()));
+                                   RandomUtils.randomValue(bridge.text()),
+                                   RandomUtils.randomValue(bridge.timestamp()),
+                                   RandomUtils.randomValue(bridge.aInt()));
                   }
               })
               .withCheck(dataset -> {
                   Map<Long, Row> rows = dataset.collectAsList().stream()
-                                                               .collect(Collectors.toMap(row -> row.getLong(0),
-                                                                                         row -> row.getStruct(1)));
+                                               .collect(Collectors.toMap(row -> row.getLong(0),
+                                                                         row -> row.getStruct(1)));
                   assertEquals(values.size(), rows.size());
                   for (Map.Entry<Long, Row> pk : rows.entrySet())
                   {
@@ -1971,7 +1968,7 @@ public class EndToEndTests
     public void testLargeBlobExclude(CassandraBridge bridge)
     {
         qt().forAll(booleans().all())
-            .checkAssert(enableCompression ->
+            .checkAssert(enableCompression -> {
                 Tester.builder(TestSchema.builder()
                                          .withPartitionKey("pk", bridge.uuid())
                                          .withClusteringKey("ck", bridge.aInt())
@@ -2005,8 +2002,8 @@ public class EndToEndTests
                           assertTrue(skippedRangeBytes.get() > 5_000_000);
                       })
                       .withReset(EndToEndTests::resetStats)
-                      .run()
-            );
+                      .run();
+            });
     }
 
     @ParameterizedTest
@@ -2391,6 +2388,114 @@ public class EndToEndTests
                       assertTrue(observedLMT.add(lmt), "Observed a duplicated LMT");
                   }
               })
+              .run();
+    }
+
+    /* Identifiers That Need Quoting Tests */
+
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
+    public void testQuotedKeyspaceName(CassandraBridge bridge)
+    {
+        Tester.builder(keyspace1 -> TestSchema.builder()
+                                              .withKeyspace("\"Quoted_Keyspace_" + UUID.randomUUID().toString().replaceAll("-", "_") + "\"")
+                                              .withPartitionKey("pk", bridge.uuid())
+                                              .withColumn("c1", bridge.varint())
+                                              .withColumn("c2", bridge.text()))
+              .run();
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
+    public void testReservedWordKeyspaceName(CassandraBridge bridge)
+    {
+        Tester.builder(keyspace1 -> TestSchema.builder()
+                                              .withKeyspace("\"keyspace\"")
+                                              .withPartitionKey("pk", bridge.uuid())
+                                              .withColumn("c1", bridge.varint())
+                                              .withColumn("c2", bridge.text()))
+              .run();
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
+    public void testQuotedTableName(CassandraBridge bridge)
+    {
+        Tester.builder(keyspace1 -> TestSchema.builder()
+                                              .withKeyspace("\"Quoted_Keyspace_" + UUID.randomUUID().toString().replaceAll("-", "_") + "\"")
+                                              .withTable("\"Quoted_Table_" + UUID.randomUUID().toString().replaceAll("-", "_") + "\"")
+                                              .withPartitionKey("pk", bridge.uuid())
+                                              .withColumn("c1", bridge.varint())
+                                              .withColumn("c2", bridge.text()))
+              .run();
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
+    public void testReservedWordTableName(CassandraBridge bridge)
+    {
+        Tester.builder(keyspace1 -> TestSchema.builder()
+                                              .withKeyspace("\"Quoted_Keyspace_" + UUID.randomUUID().toString().replaceAll("-", "_") + "\"")
+                                              .withTable("\"table\"")
+                                              .withPartitionKey("pk", bridge.uuid())
+                                              .withColumn("c1", bridge.varint())
+                                              .withColumn("c2", bridge.text()))
+              .run();
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
+    public void testQuotedPartitionKey(CassandraBridge bridge)
+    {
+        Tester.builder(keyspace1 -> TestSchema.builder()
+                                              .withKeyspace("\"Quoted_Keyspace_" + UUID.randomUUID().toString().replaceAll("-", "_") + "\"")
+                                              .withTable("\"Quoted_Table_" + UUID.randomUUID().toString().replaceAll("-", "_") + "\"")
+                                              .withPartitionKey("\"Partition_Key_0\"", bridge.uuid())
+                                              .withColumn("c1", bridge.varint())
+                                              .withColumn("c2", bridge.text()))
+              .run();
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
+    public void testMultipleQuotedPartitionKeys(CassandraBridge bridge)
+    {
+        Tester.builder(keyspace1 -> TestSchema.builder()
+                                              .withKeyspace("\"Quoted_Keyspace_" + UUID.randomUUID().toString().replaceAll("-", "_") + "\"")
+                                              .withTable("\"Quoted_Table_" + UUID.randomUUID().toString().replaceAll("-", "_") + "\"")
+                                              .withPartitionKey("\"Partition_Key_0\"", bridge.uuid())
+                                              .withPartitionKey("\"Partition_Key_1\"", bridge.bigint())
+                                              .withColumn("c", bridge.text())
+                                              .withColumn("d", bridge.bigint()))
+              .withExpectedRowCountPerSSTable(Tester.DEFAULT_NUM_ROWS)
+              .withSumField("d")
+              .run();
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
+    public void testQuotedPartitionClusteringKeys(CassandraBridge bridge)
+    {
+        Tester.builder(keyspace1 -> TestSchema.builder()
+                                              .withKeyspace("\"Quoted_Keyspace_" + UUID.randomUUID().toString().replaceAll("-", "_") + "\"")
+                                              .withTable("\"Quoted_Table_" + UUID.randomUUID().toString().replaceAll("-", "_") + "\"")
+                                              .withPartitionKey("a", bridge.uuid())
+                                              .withClusteringKey("\"Clustering_Key_0\"", bridge.bigint())
+                                              .withClusteringKey("\"Clustering_Key_1\"", bridge.text()))
+              .withExpectedRowCountPerSSTable(Tester.DEFAULT_NUM_ROWS)
+              .run();
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
+    public void testQuotedColumnNames(CassandraBridge bridge)
+    {
+        Tester.builder(keyspace1 -> TestSchema.builder()
+                                              .withKeyspace("\"Quoted_Keyspace_" + UUID.randomUUID().toString().replaceAll("-", "_") + "\"")
+                                              .withTable("\"Quoted_Table_" + UUID.randomUUID().toString().replaceAll("-", "_") + "\"")
+                                              .withPartitionKey("\"Partition_Key_0\"", bridge.uuid())
+                                              .withColumn("\"Column_1\"", bridge.varint())
+                                              .withColumn("\"Column_2\"", bridge.text()))
               .run();
     }
 }

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/EndToEndTests.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/EndToEndTests.java
@@ -83,7 +83,7 @@ public class EndToEndTests
     @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
     public void testSinglePartitionKey(CassandraBridge bridge)
     {
-        Tester.builder(TestSchema.builder()
+        Tester.builder(TestSchema.builder(bridge)
                                  .withPartitionKey("pk", bridge.uuid())
                                  .withColumn("c1", bridge.bigint())
                                  .withColumn("c2", bridge.text()))
@@ -97,11 +97,11 @@ public class EndToEndTests
     public void testOnlyPartitionKeys(CassandraBridge bridge)
     {
         // Special case where schema is only partition keys
-        Tester.builder(TestSchema.builder()
+        Tester.builder(TestSchema.builder(bridge)
                                  .withPartitionKey("a", bridge.uuid()))
               .withExpectedRowCountPerSSTable(Tester.DEFAULT_NUM_ROWS)
               .run();
-        Tester.builder(TestSchema.builder()
+        Tester.builder(TestSchema.builder(bridge)
                                  .withPartitionKey("a", bridge.uuid())
                                  .withPartitionKey("b", bridge.bigint()))
               .withExpectedRowCountPerSSTable(Tester.DEFAULT_NUM_ROWS)
@@ -112,7 +112,7 @@ public class EndToEndTests
     @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
     public void testOnlyPartitionClusteringKeys(CassandraBridge bridge)
     {
-        Tester.builder(TestSchema.builder()
+        Tester.builder(TestSchema.builder(bridge)
                                  .withPartitionKey("a", bridge.uuid())
                                  .withClusteringKey("b", bridge.bigint())
                                  .withClusteringKey("c", bridge.text()))
@@ -124,7 +124,7 @@ public class EndToEndTests
     @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
     public void testMultiplePartitionKeys(CassandraBridge bridge)
     {
-        Tester.builder(TestSchema.builder()
+        Tester.builder(TestSchema.builder(bridge)
                                  .withPartitionKey("a", bridge.uuid())
                                  .withPartitionKey("b", bridge.bigint())
                                  .withColumn("c", bridge.text())
@@ -140,7 +140,7 @@ public class EndToEndTests
     @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
     public void testBasicSingleClusteringKey(CassandraBridge bridge)
     {
-        Tester.builder(TestSchema.builder()
+        Tester.builder(TestSchema.builder(bridge)
                                  .withPartitionKey("a", bridge.bigint())
                                  .withClusteringKey("b", bridge.bigint())
                                  .withColumn("c", bridge.bigint()))
@@ -155,7 +155,7 @@ public class EndToEndTests
     {
         qt().forAll(TestUtils.cql3Type(bridge), TestUtils.sortOrder())
             .checkAssert((clusteringKeyType, sortOrder) ->
-                Tester.builder(TestSchema.builder()
+                Tester.builder(TestSchema.builder(bridge)
                                          .withPartitionKey("a", bridge.bigint())
                                          .withClusteringKey("b", clusteringKeyType)
                                          .withColumn("c", bridge.bigint())
@@ -169,7 +169,7 @@ public class EndToEndTests
     @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
     public void testMultipleClusteringKeys(CassandraBridge bridge)
     {
-        Tester.builder(TestSchema.builder()
+        Tester.builder(TestSchema.builder(bridge)
                                  .withPartitionKey("a", bridge.uuid())
                                  .withClusteringKey("b", bridge.aInt())
                                  .withClusteringKey("c", bridge.text())
@@ -184,7 +184,7 @@ public class EndToEndTests
     @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
     public void testManyClusteringKeys(CassandraBridge bridge)
     {
-        Tester.builder(TestSchema.builder()
+        Tester.builder(TestSchema.builder(bridge)
                                  .withPartitionKey("a", bridge.uuid())
                                  .withClusteringKey("b", bridge.timestamp())
                                  .withClusteringKey("c", bridge.text())
@@ -208,7 +208,7 @@ public class EndToEndTests
             .checkAssert(partitionKeyType -> {
                 // Boolean or empty types have limited cardinality
                 int numRows = partitionKeyType.cardinality(10);
-                Tester.builder(TestSchema.builder()
+                Tester.builder(TestSchema.builder(bridge)
                                          .withPartitionKey("a", partitionKeyType)
                                          .withColumn("b", bridge.bigint()))
                       .withNumRandomSSTables(1)
@@ -225,7 +225,7 @@ public class EndToEndTests
         // Test value column can be read for all data types
         qt().forAll(TestUtils.cql3Type(bridge))
             .checkAssert(valueType ->
-                Tester.builder(TestSchema.builder()
+                Tester.builder(TestSchema.builder(bridge)
                                          .withPartitionKey("a", bridge.bigint())
                                          .withColumn("b", valueType))
                       .withNumRandomSSTables(1)
@@ -244,7 +244,7 @@ public class EndToEndTests
         AtomicLong newTotal = new AtomicLong(0);
         Map<UUID, Long> column1 = new HashMap<>(Tester.DEFAULT_NUM_ROWS);
         Map<UUID, String> column2 = new HashMap<>(Tester.DEFAULT_NUM_ROWS);
-        Tester.builder(TestSchema.builder()
+        Tester.builder(TestSchema.builder(bridge)
                                  .withPartitionKey("pk", bridge.uuid())
                                  .withColumn("c1", bridge.bigint())
                                  .withColumn("c2", bridge.text()))
@@ -301,7 +301,7 @@ public class EndToEndTests
     {
         int numRowsColumns = 20;
         AtomicInteger total = new AtomicInteger(0);
-        Tester.builder(TestSchema.builder()
+        Tester.builder(TestSchema.builder(bridge)
                                  .withPartitionKey("a", bridge.aInt())
                                  .withClusteringKey("b", bridge.aInt())
                                  .withColumn("c", bridge.aInt()))
@@ -361,7 +361,7 @@ public class EndToEndTests
             testSum.put(clusteringKey, new MutableLong(0));
         }
 
-        Tester.builder(TestSchema.builder()
+        Tester.builder(TestSchema.builder(bridge)
                                  .withPartitionKey("a", bridge.uuid())
                                  .withClusteringKey("b", bridge.aInt())
                                  .withColumn("c", bridge.bigint())
@@ -420,7 +420,7 @@ public class EndToEndTests
     @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
     public void testOnlyStaticColumn(CassandraBridge bridge)
     {
-        Tester.builder(TestSchema.builder()
+        Tester.builder(TestSchema.builder(bridge)
                                  .withPartitionKey("a", bridge.uuid())
                                  .withClusteringKey("b", bridge.bigint())
                                  .withStaticColumn("c", bridge.aInt()))
@@ -435,7 +435,7 @@ public class EndToEndTests
     {
         int numRows = 100;
         int numColumns = 20;
-        Tester.builder(TestSchema.builder()
+        Tester.builder(TestSchema.builder(bridge)
                                  .withPartitionKey("a", bridge.aInt())
                                  .withClusteringKey("b", bridge.aInt())
                                  .withStaticColumn("c", bridge.aInt())
@@ -486,7 +486,7 @@ public class EndToEndTests
     public void testNulledStaticColumns(CassandraBridge bridge)
     {
         int numClusteringKeys = 10;
-        Tester.builder(TestSchema.builder()
+        Tester.builder(TestSchema.builder(bridge)
                                  .withPartitionKey("a", bridge.uuid())
                                  .withClusteringKey("b", bridge.aInt())
                                  .withStaticColumn("c", bridge.text())
@@ -521,7 +521,7 @@ public class EndToEndTests
     public void testMultipleSSTableCompacted(CassandraVersion version)
     {
         CassandraBridge bridge = CassandraBridgeFactory.get(version);
-        TestSchema.Builder schemaBuilder = TestSchema.builder()
+        TestSchema.Builder schemaBuilder = TestSchema.builder(bridge)
                                                      .withPartitionKey("a", bridge.uuid())
                                                      .withClusteringKey("b", bridge.aInt())
                                                      .withClusteringKey("c", bridge.text())
@@ -741,7 +741,7 @@ public class EndToEndTests
                 assertTrue(endBound >= startBound && endBound <= numColumns);
                 int numTombstones = endBound - startBound;
 
-                Tester.builder(TestSchema.builder()
+                Tester.builder(TestSchema.builder(bridge)
                                          .withPartitionKey("a", bridge.aInt())
                                          .withClusteringKey("b", bridge.text())
                                          .withColumn("c", bridge.aInt())
@@ -788,7 +788,7 @@ public class EndToEndTests
     public void testPartialRow(CassandraBridge bridge)
     {
         Map<UUID, UUID> rows = new HashMap<>();
-        Tester.builder(TestSchema.builder()
+        Tester.builder(TestSchema.builder(bridge)
                                  .withPartitionKey("a", bridge.uuid())
                                  .withColumn("b", bridge.text())
                                  .withColumn("c", bridge.uuid())
@@ -830,7 +830,7 @@ public class EndToEndTests
     public void testPartialRowClusteringKeys(CassandraBridge bridge)
     {
         Map<String, String> rows = new HashMap<>();
-        Tester.builder(TestSchema.builder()
+        Tester.builder(TestSchema.builder(bridge)
                                  .withPartitionKey("a", bridge.uuid())
                                  .withClusteringKey("b", bridge.uuid())
                                  .withClusteringKey("c", bridge.uuid())
@@ -885,7 +885,7 @@ public class EndToEndTests
     {
         qt().forAll(TestUtils.cql3Type(bridge))
             .checkAssert(type ->
-                Tester.builder(TestSchema.builder()
+                Tester.builder(TestSchema.builder(bridge)
                                          .withPartitionKey("pk", bridge.uuid())
                                          .withColumn("a", bridge.set(type)))
                       .withExpectedRowCountPerSSTable(Tester.DEFAULT_NUM_ROWS)
@@ -899,7 +899,7 @@ public class EndToEndTests
     {
         qt().forAll(TestUtils.cql3Type(bridge))
             .checkAssert(type ->
-                Tester.builder(TestSchema.builder()
+                Tester.builder(TestSchema.builder(bridge)
                                          .withPartitionKey("pk", bridge.uuid())
                                          .withColumn("a", bridge.list(type)))
                       .withExpectedRowCountPerSSTable(Tester.DEFAULT_NUM_ROWS)
@@ -914,7 +914,7 @@ public class EndToEndTests
         qt().withExamples(50)  // Limit number of tests otherwise n x n tests takes too long
             .forAll(TestUtils.cql3Type(bridge), TestUtils.cql3Type(bridge))
             .checkAssert((keyType, valueType) ->
-                Tester.builder(TestSchema.builder()
+                Tester.builder(TestSchema.builder(bridge)
                                          .withPartitionKey("pk", bridge.uuid())
                                          .withColumn("a", bridge.map(keyType, valueType)))
                       .withExpectedRowCountPerSSTable(Tester.DEFAULT_NUM_ROWS)
@@ -926,7 +926,7 @@ public class EndToEndTests
     @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
     public void testClusteringKeySet(CassandraBridge bridge)
     {
-        Tester.builder(TestSchema.builder()
+        Tester.builder(TestSchema.builder(bridge)
                                  .withPartitionKey("pk", bridge.uuid())
                                  .withClusteringKey("id", bridge.aInt())
                                  .withColumn("a", bridge.set(bridge.text())))
@@ -943,7 +943,7 @@ public class EndToEndTests
         // pk -> a frozen<set<?>>
         qt().forAll(TestUtils.cql3Type(bridge))
             .checkAssert(type ->
-                Tester.builder(TestSchema.builder()
+                Tester.builder(TestSchema.builder(bridge)
                                          .withPartitionKey("pk", bridge.uuid())
                                          .withColumn("a", bridge.set(type).frozen()))
                       .withExpectedRowCountPerSSTable(Tester.DEFAULT_NUM_ROWS)
@@ -958,7 +958,7 @@ public class EndToEndTests
         // pk -> a frozen<list<?>>
         qt().forAll(TestUtils.cql3Type(bridge))
             .checkAssert(type ->
-                Tester.builder(TestSchema.builder()
+                Tester.builder(TestSchema.builder(bridge)
                                          .withPartitionKey("pk", bridge.uuid())
                                          .withColumn("a", bridge.list(type).frozen()))
                       .withExpectedRowCountPerSSTable(Tester.DEFAULT_NUM_ROWS)
@@ -974,7 +974,7 @@ public class EndToEndTests
         qt().withExamples(50)  // Limit number of tests otherwise n x n tests takes too long
             .forAll(TestUtils.cql3Type(bridge), TestUtils.cql3Type(bridge))
             .checkAssert((keyType, valueType) ->
-                Tester.builder(TestSchema.builder()
+                Tester.builder(TestSchema.builder(bridge)
                                          .withPartitionKey("pk", bridge.uuid())
                                          .withColumn("a", bridge.map(keyType, valueType).frozen()))
                       .withExpectedRowCountPerSSTable(Tester.DEFAULT_NUM_ROWS)
@@ -987,7 +987,7 @@ public class EndToEndTests
     public void testNestedMapSet(CassandraBridge bridge)
     {
         // pk -> a map<text, frozen<set<text>>>
-        Tester.builder(TestSchema.builder()
+        Tester.builder(TestSchema.builder(bridge)
                                  .withPartitionKey("pk", bridge.uuid())
                                  .withColumn("a", bridge.map(bridge.text(), bridge.set(bridge.text()).frozen())))
               .withNumRandomRows(32)
@@ -1000,7 +1000,7 @@ public class EndToEndTests
     public void testNestedMapList(CassandraBridge bridge)
     {
         // pk -> a map<text, frozen<list<text>>>
-        Tester.builder(TestSchema.builder()
+        Tester.builder(TestSchema.builder(bridge)
                                  .withPartitionKey("pk", bridge.uuid())
                                  .withColumn("a", bridge.map(bridge.text(), bridge.list(bridge.text()).frozen())))
               .withNumRandomRows(32)
@@ -1013,7 +1013,7 @@ public class EndToEndTests
     public void testNestedMapMap(CassandraBridge bridge)
     {
         // pk -> a map<text, frozen<map<bigint, varchar>>>
-        Tester.builder(TestSchema.builder()
+        Tester.builder(TestSchema.builder(bridge)
                                  .withPartitionKey("pk", bridge.uuid())
                                  .withColumn("a", bridge.map(bridge.text(),
                                                   bridge.map(bridge.bigint(), bridge.varchar()).frozen())))
@@ -1028,7 +1028,7 @@ public class EndToEndTests
     public void testFrozenNestedMapMap(CassandraBridge bridge)
     {
         // pk -> a frozen<map<text, <map<int, timestamp>>>
-        Tester.builder(TestSchema.builder()
+        Tester.builder(TestSchema.builder(bridge)
                                  .withPartitionKey("pk", bridge.uuid())
                                  .withColumn("a", bridge.map(bridge.text(),
                                                              bridge.map(bridge.aInt(), bridge.timestamp())).frozen()))
@@ -1045,7 +1045,7 @@ public class EndToEndTests
     public void testSinglePartitionKeyFilter(CassandraBridge bridge)
     {
         int numRows = 10;
-        Tester.builder(TestSchema.builder()
+        Tester.builder(TestSchema.builder(bridge)
                                  .withPartitionKey("a", bridge.aInt())
                                  .withColumn("b", bridge.aInt()))
               .dontWriteRandomData()
@@ -1074,7 +1074,7 @@ public class EndToEndTests
         int numColumns = 5;
         Set<String> keys = TestUtils.getKeys(ImmutableList.of(ImmutableList.of("2", "3"),
                                                               ImmutableList.of("2", "3", "4")));
-        Tester.builder(TestSchema.builder()
+        Tester.builder(TestSchema.builder(bridge)
                                  .withPartitionKey("a", bridge.aInt())
                                  .withPartitionKey("b", bridge.aInt())
                                  .withColumn("c", bridge.aInt()))
@@ -1108,7 +1108,7 @@ public class EndToEndTests
     public void testFiltersDoNotMatch(CassandraBridge bridge)
     {
         int numRows = 10;
-        Tester.builder(TestSchema.builder()
+        Tester.builder(TestSchema.builder(bridge)
                                  .withPartitionKey("a", bridge.aInt())
                                  .withColumn("b", bridge.aInt()))
               .dontWriteRandomData()
@@ -1128,7 +1128,7 @@ public class EndToEndTests
     public void testFilterWithClusteringKey(CassandraBridge bridge)
     {
         int numRows = 10;
-        Tester.builder(TestSchema.builder()
+        Tester.builder(TestSchema.builder(bridge)
                                  .withPartitionKey("a", bridge.aInt())
                                  .withClusteringKey("b", bridge.text())
                                  .withClusteringKey("c", bridge.timestamp()))
@@ -1160,7 +1160,7 @@ public class EndToEndTests
         // pk -> a testudt<b text, c type, d int>
         qt().forAll(TestUtils.cql3Type(bridge))
             .checkAssert(type ->
-                Tester.builder(TestSchema.builder()
+                Tester.builder(TestSchema.builder(bridge)
                               .withPartitionKey("pk", bridge.uuid())
                               .withColumn("a", bridge.udt("keyspace", "testudt")
                                                      .withField("b", bridge.text())
@@ -1178,7 +1178,7 @@ public class EndToEndTests
         // pk -> a testudt<b text, c frozen<type>, d int>
         qt().forAll(TestUtils.cql3Type(bridge))
             .checkAssert(type ->
-                Tester.builder(TestSchema.builder()
+                Tester.builder(TestSchema.builder(bridge)
                                          .withPartitionKey("pk", bridge.uuid())
                                          .withColumn("a", bridge.udt("keyspace", "testudt")
                                                                 .withField("b", bridge.text())
@@ -1196,7 +1196,7 @@ public class EndToEndTests
         // pk -> a testudt<b bigint, c frozen<list<type>>, d boolean>
         qt().forAll(TestUtils.cql3Type(bridge))
             .checkAssert(type ->
-                Tester.builder(TestSchema.builder()
+                Tester.builder(TestSchema.builder(bridge)
                                          .withPartitionKey("pk", bridge.uuid())
                                          .withColumn("a", bridge.udt("keyspace", "testudt")
                                                                 .withField("b", bridge.bigint())
@@ -1215,7 +1215,7 @@ public class EndToEndTests
         qt().withExamples(50)
             .forAll(TestUtils.cql3Type(bridge), TestUtils.cql3Type(bridge))
             .checkAssert((type1, type2) ->
-                Tester.builder(TestSchema.builder()
+                Tester.builder(TestSchema.builder(bridge)
                                          .withPartitionKey("pk", bridge.uuid())
                                          .withColumn("a", bridge.udt("keyspace", "testudt")
                                                                 .withField("b", bridge.aFloat())
@@ -1235,7 +1235,7 @@ public class EndToEndTests
         //       col2 udt2<a text, b bigint, g varchar>, col3 udt3<int, type, ascii>
         qt().forAll(TestUtils.cql3Type(bridge))
             .checkAssert(type ->
-                Tester.builder(TestSchema.builder()
+                Tester.builder(TestSchema.builder(bridge)
                                          .withPartitionKey("pk", bridge.uuid())
                                          .withColumn("col1", bridge.udt("keyspace", "udt1")
                                                                    .withField("a", bridge.aFloat())
@@ -1264,7 +1264,7 @@ public class EndToEndTests
         // pk -> a test_udt<b float, c frozen<set<uuid>>, d frozen<nested_udt<x int, y type, z int>>, e boolean>
         qt().forAll(TestUtils.cql3Type(bridge))
             .checkAssert(type ->
-                Tester.builder(TestSchema.builder()
+                Tester.builder(TestSchema.builder(bridge)
                                          .withPartitionKey("pk", bridge.uuid())
                                          .withColumn("a", bridge.udt("keyspace", "test_udt")
                                                                 .withField("b", bridge.aFloat())
@@ -1290,7 +1290,7 @@ public class EndToEndTests
         qt().withExamples(10)
             .forAll(TestUtils.cql3Type(bridge), TestUtils.cql3Type(bridge))
             .checkAssert((type1, type2) ->
-                Tester.builder(TestSchema.builder()
+                Tester.builder(TestSchema.builder(bridge)
                                          .withPartitionKey("pk", bridge.uuid())
                                          .withColumn("a", bridge.tuple(bridge.aInt(), type1, bridge.bigint(), type2)))
                       .run()
@@ -1305,7 +1305,7 @@ public class EndToEndTests
         qt().withExamples(10)
             .forAll(TestUtils.cql3Type(bridge), TestUtils.cql3Type(bridge))
             .checkAssert((type1, type2) ->
-                Tester.builder(TestSchema.builder()
+                Tester.builder(TestSchema.builder(bridge)
                                          .withPartitionKey("pk", bridge.uuid())
                                          .withClusteringKey("col1", type1)
                                          .withColumn("a", bridge.tuple(bridge.aInt(), type2, bridge.bigint())))
@@ -1322,7 +1322,7 @@ public class EndToEndTests
         qt().withExamples(10)
             .forAll(TestUtils.cql3Type(bridge), TestUtils.cql3Type(bridge))
             .checkAssert((type1, type2) ->
-                Tester.builder(TestSchema.builder()
+                Tester.builder(TestSchema.builder(bridge)
                                          .withPartitionKey("pk", bridge.uuid())
                                          .withColumn("a", bridge.tuple(bridge.varchar(),
                                                                        bridge.tuple(bridge.aInt(),
@@ -1346,7 +1346,7 @@ public class EndToEndTests
         qt().withExamples(10)
             .forAll(TestUtils.cql3Type(bridge))
             .checkAssert(type ->
-                Tester.builder(TestSchema.builder()
+                Tester.builder(TestSchema.builder(bridge)
                                          .withPartitionKey("pk", bridge.uuid())
                                          .withColumn("a", bridge.tuple(bridge.varchar(),
                                                                        bridge.tuple(bridge.aInt(),
@@ -1368,7 +1368,7 @@ public class EndToEndTests
         qt().withExamples(10)
             .forAll(TestUtils.cql3Type(bridge))
             .checkAssert(type ->
-                Tester.builder(TestSchema.builder()
+                Tester.builder(TestSchema.builder(bridge)
                                          .withPartitionKey("pk", bridge.uuid())
                                          .withColumn("a", bridge.tuple(bridge.varchar(),
                                                                        bridge.tuple(bridge.aInt(),
@@ -1390,7 +1390,7 @@ public class EndToEndTests
         qt().withExamples(10)
             .forAll(TestUtils.cql3Type(bridge), TestUtils.cql3Type(bridge))
             .checkAssert((type1, type2) ->
-                Tester.builder(TestSchema.builder()
+                Tester.builder(TestSchema.builder(bridge)
                                         .withPartitionKey("pk", bridge.uuid())
                                         .withColumn("a", bridge.tuple(bridge.varchar(),
                                                                       bridge.tuple(bridge.aInt(),
@@ -1412,7 +1412,7 @@ public class EndToEndTests
         qt().withExamples(10)
             .forAll(TestUtils.cql3Type(bridge))
             .checkAssert(type ->
-                Tester.builder(TestSchema.builder()
+                Tester.builder(TestSchema.builder(bridge)
                                          .withPartitionKey("pk", bridge.uuid())
                                          .withColumn("a", bridge.map(bridge.timeuuid(),
                                                                      bridge.tuple(bridge.bool(),
@@ -1431,7 +1431,7 @@ public class EndToEndTests
         qt().withExamples(10)
             .forAll(TestUtils.cql3Type(bridge))
             .checkAssert(type ->
-                Tester.builder(TestSchema.builder()
+                Tester.builder(TestSchema.builder(bridge)
                                          .withPartitionKey("pk", bridge.uuid())
                                          .withColumn("a", bridge.set(bridge.tuple(type,
                                                                                   bridge.aFloat(),
@@ -1449,7 +1449,7 @@ public class EndToEndTests
         qt().withExamples(10)
             .forAll(TestUtils.cql3Type(bridge))
             .checkAssert(type ->
-                Tester.builder(TestSchema.builder()
+                Tester.builder(TestSchema.builder(bridge)
                                          .withPartitionKey("pk", bridge.uuid())
                                          .withColumn("a", bridge.list(bridge.tuple(bridge.aInt(),
                                                                                    bridge.inet(),
@@ -1468,7 +1468,7 @@ public class EndToEndTests
         qt().withExamples(10)
             .forAll(TestUtils.cql3Type(bridge))
             .checkAssert(type ->
-                Tester.builder(TestSchema.builder()
+                Tester.builder(TestSchema.builder(bridge)
                                          .withPartitionKey("pk", bridge.uuid())
                                          .withColumn("a", bridge.tuple(bridge.varchar(),
                                                                        bridge.udt("keyspace", "nested_udt")
@@ -1490,7 +1490,7 @@ public class EndToEndTests
         qt().withExamples(10)
             .forAll(TestUtils.cql3Type(bridge))
             .checkAssert(type ->
-                Tester.builder(TestSchema.builder()
+                Tester.builder(TestSchema.builder(bridge)
                                          .withPartitionKey("pk", bridge.uuid())
                                          .withColumn("a", bridge.udt("keyspace", "nested_udt")
                                                                 .withField("x", bridge.text())
@@ -1510,7 +1510,7 @@ public class EndToEndTests
     {
         qt().forAll(TestUtils.cql3Type(bridge))
             .checkAssert(type ->
-                Tester.builder(TestSchema.builder()
+                Tester.builder(TestSchema.builder(bridge)
                                          .withPartitionKey("pk", bridge.uuid())
                                          .withClusteringKey("ck", bridge.tuple(bridge.aInt(),
                                                                                bridge.text(),
@@ -1529,7 +1529,7 @@ public class EndToEndTests
     {
         qt().forAll(TestUtils.cql3Type(bridge))
             .checkAssert(type ->
-                Tester.builder(TestSchema.builder()
+                Tester.builder(TestSchema.builder(bridge)
                                          .withPartitionKey("pk", bridge.uuid())
                                          .withClusteringKey("ck", bridge.udt("keyspace", "udt1")
                                                                         .withField("a", bridge.text())
@@ -1578,7 +1578,7 @@ public class EndToEndTests
                                      ).frozen())
                                      .build();
 
-        Tester.builder(keyspace1 -> TestSchema.builder()
+        Tester.builder(keyspace1 -> TestSchema.builder(bridge)
                                               .withKeyspace(keyspace1)
                                               .withPartitionKey("\"consumerId\"", bridge.text())
                                               .withClusteringKey("dimensions", udt2.frozen())
@@ -1601,7 +1601,7 @@ public class EndToEndTests
                                         .withField("b", bridge.bigint())
                                         .withField("c", bridge.aInt())
                                         .build();
-        Tester.builder(keyspace -> TestSchema.builder()
+        Tester.builder(keyspace -> TestSchema.builder(bridge)
                                              .withKeyspace(keyspace)
                                              .withPartitionKey("a", bridge.bigint())
                                              .withColumn("b", bridge.map(bridge.aInt(), testudt.frozen())))
@@ -1674,7 +1674,7 @@ public class EndToEndTests
                                      .withField("o", bridge.text())
                                      .build();
 
-        Tester.builder(keyspace1 -> TestSchema.builder()
+        Tester.builder(keyspace1 -> TestSchema.builder(bridge)
                                               .withKeyspace(keyspace1)
                                               .withPartitionKey("pk", bridge.uuid())
                                               .withClusteringKey("ck", bridge.uuid())
@@ -1712,7 +1712,7 @@ public class EndToEndTests
     @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
     public void testBigDecimal(CassandraBridge bridge)
     {
-        Tester.builder(TestSchema.builder()
+        Tester.builder(TestSchema.builder(bridge)
                                  .withPartitionKey("pk", bridge.uuid())
                                  .withColumn("c1", bridge.decimal())
                                  .withColumn("c2", bridge.text()))
@@ -1723,7 +1723,7 @@ public class EndToEndTests
     @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
     public void testBigInteger(CassandraBridge bridge)
     {
-        Tester.builder(TestSchema.builder()
+        Tester.builder(TestSchema.builder(bridge)
                                  .withPartitionKey("pk", bridge.uuid())
                                  .withColumn("c1", bridge.varint())
                                  .withColumn("c2", bridge.text()))
@@ -1740,7 +1740,7 @@ public class EndToEndTests
                                      .withField("b", bridge.uuid())
                                      .withField("a", bridge.bool())
                                      .build();
-        Tester.builder(keyspace1 -> TestSchema.builder()
+        Tester.builder(keyspace1 -> TestSchema.builder(bridge)
                                               .withKeyspace(keyspace1)
                                               .withPartitionKey("pk", bridge.uuid())
                                               .withColumn("a", bridge.set(udt1.frozen())))
@@ -1781,7 +1781,7 @@ public class EndToEndTests
             tupleValues.put(pk, tuple);
         }
 
-        Tester.builder(keyspace -> TestSchema.builder()
+        Tester.builder(keyspace -> TestSchema.builder(bridge)
                                              .withKeyspace(keyspace)
                                              .withPartitionKey("pk", bridge.uuid())
                                              .withColumn("a", bridge.set(udtType.frozen()))
@@ -1838,7 +1838,7 @@ public class EndToEndTests
                                      .build();
         Map<Long, Map<String, Object>> values = new HashMap<>(Tester.DEFAULT_NUM_ROWS);
 
-        Tester.builder(keyspace -> TestSchema.builder()
+        Tester.builder(keyspace -> TestSchema.builder(bridge)
                                              .withKeyspace(keyspace)
                                              .withPartitionKey("pk", bridge.bigint())
                                              .withClusteringKey("ck", type.frozen())
@@ -1879,7 +1879,7 @@ public class EndToEndTests
     @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
     public void testMapClusteringKey(CassandraBridge bridge)
     {
-        Tester.builder(TestSchema.builder()
+        Tester.builder(TestSchema.builder(bridge)
                                  .withPartitionKey("pk", bridge.uuid())
                                  .withClusteringKey("ck", bridge.map(bridge.bigint(), bridge.text()).frozen())
                                  .withColumn("c1", bridge.text())
@@ -1893,7 +1893,7 @@ public class EndToEndTests
     @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
     public void testListClusteringKey(CassandraBridge bridge)
     {
-        Tester.builder(TestSchema.builder()
+        Tester.builder(TestSchema.builder(bridge)
                                  .withPartitionKey("pk", bridge.uuid())
                                  .withClusteringKey("ck", bridge.list(bridge.bigint()).frozen())
                                  .withColumn("c1", bridge.text())
@@ -1906,7 +1906,7 @@ public class EndToEndTests
     @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
     public void testSetClusteringKey(CassandraBridge bridge)
     {
-        Tester.builder(TestSchema.builder()
+        Tester.builder(TestSchema.builder(bridge)
                                  .withPartitionKey("pk", bridge.uuid())
                                  .withClusteringKey("ck", bridge.set(bridge.aFloat()).frozen())
                                  .withColumn("c1", bridge.text())
@@ -1919,7 +1919,7 @@ public class EndToEndTests
     @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
     public void testUdTClusteringKey(CassandraBridge bridge)
     {
-        Tester.builder(keyspace -> TestSchema.builder()
+        Tester.builder(keyspace -> TestSchema.builder(bridge)
                                              .withKeyspace(keyspace)
                                              .withPartitionKey("pk", bridge.uuid())
                                              .withClusteringKey("ck", bridge.udt("udt_clustering_key", "udt1")
@@ -1972,7 +1972,7 @@ public class EndToEndTests
     {
         qt().forAll(booleans().all())
             .checkAssert(enableCompression ->
-                Tester.builder(TestSchema.builder()
+                Tester.builder(TestSchema.builder(bridge)
                                          .withPartitionKey("pk", bridge.uuid())
                                          .withClusteringKey("ck", bridge.aInt())
                                          .withColumn("a", bridge.bigint())
@@ -2013,7 +2013,7 @@ public class EndToEndTests
     @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
     public void testExcludeColumns(CassandraBridge bridge)
     {
-        Tester.builder(TestSchema.builder()
+        Tester.builder(TestSchema.builder(bridge)
                                  .withPartitionKey("pk", bridge.uuid())
                                  .withClusteringKey("ck", bridge.aInt())
                                  .withColumn("a", bridge.bigint())
@@ -2050,7 +2050,7 @@ public class EndToEndTests
     @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
     public void testUpsertExcludeColumns(CassandraBridge bridge)
     {
-        Tester.builder(TestSchema.builder()
+        Tester.builder(TestSchema.builder(bridge)
                                  .withPartitionKey("pk", bridge.uuid())
                                  .withClusteringKey("ck", bridge.aInt())
                                  .withColumn("a", bridge.bigint())
@@ -2089,7 +2089,7 @@ public class EndToEndTests
     public void testExcludeNoColumns(CassandraBridge bridge)
     {
         // Include all columns
-        Tester.builder(TestSchema.builder()
+        Tester.builder(TestSchema.builder(bridge)
                                  .withPartitionKey("pk", bridge.uuid())
                                  .withClusteringKey("ck", bridge.aInt())
                                  .withColumn("a", bridge.bigint())
@@ -2108,7 +2108,7 @@ public class EndToEndTests
     public void testUpsertExcludeNoColumns(CassandraBridge bridge)
     {
         // Include all columns
-        Tester.builder(TestSchema.builder()
+        Tester.builder(TestSchema.builder(bridge)
                                  .withPartitionKey("pk", bridge.uuid())
                                  .withClusteringKey("ck", bridge.aInt())
                                  .withColumn("a", bridge.bigint())
@@ -2128,7 +2128,7 @@ public class EndToEndTests
     public void testExcludeAllColumns(CassandraBridge bridge)
     {
         // Exclude all columns except for partition/clustering keys
-        Tester.builder(TestSchema.builder()
+        Tester.builder(TestSchema.builder(bridge)
                                  .withPartitionKey("pk", bridge.uuid())
                                  .withClusteringKey("ck", bridge.aInt())
                                  .withColumn("a", bridge.bigint())
@@ -2147,7 +2147,7 @@ public class EndToEndTests
     public void testUpsertExcludeAllColumns(CassandraBridge bridge)
     {
         // Exclude all columns except for partition/clustering keys
-        Tester.builder(TestSchema.builder()
+        Tester.builder(TestSchema.builder(bridge)
                                  .withPartitionKey("pk", bridge.uuid())
                                  .withClusteringKey("ck", bridge.aInt())
                                  .withColumn("a", bridge.bigint())
@@ -2166,7 +2166,7 @@ public class EndToEndTests
     @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
     public void testExcludePartitionOnly(CassandraBridge bridge)
     {
-        Tester.builder(TestSchema.builder()
+        Tester.builder(TestSchema.builder(bridge)
                                  .withPartitionKey("pk", bridge.uuid()))
               .withColumns("pk")
               .withExpectedRowCountPerSSTable(Tester.DEFAULT_NUM_ROWS)
@@ -2177,7 +2177,7 @@ public class EndToEndTests
     @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
     public void testExcludeKeysOnly(CassandraBridge bridge)
     {
-        Tester.builder(TestSchema.builder()
+        Tester.builder(TestSchema.builder(bridge)
                                  .withPartitionKey("pk", bridge.uuid())
                                  .withClusteringKey("ck1", bridge.text())
                                  .withClusteringKey("ck2", bridge.bigint()))
@@ -2190,7 +2190,7 @@ public class EndToEndTests
     @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
     public void testExcludeKeysStaticColumnOnly(CassandraBridge bridge)
     {
-        Tester.builder(TestSchema.builder()
+        Tester.builder(TestSchema.builder(bridge)
                                  .withPartitionKey("pk", bridge.uuid())
                                  .withClusteringKey("ck1", bridge.text())
                                  .withClusteringKey("ck2", bridge.bigint())
@@ -2205,7 +2205,7 @@ public class EndToEndTests
     public void testExcludeStaticColumn(CassandraBridge bridge)
     {
         // Exclude static columns
-        Tester.builder(TestSchema.builder()
+        Tester.builder(TestSchema.builder(bridge)
                                  .withPartitionKey("pk", bridge.uuid())
                                  .withClusteringKey("ck", bridge.aInt())
                                  .withStaticColumn("a", bridge.text())
@@ -2222,7 +2222,7 @@ public class EndToEndTests
     public void testUpsertExcludeStaticColumn(CassandraBridge bridge)
     {
         // Exclude static columns
-        Tester.builder(TestSchema.builder()
+        Tester.builder(TestSchema.builder(bridge)
                                  .withPartitionKey("pk", bridge.uuid())
                                  .withClusteringKey("ck", bridge.aInt())
                                  .withStaticColumn("a", bridge.text())
@@ -2243,7 +2243,7 @@ public class EndToEndTests
         int numColumns = 5;
         long leastExpectedTimestamp = Timestamp.from(Instant.now()).getTime();
         Set<Pair<Integer, Long>> observedLMT = new HashSet<>();
-        Tester.builder(TestSchema.builder()
+        Tester.builder(TestSchema.builder(bridge)
                                  .withPartitionKey("pk", bridge.aInt())
                                  .withClusteringKey("ck", bridge.aInt())
                                  .withStaticColumn("a", bridge.text()))
@@ -2279,7 +2279,7 @@ public class EndToEndTests
     @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
     public void testLastModifiedTimestampWithExcludeColumns(CassandraBridge bridge)
     {
-        Tester.builder(TestSchema.builder().withPartitionKey("pk", bridge.uuid())
+        Tester.builder(TestSchema.builder(bridge).withPartitionKey("pk", bridge.uuid())
                                  .withClusteringKey("ck", bridge.aInt())
                                  .withColumn("a", bridge.bigint())
                                  .withColumn("b", bridge.text())
@@ -2322,7 +2322,7 @@ public class EndToEndTests
         int numRows = 10;
         long leastExpectedTimestamp = Timestamp.from(Instant.now()).getTime();
         Set<Long> observedLMT = new HashSet<>();
-        Tester.builder(TestSchema.builder()
+        Tester.builder(TestSchema.builder(bridge)
                                  .withPartitionKey("pk", bridge.aInt())
                                  .withColumn("a", bridge.text())
                                  .withColumn("b", bridge.aDouble())
@@ -2363,7 +2363,7 @@ public class EndToEndTests
     {
         long leastExpectedTimestamp = Timestamp.from(Instant.now()).getTime();
         Set<Long> observedLMT = new HashSet<>();
-        Tester.builder(TestSchema.builder()
+        Tester.builder(TestSchema.builder(bridge)
                                  .withPartitionKey("pk", bridge.timeuuid())
                                  .withClusteringKey("ck", bridge.aInt())
                                  .withColumn("a", bridge.map(bridge.text(),
@@ -2400,8 +2400,8 @@ public class EndToEndTests
     @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
     public void testQuotedKeyspaceName(CassandraBridge bridge)
     {
-        Tester.builder(keyspace1 -> TestSchema.builder()
-                                              .withKeyspace("\"Quoted_Keyspace_" + UUID.randomUUID().toString().replaceAll("-", "_") + "\"")
+        Tester.builder(keyspace1 -> TestSchema.builder(bridge)
+                                              .withKeyspace("Quoted_Keyspace_" + UUID.randomUUID().toString().replaceAll("-", "_"))
                                               .withPartitionKey("pk", bridge.uuid())
                                               .withColumn("c1", bridge.varint())
                                               .withColumn("c2", bridge.text()))
@@ -2412,8 +2412,8 @@ public class EndToEndTests
     @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
     public void testReservedWordKeyspaceName(CassandraBridge bridge)
     {
-        Tester.builder(keyspace1 -> TestSchema.builder()
-                                              .withKeyspace("\"keyspace\"")
+        Tester.builder(keyspace1 -> TestSchema.builder(bridge)
+                                              .withKeyspace("keyspace")
                                               .withPartitionKey("pk", bridge.uuid())
                                               .withColumn("c1", bridge.varint())
                                               .withColumn("c2", bridge.text()))
@@ -2424,9 +2424,9 @@ public class EndToEndTests
     @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
     public void testQuotedTableName(CassandraBridge bridge)
     {
-        Tester.builder(keyspace1 -> TestSchema.builder()
-                                              .withKeyspace("\"Quoted_Keyspace_" + UUID.randomUUID().toString().replaceAll("-", "_") + "\"")
-                                              .withTable("\"Quoted_Table_" + UUID.randomUUID().toString().replaceAll("-", "_") + "\"")
+        Tester.builder(keyspace1 -> TestSchema.builder(bridge)
+                                              .withKeyspace("Quoted_Keyspace_" + UUID.randomUUID().toString().replaceAll("-", "_"))
+                                              .withTable("Quoted_Table_" + UUID.randomUUID().toString().replaceAll("-", "_"))
                                               .withPartitionKey("pk", bridge.uuid())
                                               .withColumn("c1", bridge.varint())
                                               .withColumn("c2", bridge.text()))
@@ -2437,9 +2437,9 @@ public class EndToEndTests
     @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
     public void testReservedWordTableName(CassandraBridge bridge)
     {
-        Tester.builder(keyspace1 -> TestSchema.builder()
-                                              .withKeyspace("\"Quoted_Keyspace_" + UUID.randomUUID().toString().replaceAll("-", "_") + "\"")
-                                              .withTable("\"table\"")
+        Tester.builder(keyspace1 -> TestSchema.builder(bridge)
+                                              .withKeyspace("Quoted_Keyspace_" + UUID.randomUUID().toString().replaceAll("-", "_"))
+                                              .withTable("table")
                                               .withPartitionKey("pk", bridge.uuid())
                                               .withColumn("c1", bridge.varint())
                                               .withColumn("c2", bridge.text()))
@@ -2450,10 +2450,10 @@ public class EndToEndTests
     @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
     public void testQuotedPartitionKey(CassandraBridge bridge)
     {
-        Tester.builder(keyspace1 -> TestSchema.builder()
-                                              .withKeyspace("\"Quoted_Keyspace_" + UUID.randomUUID().toString().replaceAll("-", "_") + "\"")
-                                              .withTable("\"Quoted_Table_" + UUID.randomUUID().toString().replaceAll("-", "_") + "\"")
-                                              .withPartitionKey("\"Partition_Key_0\"", bridge.uuid())
+        Tester.builder(keyspace1 -> TestSchema.builder(bridge)
+                                              .withKeyspace("Quoted_Keyspace_" + UUID.randomUUID().toString().replaceAll("-", "_"))
+                                              .withTable("Quoted_Table_" + UUID.randomUUID().toString().replaceAll("-", "_"))
+                                              .withPartitionKey("Partition_Key_0", bridge.uuid())
                                               .withColumn("c1", bridge.varint())
                                               .withColumn("c2", bridge.text()))
               .run();
@@ -2463,11 +2463,11 @@ public class EndToEndTests
     @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
     public void testMultipleQuotedPartitionKeys(CassandraBridge bridge)
     {
-        Tester.builder(keyspace1 -> TestSchema.builder()
-                                              .withKeyspace("\"Quoted_Keyspace_" + UUID.randomUUID().toString().replaceAll("-", "_") + "\"")
-                                              .withTable("\"Quoted_Table_" + UUID.randomUUID().toString().replaceAll("-", "_") + "\"")
-                                              .withPartitionKey("\"Partition_Key_0\"", bridge.uuid())
-                                              .withPartitionKey("\"Partition_Key_1\"", bridge.bigint())
+        Tester.builder(keyspace1 -> TestSchema.builder(bridge)
+                                              .withKeyspace("Quoted_Keyspace_" + UUID.randomUUID().toString().replaceAll("-", "_"))
+                                              .withTable("Quoted_Table_" + UUID.randomUUID().toString().replaceAll("-", "_"))
+                                              .withPartitionKey("Partition_Key_0", bridge.uuid())
+                                              .withPartitionKey("Partition_Key_1", bridge.bigint())
                                               .withColumn("c", bridge.text())
                                               .withColumn("d", bridge.bigint()))
               .withExpectedRowCountPerSSTable(Tester.DEFAULT_NUM_ROWS)
@@ -2479,12 +2479,12 @@ public class EndToEndTests
     @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
     public void testQuotedPartitionClusteringKeys(CassandraBridge bridge)
     {
-        Tester.builder(keyspace1 -> TestSchema.builder()
-                                              .withKeyspace("\"Quoted_Keyspace_" + UUID.randomUUID().toString().replaceAll("-", "_") + "\"")
-                                              .withTable("\"Quoted_Table_" + UUID.randomUUID().toString().replaceAll("-", "_") + "\"")
+        Tester.builder(keyspace1 -> TestSchema.builder(bridge)
+                                              .withKeyspace("Quoted_Keyspace_" + UUID.randomUUID().toString().replaceAll("-", "_"))
+                                              .withTable("Quoted_Table_" + UUID.randomUUID().toString().replaceAll("-", "_"))
                                               .withPartitionKey("a", bridge.uuid())
-                                              .withClusteringKey("\"Clustering_Key_0\"", bridge.bigint())
-                                              .withClusteringKey("\"Clustering_Key_1\"", bridge.text()))
+                                              .withClusteringKey("Clustering_Key_0", bridge.bigint())
+                                              .withClusteringKey("Clustering_Key_1", bridge.text()))
               .withExpectedRowCountPerSSTable(Tester.DEFAULT_NUM_ROWS)
               .run();
     }
@@ -2493,12 +2493,26 @@ public class EndToEndTests
     @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
     public void testQuotedColumnNames(CassandraBridge bridge)
     {
-        Tester.builder(keyspace1 -> TestSchema.builder()
-                                              .withKeyspace("\"Quoted_Keyspace_" + UUID.randomUUID().toString().replaceAll("-", "_") + "\"")
-                                              .withTable("\"Quoted_Table_" + UUID.randomUUID().toString().replaceAll("-", "_") + "\"")
-                                              .withPartitionKey("\"Partition_Key_0\"", bridge.uuid())
-                                              .withColumn("\"Column_1\"", bridge.varint())
-                                              .withColumn("\"Column_2\"", bridge.text()))
+        Tester.builder(keyspace1 -> TestSchema.builder(bridge)
+                                              .withKeyspace("Quoted_Keyspace_" + UUID.randomUUID().toString().replaceAll("-", "_"))
+                                              .withTable("Quoted_Table_" + UUID.randomUUID().toString().replaceAll("-", "_"))
+                                              .withPartitionKey("Partition_Key_0", bridge.uuid())
+                                              .withColumn("Column_1", bridge.varint())
+                                              .withColumn("Column_2", bridge.text()))
+              .run();
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
+    public void testQuotedColumnNamesWithColumnFilter(CassandraBridge bridge)
+    {
+        Tester.builder(keyspace1 -> TestSchema.builder(bridge)
+                                              .withKeyspace("Quoted_Keyspace_" + UUID.randomUUID().toString().replaceAll("-", "_"))
+                                              .withTable("Quoted_Table_" + UUID.randomUUID().toString().replaceAll("-", "_"))
+                                              .withPartitionKey("Partition_Key_0", bridge.uuid())
+                                              .withColumn("Column_1", bridge.varint())
+                                              .withColumn("Column_2", bridge.text()))
+              .withColumns("Partition_Key_0", "Column_1") // PK is required for lookup of the inserted data
               .run();
     }
 }

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/EndToEndTests.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/EndToEndTests.java
@@ -2511,7 +2511,8 @@ public class EndToEndTests
                                               .withTable("Quoted_Table_" + UUID.randomUUID().toString().replaceAll("-", "_"))
                                               .withPartitionKey("Partition_Key_0", bridge.uuid())
                                               .withColumn("Column_1", bridge.varint())
-                                              .withColumn("Column_2", bridge.text()))
+                                              .withColumn("Column_2", bridge.text())
+                                              .withQuoteIdentifiers())
               .withColumns("Partition_Key_0", "Column_1") // PK is required for lookup of the inserted data
               .run();
     }

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/EndToEndTests.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/EndToEndTests.java
@@ -2404,7 +2404,8 @@ public class EndToEndTests
                                               .withKeyspace("Quoted_Keyspace_" + UUID.randomUUID().toString().replaceAll("-", "_"))
                                               .withPartitionKey("pk", bridge.uuid())
                                               .withColumn("c1", bridge.varint())
-                                              .withColumn("c2", bridge.text()))
+                                              .withColumn("c2", bridge.text())
+                                              .withQuotedIdentifiers())
               .run();
     }
 
@@ -2416,7 +2417,8 @@ public class EndToEndTests
                                               .withKeyspace("keyspace")
                                               .withPartitionKey("pk", bridge.uuid())
                                               .withColumn("c1", bridge.varint())
-                                              .withColumn("c2", bridge.text()))
+                                              .withColumn("c2", bridge.text())
+                                              .withQuotedIdentifiers())
               .run();
     }
 
@@ -2429,7 +2431,8 @@ public class EndToEndTests
                                               .withTable("Quoted_Table_" + UUID.randomUUID().toString().replaceAll("-", "_"))
                                               .withPartitionKey("pk", bridge.uuid())
                                               .withColumn("c1", bridge.varint())
-                                              .withColumn("c2", bridge.text()))
+                                              .withColumn("c2", bridge.text())
+                                              .withQuotedIdentifiers())
               .run();
     }
 
@@ -2442,7 +2445,8 @@ public class EndToEndTests
                                               .withTable("table")
                                               .withPartitionKey("pk", bridge.uuid())
                                               .withColumn("c1", bridge.varint())
-                                              .withColumn("c2", bridge.text()))
+                                              .withColumn("c2", bridge.text())
+                                              .withQuotedIdentifiers())
               .run();
     }
 
@@ -2455,7 +2459,8 @@ public class EndToEndTests
                                               .withTable("Quoted_Table_" + UUID.randomUUID().toString().replaceAll("-", "_"))
                                               .withPartitionKey("Partition_Key_0", bridge.uuid())
                                               .withColumn("c1", bridge.varint())
-                                              .withColumn("c2", bridge.text()))
+                                              .withColumn("c2", bridge.text())
+                                              .withQuotedIdentifiers())
               .run();
     }
 
@@ -2469,7 +2474,8 @@ public class EndToEndTests
                                               .withPartitionKey("Partition_Key_0", bridge.uuid())
                                               .withPartitionKey("Partition_Key_1", bridge.bigint())
                                               .withColumn("c", bridge.text())
-                                              .withColumn("d", bridge.bigint()))
+                                              .withColumn("d", bridge.bigint())
+                                              .withQuotedIdentifiers())
               .withExpectedRowCountPerSSTable(Tester.DEFAULT_NUM_ROWS)
               .withSumField("d")
               .run();
@@ -2484,7 +2490,8 @@ public class EndToEndTests
                                               .withTable("Quoted_Table_" + UUID.randomUUID().toString().replaceAll("-", "_"))
                                               .withPartitionKey("a", bridge.uuid())
                                               .withClusteringKey("Clustering_Key_0", bridge.bigint())
-                                              .withClusteringKey("Clustering_Key_1", bridge.text()))
+                                              .withClusteringKey("Clustering_Key_1", bridge.text())
+                                              .withQuotedIdentifiers())
               .withExpectedRowCountPerSSTable(Tester.DEFAULT_NUM_ROWS)
               .run();
     }
@@ -2498,7 +2505,8 @@ public class EndToEndTests
                                               .withTable("Quoted_Table_" + UUID.randomUUID().toString().replaceAll("-", "_"))
                                               .withPartitionKey("Partition_Key_0", bridge.uuid())
                                               .withColumn("Column_1", bridge.varint())
-                                              .withColumn("Column_2", bridge.text()))
+                                              .withColumn("Column_2", bridge.text())
+                                              .withQuotedIdentifiers())
               .run();
     }
 
@@ -2512,7 +2520,7 @@ public class EndToEndTests
                                               .withPartitionKey("Partition_Key_0", bridge.uuid())
                                               .withColumn("Column_1", bridge.varint())
                                               .withColumn("Column_2", bridge.text())
-                                              .withQuoteIdentifiers())
+                                              .withQuotedIdentifiers())
               .withColumns("Partition_Key_0", "Column_1") // PK is required for lookup of the inserted data
               .run();
     }

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/TestUtils.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/TestUtils.java
@@ -189,7 +189,8 @@ public final class TestUtils
         }
     }
 
-    static Dataset<Row> openLocalPartitionSizeSource(Partitioner partitioner,
+    static Dataset<Row> openLocalPartitionSizeSource(CassandraBridge bridge,
+                                                     Partitioner partitioner,
                                                      Path dir,
                                                      String keyspace,
                                                      String createStmt,
@@ -204,7 +205,7 @@ public final class TestUtils
                                            .option("version", version.toString())
                                            .option("useSSTableInputStream", true) // use in the test system to test the SSTableInputStream
                                            .option("partitioner", partitioner.name())
-                                           .option("udts", udts.stream().map(f -> f.createStatement(keyspace)).collect(Collectors.joining("\n")));
+                                           .option("udts", udts.stream().map(f -> f.createStatement(bridge, keyspace)).collect(Collectors.joining("\n")));
         if (statsClass != null)
         {
             frameReader = frameReader.option("statsClass", statsClass);
@@ -222,7 +223,8 @@ public final class TestUtils
     }
 
     // CHECKSTYLE IGNORE: Method with many parameters
-    public static Dataset<Row> openLocalDataset(Partitioner partitioner,
+    public static Dataset<Row> openLocalDataset(CassandraBridge bridge,
+                                                Partitioner partitioner,
                                                 Path directory,
                                                 String keyspace,
                                                 String createStatement,
@@ -233,17 +235,18 @@ public final class TestUtils
                                                 @Nullable String filterExpression,
                                                 @Nullable String... columns)
     {
-        DataFrameReader frameReader = SPARK.read().format("org.apache.cassandra.spark.sparksql.LocalDataSource")
-                .option("keyspace", keyspace)
-                .option("createStmt", createStatement)
-                .option("dirs", directory.toAbsolutePath().toString())
-                .option("version", version.toString())
-                .option("useSSTableInputStream", true)  // Use in the test system to test the SSTableInputStream
-                .option("partitioner", partitioner.name())
-                .option(SchemaFeatureSet.LAST_MODIFIED_TIMESTAMP.optionName(), addLastModifiedTimestampColumn)
-                .option("udts", udts.stream()
-                                    .map(udt -> udt.createStatement(keyspace))
-                                    .collect(Collectors.joining("\n")));
+        DataFrameReader frameReader = SPARK.read()
+                                           .format("org.apache.cassandra.spark.sparksql.LocalDataSource")
+                                           .option("keyspace", keyspace)
+                                           .option("createStmt", createStatement)
+                                           .option("dirs", directory.toAbsolutePath().toString())
+                                           .option("version", version.toString())
+                                           .option("useSSTableInputStream", true)  // Use in the test system to test the SSTableInputStream
+                                           .option("partitioner", partitioner.name())
+                                           .option(SchemaFeatureSet.LAST_MODIFIED_TIMESTAMP.optionName(), addLastModifiedTimestampColumn)
+                                           .option("udts", udts.stream()
+                                                               .map(udt -> udt.createStatement(bridge, keyspace))
+                                                               .collect(Collectors.joining("\n")));
         if (statsClass != null)
         {
             frameReader = frameReader.option("statsClass", statsClass);

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/TestUtils.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/TestUtils.java
@@ -72,6 +72,9 @@ public final class TestUtils
     private static final SparkSession SPARK = SparkSession.builder()
                                                           .appName("Java Test")
                                                           .config("spark.master", "local")
+                                                          // Spark is not case-sensitive by default, but we want to make it case-sensitive for
+                                                          // the quoted identifiers tests where we test mixed case
+                                                          .config("spark.sql.caseSensitive", "True")
                                                           .getOrCreate();
 
     private TestUtils()

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/Tester.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/Tester.java
@@ -453,7 +453,8 @@ public final class Tester
                              "Number of SSTables written does not match expected");
             }
 
-            Dataset<Row> dataset = TestUtils.openLocalDataset(partitioner,
+            Dataset<Row> dataset = TestUtils.openLocalDataset(bridge,
+                                                              partitioner,
                                                               directory,
                                                               schema.keyspace,
                                                               schema.createStatement,

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/BulkSparkConfTest.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/BulkSparkConfTest.java
@@ -34,7 +34,7 @@ import org.apache.cassandra.spark.utils.BuildInfo;
 import org.apache.spark.SparkConf;
 import org.jetbrains.annotations.NotNull;
 
-import static org.apache.cassandra.spark.data.CassandraDataLayer.ClientConfig.DEFAULT_SIDECAR_PORT;
+import static org.apache.cassandra.spark.bulkwriter.BulkSparkConf.DEFAULT_SIDECAR_PORT;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.core.Is.is;
@@ -266,6 +266,17 @@ public class BulkSparkConfTest
         BulkSparkConf bulkSparkConf = new BulkSparkConf(sparkConf, options);
         assertNotNull(bulkSparkConf);
         assertEquals(bulkSparkConf.rowBufferMode, RowBufferMode.BUFFERED);
+    }
+
+    @Test
+    void testQuoteIdentifiers()
+    {
+        assertFalse(bulkSparkConf.quoteIdentifiers);
+        Map<String, String> options = copyDefaultOptions();
+        options.put(WriterOptions.QUOTE_IDENTIFIERS.name(), "true");
+        BulkSparkConf bulkSparkConf = new BulkSparkConf(sparkConf, options);
+        assertNotNull(bulkSparkConf);
+        assertTrue(bulkSparkConf.quoteIdentifiers);
     }
 
     private Map<String, String> copyDefaultOptions()

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/BulkSparkConfTest.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/BulkSparkConfTest.java
@@ -268,17 +268,6 @@ public class BulkSparkConfTest
         assertEquals(bulkSparkConf.rowBufferMode, RowBufferMode.BUFFERED);
     }
 
-    @Test
-    void testQuoteIdentifiers()
-    {
-        assertFalse(bulkSparkConf.quoteIdentifiers);
-        Map<String, String> options = copyDefaultOptions();
-        options.put(WriterOptions.QUOTE_IDENTIFIERS.name(), "true");
-        BulkSparkConf bulkSparkConf = new BulkSparkConf(sparkConf, options);
-        assertNotNull(bulkSparkConf);
-        assertTrue(bulkSparkConf.quoteIdentifiers);
-    }
-
     private Map<String, String> copyDefaultOptions()
     {
         TreeMap<String, String> map = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/data/CassandraDataSourceHelperCacheTest.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/data/CassandraDataSourceHelperCacheTest.java
@@ -151,7 +151,7 @@ public class CassandraDataSourceHelperCacheTest
                                                      Map<String, String> options) throws ExecutionException
     {
         return cassandraDataLayerCache.get(key, () -> {
-            CassandraDataLayer.ClientConfig config = CassandraDataLayer.ClientConfig.create(options);
+            ClientConfig config = ClientConfig.create(options);
             return new CassandraDataLayer(config, Sidecar.ClientConfig.create(options), SslConfig.create(options));
         });
     }

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/data/DataLayerUnsupportedPushDownFiltersTest.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/data/DataLayerUnsupportedPushDownFiltersTest.java
@@ -240,7 +240,7 @@ public class DataLayerUnsupportedPushDownFiltersTest
 
     private TestSchema schemaWithCompositePartitionKey(CassandraBridge bridge)
     {
-        return TestSchema.builder()
+        return TestSchema.builder(bridge)
                          .withPartitionKey("a", bridge.aInt())
                          .withPartitionKey("b", bridge.aInt())
                          .withPartitionKey("c", bridge.aInt())

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/utils/CqlUtilsTest.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/utils/CqlUtilsTest.java
@@ -302,7 +302,7 @@ public class CqlUtilsTest extends VersionRunner
                          + "    AND max_index_interval = 2048\\n"
                          + "    AND crc_check_chance = 1.0\\n"
                          + "    AND memtable_flush_period_in_ms = 0;";
-        String expectedCreateStmt = "CREATE TABLE ks.tb ("
+        String expectedCreateStmt = "CREATE TABLE ks.\"tb\" ("
                                   + "\"key\" text, "
                                   + "\"id1\" text, "
                                   + "\"id2\" text, "
@@ -330,15 +330,6 @@ public class CqlUtilsTest extends VersionRunner
         assertEquals("tb", table.table());
         assertEquals("key", table.getField("key").name());
         assertEquals("id1", table.getField("id1").name());
-    }
-
-    @ParameterizedTest
-    @MethodSource("org.apache.cassandra.spark.data.VersionRunner#bridges")
-    public void testCleanTableName(CassandraBridge bridge)
-    {
-        assertEquals("test", CqlUtils.cleanTableName("test"));
-        assertEquals("test", CqlUtils.cleanTableName("\"test\""));
-        assertEquals("test", CqlUtils.cleanTableName("\"\"test\"\""));
     }
 
     @ParameterizedTest

--- a/cassandra-analytics-core/src/test/spark2/org/apache/cassandra/spark/sparksql/SparkRowIteratorTests.java
+++ b/cassandra-analytics-core/src/test/spark2/org/apache/cassandra/spark/sparksql/SparkRowIteratorTests.java
@@ -62,7 +62,7 @@ public class SparkRowIteratorTests
     {
         // I.e. "create table keyspace.table (a %s, b %s, primary key(a));"
         qt().forAll(TestUtils.versions(), TestUtils.cql3Type(bridge), TestUtils.cql3Type(bridge))
-            .checkAssert((version, type1, type2) -> runTest(version, TestSchema.builder()
+            .checkAssert((version, type1, type2) -> runTest(version, TestSchema.builder(bridge)
                     .withPartitionKey("a", type1)
                     .withColumn("b", type2)
                     .build()));
@@ -73,7 +73,7 @@ public class SparkRowIteratorTests
     public void testMultiPartitionKeys(CassandraBridge bridge)
     {
         qt().forAll(TestUtils.versions(), TestUtils.cql3Type(bridge), TestUtils.cql3Type(bridge), TestUtils.cql3Type(bridge))
-            .checkAssert((version, type1, type2, type3) -> runTest(version, TestSchema.builder()
+            .checkAssert((version, type1, type2, type3) -> runTest(version, TestSchema.builder(bridge)
                     .withPartitionKey("a", type1)
                     .withPartitionKey("b", type2)
                     .withPartitionKey("c", type3)
@@ -88,7 +88,7 @@ public class SparkRowIteratorTests
         for (CassandraVersion version : TestUtils.testableVersions())
         {
             qt().forAll(TestUtils.cql3Type(bridge), TestUtils.cql3Type(bridge), TestUtils.cql3Type(bridge), TestUtils.sortOrder())
-                .checkAssert((type1, type2, type3, order) -> runTest(version, TestSchema.builder()
+                .checkAssert((type1, type2, type3, order) -> runTest(version, TestSchema.builder(bridge)
                         .withPartitionKey("a", type1)
                         .withClusteringKey("b", type2)
                         .withColumn("c", type3)
@@ -104,7 +104,7 @@ public class SparkRowIteratorTests
         for (CassandraVersion version : TestUtils.testableVersions())
         {
             qt().forAll(TestUtils.cql3Type(bridge), TestUtils.cql3Type(bridge), TestUtils.sortOrder(), TestUtils.sortOrder())
-                .checkAssert((type1, type2, order1, order2) -> runTest(version, TestSchema.builder()
+                .checkAssert((type1, type2, order1, order2) -> runTest(version, TestSchema.builder(bridge)
                         .withPartitionKey("a", bridge.bigint())
                         .withClusteringKey("b", type1)
                         .withClusteringKey("c", type2)
@@ -120,7 +120,7 @@ public class SparkRowIteratorTests
     public void testUdt(CassandraBridge bridge)
     {
         qt().forAll(TestUtils.cql3Type(bridge), TestUtils.cql3Type(bridge))
-            .checkAssert((type1, type2) -> runTest(CassandraVersion.FOURZERO, TestSchema.builder()
+            .checkAssert((type1, type2) -> runTest(CassandraVersion.FOURZERO, TestSchema.builder(bridge)
                     .withPartitionKey("a", bridge.bigint())
                     .withClusteringKey("b", bridge.text())
                     .withColumn("c", bridge.udt("keyspace", "testudt")
@@ -136,7 +136,7 @@ public class SparkRowIteratorTests
     public void testTuple(CassandraBridge bridge)
     {
         qt().forAll(TestUtils.cql3Type(bridge), TestUtils.cql3Type(bridge))
-            .checkAssert((type1, type2) -> runTest(CassandraVersion.FOURZERO, TestSchema.builder()
+            .checkAssert((type1, type2) -> runTest(CassandraVersion.FOURZERO, TestSchema.builder(bridge)
                     .withPartitionKey("a", bridge.bigint())
                     .withClusteringKey("b", bridge.text())
                     .withColumn("c", bridge.tuple(bridge.aInt(), type1, bridge.ascii(), type2, bridge.date()))

--- a/cassandra-analytics-core/src/test/spark3/org/apache/cassandra/spark/PartitionSizeTests.java
+++ b/cassandra-analytics-core/src/test/spark3/org/apache/cassandra/spark/PartitionSizeTests.java
@@ -69,13 +69,14 @@ public class PartitionSizeTests extends VersionRunner
                 }
             });
 
-            Dataset<Row> ds = TestUtils.openLocalPartitionSizeSource(partitioner,
-                                                                           dir,
-                                                                           schema.keyspace,
-                                                                           schema.createStatement,
-                                                                           version,
-                                                                           Collections.emptySet(),
-                                                                           null);
+            Dataset<Row> ds = TestUtils.openLocalPartitionSizeSource(bridge,
+                                                                     partitioner,
+                                                                     dir,
+                                                                     schema.keyspace,
+                                                                     schema.createStatement,
+                                                                     version,
+                                                                     Collections.emptySet(),
+                                                                     null);
             List<Row> rows = ds.collectAsList();
             assertEquals(numRows, rows.size());
             for (Row row : rows)

--- a/cassandra-analytics-core/src/test/spark3/org/apache/cassandra/spark/PartitionSizeTests.java
+++ b/cassandra-analytics-core/src/test/spark3/org/apache/cassandra/spark/PartitionSizeTests.java
@@ -47,7 +47,7 @@ public class PartitionSizeTests extends VersionRunner
         TestUtils.runTest(version, (partitioner, dir, bridge) -> {
             int numRows = Tester.DEFAULT_NUM_ROWS;
             int numCols = 25;
-            TestSchema schema = TestSchema.builder()
+            TestSchema schema = TestSchema.builder(bridge)
                                                 .withPartitionKey("a", bridge.text())
                                                 .withClusteringKey("b", bridge.aInt())
                                                 .withColumn("c", bridge.aInt())

--- a/cassandra-analytics-integration-framework/build.gradle
+++ b/cassandra-analytics-integration-framework/build.gradle
@@ -1,5 +1,3 @@
-import java.nio.file.Paths
-
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -19,12 +17,19 @@ import java.nio.file.Paths
  * under the License.
  */
 
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+import java.nio.file.Paths
+
 project(':cassandra-analytics-integration-framework') {
     apply(plugin: 'java-library')
     apply(plugin: 'com.github.johnrengelman.shadow')
 
     ext.dtestJar = System.getenv("DTEST_JAR") ?: "dtest-4.1.4.jar" // latest supported Cassandra build is 4.1
     def dtestJarFullPath = "${dependencyLocation}${ext.dtestJar}"
+
+    test {
+        useJUnitPlatform()
+    }
 
     dependencies {
 
@@ -45,13 +50,13 @@ project(':cassandra-analytics-integration-framework') {
         shadow("org.apache.cassandra:dtest-api:0.0.16")
         // Needed by the Cassandra dtest framework
         // JUnit
-        api("org.junit.jupiter:junit-jupiter-api:${project.junitVersion}")
-        api("org.junit.jupiter:junit-jupiter-params:${project.junitVersion}")
-        api("org.junit.jupiter:junit-jupiter-engine:${project.junitVersion}")
+        implementation("org.junit.jupiter:junit-jupiter-api:${project.junitVersion}")
+        implementation("org.junit.jupiter:junit-jupiter-params:${project.junitVersion}")
+        implementation("org.junit.jupiter:junit-jupiter-engine:${project.junitVersion}")
 
-        api("org.junit.vintage:junit-vintage-engine:${junitVersion}")
-        api('org.mockito:mockito-inline:4.10.0')
-        api("org.assertj:assertj-core:3.24.2")
+        implementation("org.junit.vintage:junit-vintage-engine:${junitVersion}")
+        implementation('org.mockito:mockito-inline:4.10.0')
+        implementation("org.assertj:assertj-core:3.24.2")
 
         shadow('com.datastax.cassandra:cassandra-driver-core:3.9.0')
 

--- a/cassandra-analytics-integration-framework/build.gradle
+++ b/cassandra-analytics-integration-framework/build.gradle
@@ -17,9 +17,6 @@
  * under the License.
  */
 
-import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
-import java.nio.file.Paths
-
 project(':cassandra-analytics-integration-framework') {
     apply(plugin: 'java-library')
     apply(plugin: 'com.github.johnrengelman.shadow')

--- a/cassandra-analytics-integration-framework/src/main/java/org/apache/cassandra/sidecar/testing/QualifiedName.java
+++ b/cassandra-analytics-integration-framework/src/main/java/org/apache/cassandra/sidecar/testing/QualifiedName.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.sidecar.testing;
+
+import org.apache.cassandra.cql3.ColumnIdentifier;
+
+/**
+ * Simple class representing a Cassandra table, used for integration testing
+ */
+public class QualifiedName
+{
+    private final String keyspace;
+    private final String table;
+
+    public QualifiedName(String keyspace, String table)
+    {
+        this.keyspace = keyspace;
+        this.table = table;
+    }
+
+    public String keyspace()
+    {
+        return keyspace;
+    }
+
+    public String maybeQuotedKeyspace()
+    {
+        return ColumnIdentifier.maybeQuote(keyspace);
+    }
+
+    public String table()
+    {
+        return table;
+    }
+
+    public String maybeQuotedTable()
+    {
+        return ColumnIdentifier.maybeQuote(table);
+    }
+
+    @Override
+    public String toString()
+    {
+        return String.format("%s.%s", maybeQuotedKeyspace(), maybeQuotedTable());
+    }
+}

--- a/cassandra-analytics-integration-framework/src/main/java/org/apache/cassandra/sidecar/testing/TemporaryCqlSessionProvider.java
+++ b/cassandra-analytics-integration-framework/src/main/java/org/apache/cassandra/sidecar/testing/TemporaryCqlSessionProvider.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.sidecar.testing;
+
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.NettyOptions;
+import com.datastax.driver.core.Session;
+import com.datastax.driver.core.exceptions.DriverException;
+import com.datastax.driver.core.exceptions.DriverInternalError;
+import com.datastax.driver.core.policies.ExponentialReconnectionPolicy;
+import com.datastax.driver.core.policies.ReconnectionPolicy;
+import org.apache.cassandra.sidecar.common.CQLSessionProvider;
+import org.jetbrains.annotations.Nullable;
+
+public class TemporaryCqlSessionProvider extends CQLSessionProvider
+{
+    private static final Logger logger = LoggerFactory.getLogger(TemporaryCqlSessionProvider.class);
+    private Session localSession;
+    private final InetSocketAddress inet;
+    private final NettyOptions nettyOptions;
+    private final ReconnectionPolicy reconnectionPolicy;
+    private final List<InetSocketAddress> addresses = new ArrayList<>();
+
+    public TemporaryCqlSessionProvider(InetSocketAddress target, NettyOptions options, List<InetSocketAddress> addresses)
+    {
+        super(target, options);
+        inet = target;
+        nettyOptions = options;
+        reconnectionPolicy = new ExponentialReconnectionPolicy(100, 1000);
+        this.addresses.addAll(addresses);
+    }
+
+    @Override
+    public synchronized @Nullable Session localCql()
+    {
+        Cluster cluster = null;
+        try
+        {
+            if (localSession == null)
+            {
+                logger.info("Connecting to {}", inet);
+                cluster = Cluster.builder()
+                                 .addContactPointsWithPorts(addresses)
+                                 .withReconnectionPolicy(reconnectionPolicy)
+                                 .withoutMetrics()
+                                 // tests can create a lot of these Cluster objects, to avoid creating HWTs and
+                                 // event thread pools for each we have the override
+                                 .withNettyOptions(nettyOptions)
+                                 .build();
+                localSession = cluster.connect();
+                logger.info("Successfully connected to Cassandra instance!");
+            }
+        }
+        catch (Exception e)
+        {
+            logger.error("Failed to reach Cassandra", e);
+            if (cluster != null)
+            {
+                try
+                {
+                    cluster.close();
+                }
+                catch (Exception ex)
+                {
+                    logger.error("Failed to close cluster in cleanup", ex);
+                }
+            }
+        }
+        return localSession;
+    }
+
+    @Override
+    public Session close()
+    {
+        Session localSession;
+        synchronized (this)
+        {
+            localSession = this.localSession;
+            this.localSession = null;
+        }
+
+        if (localSession != null)
+        {
+            try
+            {
+                localSession.getCluster().closeAsync().get(1, TimeUnit.MINUTES);
+                localSession.closeAsync().get(1, TimeUnit.MINUTES);
+            }
+            catch (InterruptedException e)
+            {
+                Thread.currentThread().interrupt();
+            }
+            catch (TimeoutException e)
+            {
+                logger.warn("Unable to close session after 1 minute for provider {}", this, e);
+            }
+            catch (ExecutionException e)
+            {
+                throw propagateCause(e);
+            }
+        }
+        return localSession;
+    }
+
+    static RuntimeException propagateCause(ExecutionException e)
+    {
+        Throwable cause = e.getCause();
+        if (cause instanceof Error)
+        {
+            throw (Error) cause;
+        }
+        else if (cause instanceof DriverException)
+        {
+            throw ((DriverException) cause).copy();
+        }
+        else
+        {
+            throw new DriverInternalError("Unexpected exception thrown", cause);
+        }
+    }
+}

--- a/cassandra-analytics-integration-framework/src/main/java/org/apache/cassandra/testing/AbstractCassandraTestContext.java
+++ b/cassandra-analytics-integration-framework/src/main/java/org/apache/cassandra/testing/AbstractCassandraTestContext.java
@@ -69,7 +69,7 @@ public abstract class AbstractCassandraTestContext implements AutoCloseable
             {
                 // Because different classloaders or different jars may be used to load this class, we can't
                 // actually catch the specific ShutdownException.
-                if (ex.getClass().getCanonicalName() == "org.apache.cassandra.distributed.shared.ShutdownException")
+                if (ex.getClass().getCanonicalName().equals("org.apache.cassandra.distributed.shared.ShutdownException"))
                 {
                     LOGGER.warn("Encountered shutdown exception which closing the cluster", ex);
                 }

--- a/cassandra-analytics-integration-tests/build.gradle
+++ b/cassandra-analytics-integration-tests/build.gradle
@@ -22,10 +22,10 @@ import java.nio.file.Paths
 project(':cassandra-analytics-integration-tests') {
     apply(plugin: 'java-library')
 
-    def integrationMaxHeapSize = System.getenv("INTEGRATION_MAX_HEAP_SIZE") ?: "6g"
+    def integrationMaxHeapSize = System.getenv("INTEGRATION_MAX_HEAP_SIZE") ?: "3000M"
     println("Using ${integrationMaxHeapSize} maxHeapSize")
 
-    def integrationMaxParallelForks = (System.getenv("INTEGRATION_MAX_PARALLEL_FORKS") ?: "8") as int
+    def integrationMaxParallelForks = (System.getenv("INTEGRATION_MAX_PARALLEL_FORKS") ?: "4") as int
     println("Using ${integrationMaxParallelForks} maxParallelForks")
 
     configurations {

--- a/cassandra-analytics-integration-tests/build.gradle
+++ b/cassandra-analytics-integration-tests/build.gradle
@@ -21,12 +21,16 @@ import java.nio.file.Paths
 
 project(':cassandra-analytics-integration-tests') {
     apply(plugin: 'java-library')
+
+    def integrationMaxHeapSize = System.getenv("INTEGRATION_MAX_HEAP_SIZE") ?: "6g"
+    println("Using ${integrationMaxHeapSize} maxHeapSize")
+
+    def integrationMaxParallelForks = (System.getenv("INTEGRATION_MAX_PARALLEL_FORKS") ?: "8") as int
+    println("Using ${integrationMaxParallelForks} maxParallelForks")
+
     configurations {
-        configureEach {
-            resolutionStrategy {
-                force("com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}")
-            }
-        }
+        all*.exclude(group: 'org.slf4j', module: 'slf4j-log4j12')
+        all*.exclude(group: 'log4j', module: 'log4j')
     }
     dependencies {
 
@@ -36,12 +40,14 @@ project(':cassandra-analytics-integration-tests') {
         testImplementation(group: "${sparkGroupId}", name: "spark-core_${scalaMajorVersion}", version: "${sparkVersion}")
         testImplementation(group: "${sparkGroupId}", name: "spark-sql_${scalaMajorVersion}", version: "${sparkVersion}")
 
+        testImplementation(group: "${sidecarClientGroup}", name: "${sidecarClientName}", version: "${sidecarVersion}")
+
         // JUnit
         testImplementation("org.junit.jupiter:junit-jupiter-api:${project.junitVersion}")
         testImplementation("org.junit.jupiter:junit-jupiter-params:${project.junitVersion}")
         testImplementation("org.junit.jupiter:junit-jupiter-engine:${project.junitVersion}")
+        testImplementation("org.assertj:assertj-core:3.24.2")
         testImplementation(project(path: ":cassandra-analytics-integration-framework", configuration: "shadow"))
-        testImplementation(project(':cassandra-analytics-core-example'))
         ext.dtestJar = System.getenv("DTEST_JAR") ?: "dtest-4.1.4.jar" // latest supported Cassandra build is 4.1
         def dtestJarFullPath = "${dependencyLocation}${ext.dtestJar}"
         println("Using DTest jar: " + dtestJarFullPath)
@@ -59,14 +65,13 @@ project(':cassandra-analytics-integration-tests') {
         // Because system properties aren't passed from the command line through to tests, we need to specifically
         // set them again here.
         systemProperty "cassandra.test.dtest_jar_path", dependencyLocation
-        systemProperty "cassandra.sidecar.versions_to_test", System.getProperty("cassandra.sidecar.versions_to_test", "4.0,4.1")
+        systemProperty "cassandra.sidecar.versions_to_test",
+                System.getProperty("cassandra.sidecar.versions_to_test", "4.0")
         systemProperty "SKIP_STARTUP_VALIDATIONS", "true"
         systemProperty "logback.configurationFile", "src/test/resources/logback-test.xml"
-        minHeapSize = '1024m'
-        maxHeapSize = '3072m'
-        // For now, keep maxParallelForks at 1 until we can fix dynamic port allocation across forks
-        maxParallelForks = 1
-        // maxParallelForks = Math.max(Runtime.runtime.availableProcessors() * 2, 8)
+        minHeapSize = '1g'
+        maxHeapSize = integrationMaxHeapSize
+        maxParallelForks = integrationMaxParallelForks
         forkEvery = 1  // Enables different end-to-end test classes use Spark contexts with different configurations
 
         // Make it so unit tests run on a JAr with Cassandra bridge implementations built in
@@ -79,7 +84,7 @@ project(':cassandra-analytics-integration-tests') {
                 enabled true
                 destination = destDir
             }
-            html{
+            html {
                 enabled true
                 destination = destDir
             }

--- a/cassandra-analytics-integration-tests/src/test/java/org/apache/cassandra/analytics/BulkWriteTtlTest.java
+++ b/cassandra-analytics-integration-tests/src/test/java/org/apache/cassandra/analytics/BulkWriteTtlTest.java
@@ -48,7 +48,7 @@ import static org.apache.spark.sql.types.DataTypes.LongType;
 
 public class BulkWriteTtlTest extends IntegrationTestBase
 {
-    @CassandraIntegrationTest(nodesPerDc = 3)
+    @CassandraIntegrationTest(nodesPerDc = 3, gossip = true)
     public void testTableDefaultTtl()
     {
         UpgradeableCluster cluster = sidecarTestContext.cluster();
@@ -80,7 +80,7 @@ public class BulkWriteTtlTest extends IntegrationTestBase
         Assertions.assertFalse(result.hasNext());
     }
 
-    @CassandraIntegrationTest(nodesPerDc = 3)
+    @CassandraIntegrationTest(nodesPerDc = 3, gossip = true)
     public void testTtlOptionConstant()
     {
         UpgradeableCluster cluster = sidecarTestContext.cluster();
@@ -113,7 +113,7 @@ public class BulkWriteTtlTest extends IntegrationTestBase
         Assertions.assertFalse(result.hasNext());
     }
 
-    @CassandraIntegrationTest(nodesPerDc = 3)
+    @CassandraIntegrationTest(nodesPerDc = 3, gossip = true)
     public void testTtlOptionPerRow()
     {
         UpgradeableCluster cluster = sidecarTestContext.cluster();

--- a/cassandra-analytics-integration-tests/src/test/java/org/apache/cassandra/analytics/QuoteIdentifiersTest.java
+++ b/cassandra-analytics-integration-tests/src/test/java/org/apache/cassandra/analytics/QuoteIdentifiersTest.java
@@ -27,8 +27,6 @@ import java.util.stream.Collectors;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.Uninterruptibles;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -54,20 +52,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 class QuoteIdentifiersTest extends SparkIntegrationTestBase
 {
     private static final Logger LOGGER = LoggerFactory.getLogger(QuoteIdentifiersTest.class);
-
-    WebClient client;
-
-    @BeforeEach
-    void setup()
-    {
-        client = WebClient.create(vertx);
-    }
-
-    @AfterEach
-    void cleanup()
-    {
-        client.close();
-    }
 
     @CassandraIntegrationTest(nodesPerDc = 3, gossip = true)
     void testMixedCaseKeyspace(VertxTestContext context)
@@ -199,6 +183,7 @@ class QuoteIdentifiersTest extends SparkIntegrationTestBase
 
     void waitUntilSidecarPicksUpSchemaChange(String quotedKeyspace)
     {
+        WebClient client = WebClient.create(vertx);
         while (true)
         {
             try
@@ -218,5 +203,6 @@ class QuoteIdentifiersTest extends SparkIntegrationTestBase
                 Uninterruptibles.sleepUninterruptibly(200, TimeUnit.MILLISECONDS);
             }
         }
+        client.close();
     }
 }

--- a/cassandra-analytics-integration-tests/src/test/java/org/apache/cassandra/analytics/QuoteIdentifiersTest.java
+++ b/cassandra-analytics-integration-tests/src/test/java/org/apache/cassandra/analytics/QuoteIdentifiersTest.java
@@ -114,7 +114,11 @@ class QuoteIdentifiersTest extends SparkIntegrationTestBase
                           .coordinator()
                           .execute(createUdtQuery, ConsistencyLevel.ALL);
 
-        createTestTable(String.format("CREATE TABLE IF NOT EXISTS %s (\"IdEnTiFiEr\" text, IdEnTiFiEr int, \"User_Defined_Type\" frozen<\"UdT1\">, PRIMARY KEY(\"IdEnTiFiEr\", IdEnTiFiEr));",
+        createTestTable(String.format("CREATE TABLE IF NOT EXISTS %s (" +
+                                      "\"IdEnTiFiEr\" text, " +
+                                      "IdEnTiFiEr int, " +
+                                      "\"User_Defined_Type\" frozen<\"UdT1\">, " +
+                                      "PRIMARY KEY(\"IdEnTiFiEr\", IdEnTiFiEr));",
                                       tableName));
         List<String> dataset = Arrays.asList("a", "b", "c", "d", "e", "f", "g");
         populateTableWithUdt(tableName, dataset);
@@ -182,7 +186,9 @@ class QuoteIdentifiersTest extends SparkIntegrationTestBase
         for (int i = 0; i < dataset.size(); i++)
         {
             String value = dataset.get(i);
-            String query = String.format("INSERT INTO %s (\"IdEnTiFiEr\", IdEnTiFiEr, \"User_Defined_Type\") VALUES ('%s', %d, { \"TimE\" : %d, \"limit\" : %d });", tableName, value, i, i, i);
+            String query = String.format("INSERT INTO %s (\"IdEnTiFiEr\", IdEnTiFiEr, \"User_Defined_Type\") " +
+                                         "VALUES ('%s', %d, { \"TimE\" : %d, \"limit\" : %d });",
+                                         tableName, value, i, i, i);
             sidecarTestContext.cassandraTestContext()
                               .cluster()
                               .getFirstRunningInstance()

--- a/cassandra-analytics-integration-tests/src/test/java/org/apache/cassandra/analytics/QuoteIdentifiersTest.java
+++ b/cassandra-analytics-integration-tests/src/test/java/org/apache/cassandra/analytics/QuoteIdentifiersTest.java
@@ -1,0 +1,216 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cassandra.analytics;
+
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.util.concurrent.Uninterruptibles;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.vertx.ext.web.client.WebClient;
+import io.vertx.ext.web.client.predicate.ResponsePredicate;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import org.apache.cassandra.distributed.api.ConsistencyLevel;
+import org.apache.cassandra.sidecar.testing.QualifiedName;
+import org.apache.cassandra.testing.CassandraIntegrationTest;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests the bulk reader behavior when requiring quoted identifiers for keyspace, table name, and column names.
+ * These tests exercise a full integration test, which includes testing Sidecar behavior when dealing with quoted
+ * identifiers.
+ */
+@ExtendWith(VertxExtension.class)
+class QuoteIdentifiersTest extends SparkIntegrationTestBase
+{
+    private static final Logger LOGGER = LoggerFactory.getLogger(QuoteIdentifiersTest.class);
+
+    WebClient client;
+
+    @BeforeEach
+    void setup()
+    {
+        client = WebClient.create(vertx);
+    }
+
+    @AfterEach
+    void cleanup()
+    {
+        client.close();
+    }
+
+    @CassandraIntegrationTest(nodesPerDc = 3, gossip = true)
+    void testMixedCaseKeyspace(VertxTestContext context)
+    {
+        QualifiedName qualifiedTableName = uniqueTestTableFullName("QuOtEd_KeYsPaCe");
+        runTestScenario(context, qualifiedTableName);
+    }
+
+    @CassandraIntegrationTest(nodesPerDc = 3, gossip = true)
+    void testReservedWordKeyspace(VertxTestContext context)
+    {
+        // keyspace is a reserved word
+        QualifiedName qualifiedTableName = uniqueTestTableFullName("keyspace");
+        runTestScenario(context, qualifiedTableName);
+    }
+
+    @CassandraIntegrationTest(nodesPerDc = 3, gossip = true)
+    void testMixedCaseTable(VertxTestContext context)
+    {
+        QualifiedName qualifiedTableName = uniqueTestTableFullName(TEST_KEYSPACE, "QuOtEd_TaBlE");
+        runTestScenario(context, qualifiedTableName);
+    }
+
+    @CassandraIntegrationTest(nodesPerDc = 3, gossip = true)
+    void testReservedWordTable(VertxTestContext context)
+    {
+        // table is a reserved word
+        runTestScenario(context, new QualifiedName(TEST_KEYSPACE, "table"));
+    }
+
+    @CassandraIntegrationTest(nodesPerDc = 3, gossip = true)
+    void testReadComplexSchema(VertxTestContext context)
+    {
+        QualifiedName tableName = uniqueTestTableFullName("QuOtEd_KeYsPaCe", "QuOtEd_TaBlE");
+
+        String quotedKeyspace = tableName.maybeQuotedKeyspace();
+        createTestKeyspace(quotedKeyspace, ImmutableMap.of("datacenter1", 3));
+
+        // Create UDT
+        String createUdtQuery = "CREATE TYPE " + quotedKeyspace + ".\"UdT1\" (\"TimE\" bigint, \"limit\" int);";
+        sidecarTestContext.cassandraTestContext()
+                          .cluster()
+                          .getFirstRunningInstance()
+                          .coordinator()
+                          .execute(createUdtQuery, ConsistencyLevel.ALL);
+
+        createTestTable(String.format("CREATE TABLE IF NOT EXISTS %s (\"IdEnTiFiEr\" text, IdEnTiFiEr int, \"User_Defined_Type\" frozen<\"UdT1\">, PRIMARY KEY(\"IdEnTiFiEr\", IdEnTiFiEr));",
+                                      tableName));
+        List<String> dataset = Arrays.asList("a", "b", "c", "d", "e", "f", "g");
+        populateTableWithUdt(tableName, dataset);
+        waitUntilSidecarPicksUpSchemaChange(quotedKeyspace);
+
+        Dataset<Row> data = bulkReaderDataFrame(tableName).option("quote_identifiers", "true")
+                                                          .load();
+        assertThat(data.count()).isEqualTo(dataset.size());
+        List<Row> rowList = data.collectAsList().stream()
+                                .sorted(Comparator.comparing(row -> row.getString(0)))
+                                .collect(Collectors.toList());
+        for (int i = 0; i < dataset.size(); i++)
+        {
+            Row row = rowList.get(i);
+            assertThat(row.getString(0)).isEqualTo(dataset.get(i));
+            assertThat(row.getInt(1)).isEqualTo(i);
+            assertThat(row.getStruct(2).getLong(0)).isEqualTo(i); // from UdT1 TimE column
+            assertThat(row.getStruct(2).getInt(1)).isEqualTo(i); // from UdT1 limit column (limit is a reserved word)
+        }
+        context.completeNow();
+    }
+
+    void runTestScenario(VertxTestContext context, QualifiedName tableName)
+    {
+        String quotedKeyspace = tableName.maybeQuotedKeyspace();
+
+        createTestKeyspace(quotedKeyspace, ImmutableMap.of("datacenter1", 3));
+        createTestTable(String.format("CREATE TABLE IF NOT EXISTS %s (\"IdEnTiFiEr\" text, IdEnTiFiEr int, PRIMARY KEY(\"IdEnTiFiEr\"));",
+                                      tableName));
+        List<String> dataset = Arrays.asList("a", "b", "c", "d", "e", "f", "g");
+        populateTable(tableName, dataset);
+        waitUntilSidecarPicksUpSchemaChange(quotedKeyspace);
+
+        Dataset<Row> data = bulkReaderDataFrame(tableName).option("quote_identifiers", "true")
+                                                          .load();
+
+        assertThat(data.count()).isEqualTo(dataset.size());
+        List<Row> rowList = data.collectAsList().stream()
+                                .sorted(Comparator.comparing(row -> row.getString(0)))
+                                .collect(Collectors.toList());
+        for (int i = 0; i < dataset.size(); i++)
+        {
+            assertThat(rowList.get(i).getString(0)).isEqualTo(dataset.get(i));
+            assertThat(rowList.get(i).getInt(1)).isEqualTo(i);
+        }
+        context.completeNow();
+    }
+
+    void populateTable(QualifiedName tableName, List<String> values)
+    {
+        for (int i = 0; i < values.size(); i++)
+        {
+            String value = values.get(i);
+            String query = String.format("INSERT INTO %s (\"IdEnTiFiEr\", IdEnTiFiEr) VALUES ('%s', %d);", tableName, value, i);
+            sidecarTestContext.cassandraTestContext()
+                              .cluster()
+                              .getFirstRunningInstance()
+                              .coordinator()
+                              .execute(query, ConsistencyLevel.ALL);
+        }
+    }
+
+    void populateTableWithUdt(QualifiedName tableName, List<String> dataset)
+    {
+        for (int i = 0; i < dataset.size(); i++)
+        {
+            String value = dataset.get(i);
+            String query = String.format("INSERT INTO %s (\"IdEnTiFiEr\", IdEnTiFiEr, \"User_Defined_Type\") VALUES ('%s', %d, { \"TimE\" : %d, \"limit\" : %d });", tableName, value, i, i, i);
+            sidecarTestContext.cassandraTestContext()
+                              .cluster()
+                              .getFirstRunningInstance()
+                              .coordinator()
+                              .execute(query, ConsistencyLevel.ALL);
+        }
+    }
+
+    void waitUntilSidecarPicksUpSchemaChange(String quotedKeyspace)
+    {
+        while (true)
+        {
+            try
+            {
+                client.get(server.actualPort(), "localhost", "/api/v1/keyspaces/" + quotedKeyspace + "/schema")
+                      .expect(ResponsePredicate.SC_OK)
+                      .send()
+                      .toCompletionStage()
+                      .toCompletableFuture()
+                      .get(30, TimeUnit.SECONDS);
+                LOGGER.info("Schema is ready in Sidecar");
+                break;
+            }
+            catch (Exception exception)
+            {
+                LOGGER.info("Waiting for schema to propagate to Sidecar");
+                Uninterruptibles.sleepUninterruptibly(200, TimeUnit.MILLISECONDS);
+            }
+        }
+    }
+}

--- a/cassandra-analytics-integration-tests/src/test/java/org/apache/cassandra/analytics/SparkBulkWriterSimpleTest.java
+++ b/cassandra-analytics-integration-tests/src/test/java/org/apache/cassandra/analytics/SparkBulkWriterSimpleTest.java
@@ -42,7 +42,7 @@ import static org.apache.spark.sql.types.DataTypes.LongType;
 public class SparkBulkWriterSimpleTest extends IntegrationTestBase
 {
 
-    @CassandraIntegrationTest(nodesPerDc = 3)
+    @CassandraIntegrationTest(nodesPerDc = 3, gossip = true)
     public void runSampleJob()
     {
         UpgradeableCluster cluster = sidecarTestContext.cluster();

--- a/cassandra-analytics-integration-tests/src/test/java/org/apache/cassandra/analytics/SparkIntegrationTestBase.java
+++ b/cassandra-analytics-integration-tests/src/test/java/org/apache/cassandra/analytics/SparkIntegrationTestBase.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cassandra.analytics;
+
+import java.util.UUID;
+
+import org.apache.cassandra.sidecar.testing.IntegrationTestBase;
+import org.apache.cassandra.sidecar.testing.QualifiedName;
+import org.apache.cassandra.spark.KryoRegister;
+import org.apache.cassandra.spark.bulkwriter.BulkSparkConf;
+import org.apache.spark.SparkConf;
+import org.apache.spark.SparkContext;
+import org.apache.spark.sql.DataFrameReader;
+import org.apache.spark.sql.SQLContext;
+import org.apache.spark.sql.SparkSession;
+
+/**
+ * Extends the {@link org.apache.cassandra.sidecar.testing.IntegrationTestBase} with Spark functionality for
+ * test classes.
+ */
+public class SparkIntegrationTestBase extends IntegrationTestBase
+{
+    protected SparkConf sparkConf;
+    protected SparkSession sparkSession;
+
+    protected DataFrameReader bulkReaderDataFrame(QualifiedName tableName)
+    {
+        SparkConf sparkConf = getOrCreateSparkConf();
+        SparkSession spark = getOrCreateSparkSession();
+        SQLContext sql = spark.sqlContext();
+        SparkContext sc = spark.sparkContext();
+
+        int coresPerExecutor = sparkConf.getInt("spark.executor.cores", 1);
+        int numExecutors = sparkConf.getInt("spark.dynamicAllocation.maxExecutors", sparkConf.getInt("spark.executor.instances", 1));
+        int numCores = coresPerExecutor * numExecutors;
+
+        return sql.read().format("org.apache.cassandra.spark.sparksql.CassandraDataSource")
+                  .option("sidecar_instances", "localhost,localhost2,localhost3")
+                  .option("keyspace", tableName.keyspace()) // unquoted
+                  .option("table", tableName.table()) // unquoted
+                  .option("DC", "datacenter1")
+                  .option("snapshotName", UUID.randomUUID().toString())
+                  .option("createSnapshot", "true")
+                  .option("defaultParallelism", sc.defaultParallelism())
+                  .option("numCores", numCores)
+                  .option("sizing", "default")
+                  .option("sidecar_port", server.actualPort());
+    }
+
+    protected SparkConf getOrCreateSparkConf()
+    {
+        if (sparkConf == null)
+        {
+            sparkConf = new SparkConf()
+                        .setAppName("Integration test Spark Cassandra Bulk Reader Job")
+                        .set("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
+                        // Spark is not case-sensitive by default, but we want to make it case-sensitive for
+                        // the quoted identifiers tests where we test mixed case
+                        .set("spark.sql.caseSensitive", "True")
+                        .set("spark.master", "local[8,4]");
+            BulkSparkConf.setupSparkConf(sparkConf, true);
+            KryoRegister.setup(sparkConf);
+        }
+        return sparkConf;
+    }
+
+    protected SparkSession getOrCreateSparkSession()
+    {
+        if (sparkSession == null)
+        {
+            sparkSession = SparkSession
+                           .builder()
+                           .config(sparkConf)
+                           .getOrCreate();
+        }
+        return sparkSession;
+    }
+}

--- a/cassandra-bridge/src/main/java/org/apache/cassandra/bridge/CassandraBridge.java
+++ b/cassandra-bridge/src/main/java/org/apache/cassandra/bridge/CassandraBridge.java
@@ -157,6 +157,25 @@ public abstract class CassandraBridge
                                          @Nullable UUID tableId,
                                          int indexCount);
 
+    /**
+     * Returns the quoted identifier, if the {@code identifier} has mixed case or if the {@code identifier}
+     * is a reserved word.
+     *
+     * @param identifier the identifier
+     * @return the quoted identifier when the input is mixed case or a reserved word, the original input otherwise
+     */
+    public abstract String maybeQuoteIdentifier(String identifier);
+
+    protected boolean isAlreadyQuoted(String identifier)
+    {
+        if (identifier != null && identifier.length() > 1)
+        {
+            return identifier.charAt(0) == '"' &&
+                   identifier.charAt(identifier.length() - 1) == '"';
+        }
+        return false;
+    }
+
     // CQL Type Parsing
 
     public abstract CqlField.CqlType readType(CqlField.CqlType.InternalType type, Input input);

--- a/cassandra-bridge/src/main/java/org/apache/cassandra/spark/data/CqlField.java
+++ b/cassandra-bridge/src/main/java/org/apache/cassandra/spark/data/CqlField.java
@@ -212,7 +212,7 @@ public class CqlField implements Serializable, Comparable<CqlField>
     {
         CqlFrozen frozen();
 
-        String createStatement(String keyspace);
+        String createStatement(CassandraBridge bridge, String keyspace);
 
         String keyspace();
 
@@ -263,7 +263,7 @@ public class CqlField implements Serializable, Comparable<CqlField>
         this.isPartitionKey = isPartitionKey;
         this.isClusteringColumn = isClusteringColumn;
         this.isStaticColumn = isStaticColumn;
-        this.name = name.replaceAll("\"", "");
+        this.name = name;
         this.type = type;
         this.position = position;
     }

--- a/cassandra-bridge/src/main/java/org/apache/cassandra/spark/data/CqlTable.java
+++ b/cassandra-bridge/src/main/java/org/apache/cassandra/spark/data/CqlTable.java
@@ -202,10 +202,10 @@ public class CqlTable implements Serializable
         return udts;
     }
 
-    public Set<String> udtCreateStmts()
+    public Set<String> udtCreateStmts(CassandraBridge bridge)
     {
         return udts.stream()
-                   .map(udt -> udt.createStatement(keyspace))
+                   .map(udt -> udt.createStatement(bridge, keyspace))
                    .collect(Collectors.toSet());
     }
 

--- a/cassandra-bridge/src/main/java/org/apache/cassandra/spark/data/DataLayer.java
+++ b/cassandra-bridge/src/main/java/org/apache/cassandra/spark/data/DataLayer.java
@@ -165,8 +165,8 @@ public abstract class DataLayer implements Serializable
     public abstract boolean isInPartition(int partitionId, BigInteger token, ByteBuffer key);
 
     public List<PartitionKeyFilter> partitionKeyFiltersInRange(
-            int partitionId,
-            List<PartitionKeyFilter> partitionKeyFilters) throws NoMatchFoundException
+    int partitionId,
+    List<PartitionKeyFilter> partitionKeyFilters) throws NoMatchFoundException
     {
         return partitionKeyFilters;
     }
@@ -224,7 +224,7 @@ public abstract class DataLayer implements Serializable
      * the Data.db file for out-of-range partitions.
      *
      * @return true if, the SSTableReader should attempt to read Summary.db and Index.db files
-     *         to find the start index offset into the Data.db file that overlaps with the Spark workers token range
+     * to find the start index offset into the Data.db file that overlaps with the Spark workers token range
      */
     public boolean readIndexOffset()
     {
@@ -306,8 +306,8 @@ public abstract class DataLayer implements Serializable
             if (filter instanceof EqualTo || filter instanceof In)
             {
                 String columnName = StringUtils.lowerCase(filter instanceof EqualTo
-                        ? ((EqualTo) filter).attribute()
-                        : ((In) filter).attribute());
+                                                          ? ((EqualTo) filter).attribute()
+                                                          : ((In) filter).attribute());
 
                 if (partitionKeys.contains(columnName))
                 {

--- a/cassandra-bridge/src/main/java/org/apache/cassandra/spark/utils/test/TestSchema.java
+++ b/cassandra-bridge/src/main/java/org/apache/cassandra/spark/utils/test/TestSchema.java
@@ -76,6 +76,7 @@ public final class TestSchema
         private int minCollectionSize = 16;
         private Integer blobSize = null;
         private boolean withCompression = true;
+        private boolean quoteIdentifiers = false;
 
         public Builder(CassandraBridge bridge)
         {
@@ -155,12 +156,18 @@ public final class TestSchema
             return this;
         }
 
+        public Builder withQuoteIdentifiers()
+        {
+            this.quoteIdentifiers = true;
+            return this;
+        }
+
         public TestSchema build()
         {
             if (!partitionKeys.isEmpty())
             {
                 return new TestSchema(
-                        bridge,
+                        this,
                         keyspace != null ? keyspace : "keyspace_" + UUID.randomUUID().toString().replaceAll("-", ""),
                         table != null ? table : "table_" + UUID.randomUUID().toString().replaceAll("-", ""),
                         IntStream.range(0, partitionKeys.size())
@@ -174,13 +181,8 @@ public final class TestSchema
                         IntStream.range(0, columns.size())
                                  .mapToObj(index -> columns.get(index).cloneWithPosition(partitionKeys.size() + clusteringKeys.size() + index))
                                  .sorted(Comparator.comparing(CqlField::name))
-                                 .collect(Collectors.toList()),
-                        sortOrders,
-                        insertFields,
-                        deleteFields,
-                        minCollectionSize,
-                        blobSize,
-                        withCompression);
+                                 .collect(Collectors.toList())
+                );
             }
             else
             {
@@ -208,6 +210,7 @@ public final class TestSchema
     private CassandraVersion version = null;
     private final int minCollectionSize;
     private final Integer blobSize;
+    private final boolean quoteIdentifiers;
 
     public static Builder builder(CassandraBridge bridge)
     {
@@ -228,33 +231,28 @@ public final class TestSchema
     }
 
     // CHECKSTYLE IGNORE: Constructor with many parameters
-    private TestSchema(CassandraBridge bridge,
+    private TestSchema(Builder builder,
                        @NotNull String keyspace,
                        @NotNull String table,
                        List<CqlField> partitionKeys,
                        List<CqlField> clusteringKeys,
-                       List<CqlField> columns,
-                       List<CqlField.SortOrder> sortOrders,
-                       @Nullable List<String> insertOverrides,
-                       @Nullable List<String> deleteFields,
-                       int minCollectionSize,
-                       @Nullable Integer blobSize,
-                       boolean withCompression)
+                       List<CqlField> columns)
     {
-        this.bridge = bridge;
+        this.bridge = builder.bridge;
         this.keyspace = keyspace;
         this.table = table;
         this.partitionKeys = partitionKeys;
         this.clusteringKeys = clusteringKeys;
-        this.minCollectionSize = minCollectionSize;
-        this.blobSize = blobSize;
+        this.minCollectionSize = builder.minCollectionSize;
+        this.blobSize = builder.blobSize;
         this.allFields = buildAllFields(partitionKeys, clusteringKeys, columns);
         this.fieldPositions = calculateFieldPositions(allFields);
-        this.createStatement = buildCreateStatement(columns, sortOrders, withCompression);
-        this.insertStatement = buildInsertStatement(columns, insertOverrides);
+        this.createStatement = buildCreateStatement(columns, builder.sortOrders, builder.withCompression);
+        this.insertStatement = buildInsertStatement(columns, builder.insertFields);
         this.updateStatement = buildUpdateStatement();
-        this.deleteStatement = buildDeleteStatement(deleteFields);
+        this.deleteStatement = buildDeleteStatement(builder.deleteFields);
         this.udts = getUdtsFromFields();
+        this.quoteIdentifiers = builder.quoteIdentifiers;
     }
 
     // We take allFields as a parameter here to ensure it's been created before use
@@ -289,9 +287,9 @@ public final class TestSchema
     private String buildDeleteStatement(@Nullable List<String> deleteFields)
     {
         StringBuilder deleteStmtBuilder = new StringBuilder().append("DELETE FROM ")
-                                                             .append(bridge.maybeQuoteIdentifier(keyspace))
+                                                             .append(maybeQuoteIdentifierIfRequested(keyspace))
                                                              .append(".")
-                                                             .append(bridge.maybeQuoteIdentifier(table))
+                                                             .append(maybeQuoteIdentifierIfRequested(table))
                                                              .append(" WHERE ");
         if (deleteFields != null)
         {
@@ -302,7 +300,7 @@ public final class TestSchema
         else
         {
             deleteStmtBuilder.append(allFields.stream()
-                                              .map(field -> bridge.maybeQuoteIdentifier(field.name()) + " = ?")
+                                              .map(field -> maybeQuoteIdentifierIfRequested(field.name()) + " = ?")
                                               .collect(Collectors.joining(" AND ")));
         }
         return deleteStmtBuilder.append(";")
@@ -311,20 +309,20 @@ public final class TestSchema
 
     private String buildUpdateStatement()
     {
-        StringBuilder updateStmtBuilder = new StringBuilder("UPDATE ").append(bridge.maybeQuoteIdentifier(keyspace))
+        StringBuilder updateStmtBuilder = new StringBuilder("UPDATE ").append(maybeQuoteIdentifierIfRequested(keyspace))
                                                                       .append(".")
-                                                                      .append(bridge.maybeQuoteIdentifier(table))
+                                                                      .append(maybeQuoteIdentifierIfRequested(table))
                                                                       .append(" SET ");
         updateStmtBuilder.append(allFields.stream()
                                           .sorted()
                                           .filter(field -> !field.isPartitionKey() && !field.isClusteringColumn())
-                                          .map(field -> bridge.maybeQuoteIdentifier(field.name()) + " = ?")
+                                          .map(field -> maybeQuoteIdentifierIfRequested(field.name()) + " = ?")
                                           .collect(Collectors.joining(", ")));
         updateStmtBuilder.append(" WHERE ");
         updateStmtBuilder.append(allFields.stream()
                                           .sorted()
                                           .filter(field -> field.isPartitionKey() || field.isClusteringColumn())
-                                          .map(field -> bridge.maybeQuoteIdentifier(field.name()) + " = ?")
+                                          .map(field -> maybeQuoteIdentifierIfRequested(field.name()) + " = ?")
                                           .collect(Collectors.joining(" AND ")));
         return updateStmtBuilder.append(";")
                                 .toString();
@@ -333,9 +331,9 @@ public final class TestSchema
     private String buildInsertStatement(List<CqlField> columns, @Nullable List<String> insertOverrides)
     {
         StringBuilder insertStmtBuilder = new StringBuilder().append("INSERT INTO ")
-                                                             .append(bridge.maybeQuoteIdentifier(keyspace))
+                                                             .append(maybeQuoteIdentifierIfRequested(keyspace))
                                                              .append(".")
-                                                             .append(bridge.maybeQuoteIdentifier(table))
+                                                             .append(maybeQuoteIdentifierIfRequested(table))
                                                              .append(" (");
         if (insertOverrides != null)
         {
@@ -349,7 +347,7 @@ public final class TestSchema
         {
             insertStmtBuilder.append(allFields.stream()
                                               .sorted()
-                                              .map(cqlField -> bridge.maybeQuoteIdentifier(cqlField.name()))
+                                              .map(cqlField -> maybeQuoteIdentifierIfRequested(cqlField.name()))
                                               .collect(Collectors.joining(", ")))
                              .append(") VALUES (")
                              .append(Stream.of(partitionKeys, clusteringKeys, columns)
@@ -367,16 +365,16 @@ public final class TestSchema
                                         boolean withCompression)
     {
         StringBuilder createStmtBuilder = new StringBuilder().append("CREATE TABLE ")
-                                                             .append(bridge.maybeQuoteIdentifier(keyspace))
+                                                             .append(maybeQuoteIdentifierIfRequested(keyspace))
                                                              .append(".")
-                                                             .append(bridge.maybeQuoteIdentifier(table))
+                                                             .append(maybeQuoteIdentifierIfRequested(table))
                                                              .append(" (");
         for (CqlField field : Stream.of(partitionKeys, clusteringKeys, columns)
                                     .flatMap(Collection::stream)
                                     .sorted()
                                     .collect(Collectors.toList()))
         {
-            createStmtBuilder.append(bridge.maybeQuoteIdentifier(field.name()))
+            createStmtBuilder.append(maybeQuoteIdentifierIfRequested(field.name()))
                              .append(" ")
                              .append(field.cqlTypeName())
                              .append(field.isStaticColumn() ? " static" : "")
@@ -385,7 +383,7 @@ public final class TestSchema
 
         createStmtBuilder.append("PRIMARY KEY((")
                          .append(partitionKeys.stream()
-                                              .map(cqlField -> bridge.maybeQuoteIdentifier(cqlField.name()))
+                                              .map(cqlField -> maybeQuoteIdentifierIfRequested(cqlField.name()))
                                               .collect(Collectors.joining(", ")))
                          .append(")");
 
@@ -393,7 +391,7 @@ public final class TestSchema
         {
             createStmtBuilder.append(", ")
                              .append(clusteringKeys.stream()
-                                                   .map(cqlField -> bridge.maybeQuoteIdentifier(cqlField.name()))
+                                                   .map(cqlField -> maybeQuoteIdentifierIfRequested(cqlField.name()))
                                                    .collect(Collectors.joining(", ")));
         }
 
@@ -404,7 +402,7 @@ public final class TestSchema
             createStmtBuilder.append(" WITH CLUSTERING ORDER BY (");
             for (int sortOrder = 0; sortOrder < sortOrders.size(); sortOrder++)
             {
-                createStmtBuilder.append(bridge.maybeQuoteIdentifier(clusteringKeys.get(sortOrder).name()))
+                createStmtBuilder.append(maybeQuoteIdentifierIfRequested(clusteringKeys.get(sortOrder).name()))
                                  .append(" ")
                                  .append(sortOrders.get(sortOrder).toString());
                 if (sortOrder < sortOrders.size() - 1)
@@ -427,6 +425,13 @@ public final class TestSchema
     public void setCassandraVersion(@NotNull CassandraVersion version)
     {
         this.version = version;
+    }
+
+    private String maybeQuoteIdentifierIfRequested(String identifier)
+    {
+        return quoteIdentifiers
+               ? bridge.maybeQuoteIdentifier(identifier)
+               : identifier;
     }
 
     public CqlTable buildTable()

--- a/cassandra-bridge/src/main/java/org/apache/cassandra/spark/utils/test/TestSchema.java
+++ b/cassandra-bridge/src/main/java/org/apache/cassandra/spark/utils/test/TestSchema.java
@@ -64,6 +64,7 @@ public final class TestSchema
     @SuppressWarnings("SameParameterValue")
     public static class Builder
     {
+        private final CassandraBridge bridge;
         private String keyspace = null;
         private String table = null;
         private final List<CqlField> partitionKeys = new ArrayList<>();
@@ -75,6 +76,11 @@ public final class TestSchema
         private int minCollectionSize = 16;
         private Integer blobSize = null;
         private boolean withCompression = true;
+
+        public Builder(CassandraBridge bridge)
+        {
+            this.bridge = bridge;
+        }
 
         public Builder withKeyspace(String keyspace)
         {
@@ -154,6 +160,7 @@ public final class TestSchema
             if (!partitionKeys.isEmpty())
             {
                 return new TestSchema(
+                        bridge,
                         keyspace != null ? keyspace : "keyspace_" + UUID.randomUUID().toString().replaceAll("-", ""),
                         table != null ? table : "table_" + UUID.randomUUID().toString().replaceAll("-", ""),
                         IntStream.range(0, partitionKeys.size())
@@ -182,6 +189,7 @@ public final class TestSchema
         }
     }
 
+        private final CassandraBridge bridge;
     @NotNull
     public final String keyspace;
     public final String table;
@@ -201,14 +209,14 @@ public final class TestSchema
     private final int minCollectionSize;
     private final Integer blobSize;
 
-    public static Builder builder()
+    public static Builder builder(CassandraBridge bridge)
     {
-        return new Builder();
+        return new Builder(bridge);
     }
 
     public static Builder basicBuilder(CassandraBridge bridge)
     {
-        return TestSchema.builder()
+        return TestSchema.builder(bridge)
                          .withPartitionKey("a", bridge.aInt())
                          .withClusteringKey("b", bridge.aInt())
                          .withColumn("c", bridge.aInt());
@@ -220,7 +228,8 @@ public final class TestSchema
     }
 
     // CHECKSTYLE IGNORE: Constructor with many parameters
-    private TestSchema(@NotNull String keyspace,
+    private TestSchema(CassandraBridge bridge,
+                       @NotNull String keyspace,
                        @NotNull String table,
                        List<CqlField> partitionKeys,
                        List<CqlField> clusteringKeys,
@@ -232,6 +241,7 @@ public final class TestSchema
                        @Nullable Integer blobSize,
                        boolean withCompression)
     {
+        this.bridge = bridge;
         this.keyspace = keyspace;
         this.table = table;
         this.partitionKeys = partitionKeys;
@@ -279,9 +289,9 @@ public final class TestSchema
     private String buildDeleteStatement(@Nullable List<String> deleteFields)
     {
         StringBuilder deleteStmtBuilder = new StringBuilder().append("DELETE FROM ")
-                                                             .append(keyspace)
+                                                             .append(bridge.maybeQuoteIdentifier(keyspace))
                                                              .append(".")
-                                                             .append(table)
+                                                             .append(bridge.maybeQuoteIdentifier(table))
                                                              .append(" WHERE ");
         if (deleteFields != null)
         {
@@ -292,7 +302,7 @@ public final class TestSchema
         else
         {
             deleteStmtBuilder.append(allFields.stream()
-                                              .map(field -> field.name() + " = ?")
+                                              .map(field -> bridge.maybeQuoteIdentifier(field.name()) + " = ?")
                                               .collect(Collectors.joining(" AND ")));
         }
         return deleteStmtBuilder.append(";")
@@ -301,21 +311,21 @@ public final class TestSchema
 
     private String buildUpdateStatement()
     {
-        StringBuilder updateStmtBuilder = new StringBuilder("UPDATE ").append(keyspace)
+        StringBuilder updateStmtBuilder = new StringBuilder("UPDATE ").append(bridge.maybeQuoteIdentifier(keyspace))
                                                                       .append(".")
-                                                                      .append(table)
+                                                                      .append(bridge.maybeQuoteIdentifier(table))
                                                                       .append(" SET ");
         updateStmtBuilder.append(allFields.stream()
                                           .sorted()
                                           .filter(field -> !field.isPartitionKey() && !field.isClusteringColumn())
-                                          .map(field -> field.name() + " = ?")
+                                          .map(field -> bridge.maybeQuoteIdentifier(field.name()) + " = ?")
                                           .collect(Collectors.joining(", ")));
         updateStmtBuilder.append(" WHERE ");
         updateStmtBuilder.append(allFields.stream()
                                           .sorted()
                                           .filter(field -> field.isPartitionKey() || field.isClusteringColumn())
-                                          .map(field -> field.name() + " = ?")
-                                          .collect(Collectors.joining(" and ")));
+                                          .map(field -> bridge.maybeQuoteIdentifier(field.name()) + " = ?")
+                                          .collect(Collectors.joining(" AND ")));
         return updateStmtBuilder.append(";")
                                 .toString();
     }
@@ -323,9 +333,9 @@ public final class TestSchema
     private String buildInsertStatement(List<CqlField> columns, @Nullable List<String> insertOverrides)
     {
         StringBuilder insertStmtBuilder = new StringBuilder().append("INSERT INTO ")
-                                                             .append(keyspace)
+                                                             .append(bridge.maybeQuoteIdentifier(keyspace))
                                                              .append(".")
-                                                             .append(table)
+                                                             .append(bridge.maybeQuoteIdentifier(table))
                                                              .append(" (");
         if (insertOverrides != null)
         {
@@ -339,7 +349,7 @@ public final class TestSchema
         {
             insertStmtBuilder.append(allFields.stream()
                                               .sorted()
-                                              .map(CqlField::name)
+                                              .map(cqlField -> bridge.maybeQuoteIdentifier(cqlField.name()))
                                               .collect(Collectors.joining(", ")))
                              .append(") VALUES (")
                              .append(Stream.of(partitionKeys, clusteringKeys, columns)
@@ -357,16 +367,16 @@ public final class TestSchema
                                         boolean withCompression)
     {
         StringBuilder createStmtBuilder = new StringBuilder().append("CREATE TABLE ")
-                                                             .append(keyspace)
+                                                             .append(bridge.maybeQuoteIdentifier(keyspace))
                                                              .append(".")
-                                                             .append(table)
+                                                             .append(bridge.maybeQuoteIdentifier(table))
                                                              .append(" (");
         for (CqlField field : Stream.of(partitionKeys, clusteringKeys, columns)
                                     .flatMap(Collection::stream)
                                     .sorted()
                                     .collect(Collectors.toList()))
         {
-            createStmtBuilder.append(field.name())
+            createStmtBuilder.append(bridge.maybeQuoteIdentifier(field.name()))
                              .append(" ")
                              .append(field.cqlTypeName())
                              .append(field.isStaticColumn() ? " static" : "")
@@ -375,7 +385,7 @@ public final class TestSchema
 
         createStmtBuilder.append("PRIMARY KEY((")
                          .append(partitionKeys.stream()
-                                              .map(CqlField::name)
+                                              .map(cqlField -> bridge.maybeQuoteIdentifier(cqlField.name()))
                                               .collect(Collectors.joining(", ")))
                          .append(")");
 
@@ -383,7 +393,7 @@ public final class TestSchema
         {
             createStmtBuilder.append(", ")
                              .append(clusteringKeys.stream()
-                                                   .map(CqlField::name)
+                                                   .map(cqlField -> bridge.maybeQuoteIdentifier(cqlField.name()))
                                                    .collect(Collectors.joining(", ")));
         }
 
@@ -394,7 +404,7 @@ public final class TestSchema
             createStmtBuilder.append(" WITH CLUSTERING ORDER BY (");
             for (int sortOrder = 0; sortOrder < sortOrders.size(); sortOrder++)
             {
-                createStmtBuilder.append(clusteringKeys.get(sortOrder).name())
+                createStmtBuilder.append(bridge.maybeQuoteIdentifier(clusteringKeys.get(sortOrder).name()))
                                  .append(" ")
                                  .append(sortOrders.get(sortOrder).toString());
                 if (sortOrder < sortOrders.size() - 1)

--- a/cassandra-bridge/src/main/java/org/apache/cassandra/spark/utils/test/TestSchema.java
+++ b/cassandra-bridge/src/main/java/org/apache/cassandra/spark/utils/test/TestSchema.java
@@ -156,7 +156,7 @@ public final class TestSchema
             return this;
         }
 
-        public Builder withQuoteIdentifiers()
+        public Builder withQuotedIdentifiers()
         {
             this.quoteIdentifiers = true;
             return this;
@@ -239,6 +239,7 @@ public final class TestSchema
                        List<CqlField> columns)
     {
         this.bridge = builder.bridge;
+        this.quoteIdentifiers = builder.quoteIdentifiers;
         this.keyspace = keyspace;
         this.table = table;
         this.partitionKeys = partitionKeys;
@@ -252,7 +253,6 @@ public final class TestSchema
         this.updateStatement = buildUpdateStatement();
         this.deleteStatement = buildDeleteStatement(builder.deleteFields);
         this.udts = getUdtsFromFields();
-        this.quoteIdentifiers = builder.quoteIdentifiers;
     }
 
     // We take allFields as a parameter here to ensure it's been created before use

--- a/cassandra-four-zero/src/main/java/org/apache/cassandra/bridge/CassandraBridgeImplementation.java
+++ b/cassandra-four-zero/src/main/java/org/apache/cassandra/bridge/CassandraBridgeImplementation.java
@@ -163,7 +163,7 @@ public class CassandraBridgeImplementation extends CassandraBridge
             {
                 throw new RuntimeException(exception);
             }
-            config.data_file_directories = new String[]{ tempDirectory.toString() };
+            config.data_file_directories = new String[]{tempDirectory.toString()};
             DatabaseDescriptor.setEndpointSnitch(new SimpleSnitch());
             Keyspace.setInitialized();
 
@@ -245,16 +245,17 @@ public class CassandraBridgeImplementation extends CassandraBridge
         // NOTE: Need to use SchemaBuilder to init keyspace if not already set in Cassandra Schema instance
         SchemaBuilder schemaBuilder = new SchemaBuilder(table, partitioner);
         TableMetadata metadata = schemaBuilder.tableMetaData();
-        return new CompactionStreamScanner(metadata, partitioner, timeProvider, ssTables.openAll((ssTable, isRepairPrimary) ->
-                                                                                                 org.apache.cassandra.spark.reader.SSTableReader.builder(metadata, ssTable)
-                                                                                                                                                .withSparkRangeFilter(sparkRangeFilter)
-                                                                                                                                                .withPartitionKeyFilters(partitionKeyFilters)
-                                                                                                                                                .withColumnFilter(columnFilter)
-                                                                                                                                                .withReadIndexOffset(readIndexOffset)
-                                                                                                                                                .withStats(stats)
-                                                                                                                                                .useIncrementalRepair(useIncrementalRepair)
-                                                                                                                                                .isRepairPrimary(isRepairPrimary)
-                                                                                                                                                .build()));
+        return new CompactionStreamScanner(metadata, partitioner, timeProvider, ssTables.openAll((ssTable, isRepairPrimary) -> {
+            return org.apache.cassandra.spark.reader.SSTableReader.builder(metadata, ssTable)
+                                                                  .withSparkRangeFilter(sparkRangeFilter)
+                                                                  .withPartitionKeyFilters(partitionKeyFilters)
+                                                                  .withColumnFilter(columnFilter)
+                                                                  .withReadIndexOffset(readIndexOffset)
+                                                                  .withStats(stats)
+                                                                  .useIncrementalRepair(useIncrementalRepair)
+                                                                  .isRepairPrimary(isRepairPrimary)
+                                                                  .build();
+        }));
     }
 
     @Override
@@ -313,8 +314,10 @@ public class CassandraBridgeImplementation extends CassandraBridge
     @Override
     public String maybeQuoteIdentifier(String identifier)
     {
-        if (isAlreadyQuoted(identifier)) {
-            return identifier; }
+        if (isAlreadyQuoted(identifier))
+        {
+            return identifier;
+        }
         return ColumnIdentifier.maybeQuote(identifier);
     }
 

--- a/cassandra-four-zero/src/main/java/org/apache/cassandra/bridge/CassandraBridgeImplementation.java
+++ b/cassandra-four-zero/src/main/java/org/apache/cassandra/bridge/CassandraBridgeImplementation.java
@@ -51,6 +51,7 @@ import com.esotericsoftware.kryo.Serializer;
 import com.esotericsoftware.kryo.io.Input;
 import org.apache.cassandra.config.Config;
 import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.cql3.ColumnIdentifier;
 import org.apache.cassandra.db.Keyspace;
 import org.apache.cassandra.db.marshal.AbstractType;
 import org.apache.cassandra.db.marshal.ByteBufferAccessor;
@@ -162,7 +163,7 @@ public class CassandraBridgeImplementation extends CassandraBridge
             {
                 throw new RuntimeException(exception);
             }
-            config.data_file_directories = new String[]{tempDirectory.toString()};
+            config.data_file_directories = new String[]{ tempDirectory.toString() };
             DatabaseDescriptor.setEndpointSnitch(new SimpleSnitch());
             Keyspace.setInitialized();
 
@@ -245,17 +246,18 @@ public class CassandraBridgeImplementation extends CassandraBridge
         SchemaBuilder schemaBuilder = new SchemaBuilder(table, partitioner);
         TableMetadata metadata = schemaBuilder.tableMetaData();
         return new CompactionStreamScanner(metadata, partitioner, timeProvider, ssTables.openAll((ssTable, isRepairPrimary) ->
-                org.apache.cassandra.spark.reader.SSTableReader.builder(metadata, ssTable)
-                                                               .withSparkRangeFilter(sparkRangeFilter)
-                                                               .withPartitionKeyFilters(partitionKeyFilters)
-                                                               .withColumnFilter(columnFilter)
-                                                               .withReadIndexOffset(readIndexOffset)
-                                                               .withStats(stats)
-                                                               .useIncrementalRepair(useIncrementalRepair)
-                                                               .isRepairPrimary(isRepairPrimary)
-                                                               .build()));
+                                                                                                 org.apache.cassandra.spark.reader.SSTableReader.builder(metadata, ssTable)
+                                                                                                                                                .withSparkRangeFilter(sparkRangeFilter)
+                                                                                                                                                .withPartitionKeyFilters(partitionKeyFilters)
+                                                                                                                                                .withColumnFilter(columnFilter)
+                                                                                                                                                .withReadIndexOffset(readIndexOffset)
+                                                                                                                                                .withStats(stats)
+                                                                                                                                                .useIncrementalRepair(useIncrementalRepair)
+                                                                                                                                                .isRepairPrimary(isRepairPrimary)
+                                                                                                                                                .build()));
     }
 
+    @Override
     public StreamScanner<IndexEntry> getPartitionSizeIterator(@NotNull CqlTable table,
                                                               @NotNull Partitioner partitioner,
                                                               @NotNull SSTablesSupplier ssTables,
@@ -305,7 +307,15 @@ public class CassandraBridgeImplementation extends CassandraBridge
                                 @Nullable UUID tableId,
                                 int indexCount)
     {
-        return new SchemaBuilder(createStatement, keyspace, replicationFactor, partitioner, udts, tableId, indexCount).build();
+        return new SchemaBuilder(createStatement, keyspace, replicationFactor, partitioner, bridge -> udts, tableId, indexCount).build();
+    }
+
+    @Override
+    public String maybeQuoteIdentifier(String identifier)
+    {
+        if (isAlreadyQuoted(identifier)) {
+            return identifier; }
+        return ColumnIdentifier.maybeQuote(identifier);
     }
 
     // CQL Type Parser
@@ -524,16 +534,17 @@ public class CassandraBridgeImplementation extends CassandraBridge
                                           Consumer<Writer> writer)
     {
         CQLSSTableWriter.Builder builder = CQLSSTableWriter.builder()
-                                                                 .inDirectory(directory.toFile())
-                                                                 .forTable(createStatement)
-                                                                 .withPartitioner(getPartitioner(partitioner))
-                                                                 .using(upsert ? updateStatement : insertStatement)
-                                                                 .withBufferSizeInMB(128);
+                                                           .inDirectory(directory.toFile())
+                                                           .forTable(createStatement)
+                                                           .withPartitioner(getPartitioner(partitioner))
+                                                           .using(upsert ? updateStatement : insertStatement)
+                                                           .withBufferSizeInMB(128);
 
         for (CqlField.CqlUdt udt : udts)
         {
             // Add user-defined types to CQL writer
-            builder.withType(udt.createStatement(keyspace));
+            String statement = udt.createStatement(this, keyspace);
+            builder.withType(statement);
         }
 
         // TODO: Remove me once CQLSSTableWriter.Builder synchronize on schema (see CASSANDRA-TBD)
@@ -584,12 +595,12 @@ public class CassandraBridgeImplementation extends CassandraBridge
                                       Consumer<Writer> consumer)
     {
         try (SSTableTombstoneWriter writer = SSTableTombstoneWriter.builder()
-                                                                         .inDirectory(directory.toFile())
-                                                                         .forTable(createStatement)
-                                                                         .withPartitioner(getPartitioner(partitioner))
-                                                                         .using(deleteStatement)
-                                                                         .withBufferSizeInMB(128)
-                                                                         .build())
+                                                                   .inDirectory(directory.toFile())
+                                                                   .forTable(createStatement)
+                                                                   .withPartitioner(getPartitioner(partitioner))
+                                                                   .using(deleteStatement)
+                                                                   .withBufferSizeInMB(128)
+                                                                   .build())
         {
             consumer.accept(values -> {
                 try

--- a/cassandra-four-zero/src/main/java/org/apache/cassandra/spark/data/complex/CqlUdt.java
+++ b/cassandra-four-zero/src/main/java/org/apache/cassandra/spark/data/complex/CqlUdt.java
@@ -352,19 +352,25 @@ public class CqlUdt extends CqlType implements CqlField.CqlUdt
         return InternalType.Udt;
     }
 
-    public String createStatement(String keyspace)
+    @Override
+    public String createStatement(CassandraBridge bridge, String keyspace)
     {
-        return String.format("CREATE TYPE %s.%s (%s);", keyspace, name, fieldsString());
+        return String.format("CREATE TYPE %s.%s (%s);",
+                             bridge.maybeQuoteIdentifier(keyspace),
+                             bridge.maybeQuoteIdentifier(name),
+                             fieldsString(bridge));
     }
 
-    private String fieldsString()
+    private String fieldsString(CassandraBridge bridge)
     {
-        return fields.stream().map(CqlUdt::fieldString).collect(Collectors.joining(", "));
+        return fields.stream()
+                     .map(field -> fieldString(bridge, field))
+                     .collect(Collectors.joining(", "));
     }
 
-    private static String fieldString(CqlField field)
+    private static String fieldString(CassandraBridge bridge, CqlField field)
     {
-        return String.format("%s %s", field.name(), field.type().cqlName());
+        return String.format("%s %s", bridge.maybeQuoteIdentifier(field.name()), field.type().cqlName());
     }
 
     public String keyspace()

--- a/cassandra-four-zero/src/test/java/org/apache/cassandra/spark/reader/IndexReaderTests.java
+++ b/cassandra-four-zero/src/test/java/org/apache/cassandra/spark/reader/IndexReaderTests.java
@@ -60,7 +60,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.quicktheories.QuickTheory.qt;

--- a/cassandra-four-zero/src/test/java/org/apache/cassandra/spark/reader/IndexReaderTests.java
+++ b/cassandra-four-zero/src/test/java/org/apache/cassandra/spark/reader/IndexReaderTests.java
@@ -181,11 +181,11 @@ public class IndexReaderTests
                     TokenRange.closed(partitioner.minToken().add(eighth),
                                       partitioner.maxToken().subtract(eighth))
                     );
-                    TestSchema schema = TestSchema.builder()
-                                                        .withPartitionKey("a", BRIDGE.aInt())
-                                                        .withColumn("b", BRIDGE.blob())
-                                                        .withCompression(withCompression)
-                                                        .build();
+                    TestSchema schema = TestSchema.builder(BRIDGE)
+                                                  .withPartitionKey("a", BRIDGE.aInt())
+                                                  .withColumn("b", BRIDGE.blob())
+                                                  .withCompression(withCompression)
+                                                  .build();
                     CqlTable table = schema.buildTable();
                     TableMetadata metaData = new SchemaBuilder(schema.createStatement, schema.keyspace, schema.rf, partitioner).tableMetaData();
 

--- a/cassandra-four-zero/src/test/java/org/apache/cassandra/spark/reader/PartitionKeyTests.java
+++ b/cassandra-four-zero/src/test/java/org/apache/cassandra/spark/reader/PartitionKeyTests.java
@@ -48,7 +48,7 @@ public class PartitionKeyTests
     public void testBuildPartitionKey()
     {
         qt().forAll(arbitrary().pick(BRIDGE.supportedTypes())).checkAssert(partitionKeyType -> {
-            CqlTable table = TestSchema.builder()
+            CqlTable table = TestSchema.builder(BRIDGE)
                                        .withPartitionKey("a", partitionKeyType)
                                        .withClusteringKey("b", BRIDGE.aInt())
                                        .withColumn("c", BRIDGE.aInt())
@@ -66,7 +66,7 @@ public class PartitionKeyTests
     public void testBuildCompositePartitionKey()
     {
         qt().forAll(arbitrary().pick(BRIDGE.supportedTypes())).checkAssert(partitionKeyType -> {
-            CqlTable table = TestSchema.builder()
+            CqlTable table = TestSchema.builder(BRIDGE)
                                        .withPartitionKey("a", BRIDGE.aInt())
                                        .withPartitionKey("b", partitionKeyType)
                                        .withPartitionKey("c", BRIDGE.text())

--- a/cassandra-four-zero/src/test/java/org/apache/cassandra/spark/reader/SSTableReaderTests.java
+++ b/cassandra-four-zero/src/test/java/org/apache/cassandra/spark/reader/SSTableReaderTests.java
@@ -947,7 +947,7 @@ public class SSTableReaderTests
             .checkAssert(partitioner -> {
                 try (TemporaryDirectory directory = new TemporaryDirectory())
                 {
-                    TestSchema schema = TestSchema.builder()
+                    TestSchema schema = TestSchema.builder(BRIDGE)
                                                   .withPartitionKey("a", BRIDGE.text())
                                                   .withClusteringKey("b", BRIDGE.aInt())
                                                   .withColumn("c", BRIDGE.aInt())

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -63,7 +63,7 @@
     <!-- See https://checkstyle.org/config_sizes.html -->
     <module name="FileLength">
         <property name="fileExtensions" value="java, xml, properties, gradle, sh" />
-        <property name="max" value="2500" />
+        <property name="max" value="3500" />
     </module>
     <module name="LineLength">
         <property name="fileExtensions" value="java, xml, properties, gradle, sh" />

--- a/scripts/build-sidecar.sh
+++ b/scripts/build-sidecar.sh
@@ -24,7 +24,7 @@ else
   SCRIPT_DIR=$( dirname -- "$( readlink -f -- "$0"; )"; )
   SIDECAR_REPO="${SIDECAR_REPO:-https://github.com/apache/cassandra-sidecar.git}"
   SIDECAR_BRANCH="${SIDECAR_BRANCH:-trunk}"
-  SIDECAR_COMMIT="${SIDECAR_COMMIT:-0dd7a14f7e70dc8a40d20eba5c78dc4f6a580e17}"
+  SIDECAR_COMMIT="${SIDECAR_COMMIT:-ad936f6482aee2a05fa45ba4fdd06267958298f6}"
   SIDECAR_JAR_DIR="$(dirname "${SCRIPT_DIR}/")/dependencies"
   SIDECAR_JAR_DIR=${CASSANDRA_DEP_DIR:-$SIDECAR_JAR_DIR}
   SIDECAR_BUILD_DIR="${SIDECAR_JAR_DIR}/sidecar-build"


### PR DESCRIPTION
Cassandra in nature is case insensitive when creating identifiers (i.e. keyspace names, table names, column names, etc). We can define a case-sensitive identifier or we can use a reserved word as an identifier by quoting it during DDL creation.

In the analytics library, bulk reads fail when we encounter these identifiers. In this, commit, we fix the issue by properly propagating information about whether identifiers need to be quoted by exposing a new data frame option (`quote_identifiers`). When set to `true`, it will maybe quote the keyspace/table and it will properly be able to read data when these situations are encountered.