### PR TITLE
CASSANDRA-19031: Fix bulk writing when using identifiers that need quotes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,6 +58,7 @@ jobs:
             SPARK_VERSION: "2"
             SCALA_VERSION: "2.11"
             JDK_VERSION: "1.8"
+            INTEGRATION_MAX_PARALLEL_FORKS: 2
 
       - store_artifacts:
           path: build/test-reports
@@ -85,6 +86,7 @@ jobs:
             SPARK_VERSION: "2"
             SCALA_VERSION: "2.12"
             JDK_VERSION: "1.8"
+            INTEGRATION_MAX_PARALLEL_FORKS: 2
 
       - store_artifacts:
           path: build/test-reports

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 1.0.0
+ * Fix bulk writing when using identifiers that need quotes (CASSANDRA-19031)
  * Fix bulk reading when using identifiers that need quotes (CASSANDRA-19024)
  * Remove unused dead code (CASSANDRA-19148)
  * Get Sidecar port through CassandraContext for more flexibility (CASSANDRA-19903)

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/bridge/CassandraBridgeFactory.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/bridge/CassandraBridgeFactory.java
@@ -124,12 +124,24 @@ public final class CassandraBridgeFactory
             Class<CassandraBridge> bridge = (Class<CassandraBridge>) loader.loadClass("org.apache.cassandra.bridge.CassandraBridgeImplementation");
             Constructor<CassandraBridge> constructor = bridge.getConstructor();
             return constructor.newInstance();
-
         }
         catch (IOException | ClassNotFoundException | NoSuchMethodException | InstantiationException
              | IllegalAccessException | InvocationTargetException exception)
         {
             throw new RuntimeException("Failed to create Cassandra bridge for label " + label, exception);
         }
+    }
+
+    /***
+     * Returns the quoted name when the {@code quoteIdentifiers} parameter is {@code true} <i>AND</i> the
+     * {@code unquotedName} needs to be quoted (i.e. it uses mixed case, or it is a Cassandra reserved word).
+     * @param bridge the Cassandra bridge
+     * @param quoteIdentifiers whether identifiers should be quoted
+     * @param unquotedName the unquoted name to maybe be quoted
+     * @return the quoted name when the conditions are met
+     */
+    public static String maybeQuotedIdentifier(CassandraBridge bridge, boolean quoteIdentifiers, String unquotedName)
+    {
+        return quoteIdentifiers ? bridge.maybeQuoteIdentifier(unquotedName) : unquotedName;
     }
 }

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/BulkSparkConf.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/BulkSparkConf.java
@@ -126,6 +126,7 @@ public class BulkSparkConf implements Serializable
     protected final SparkConf conf;
     public final boolean validateSSTables;
     public final int commitThreadsPerInstance;
+    public boolean quoteIdentifiers;
     protected final int effectiveSidecarPort;
     protected final int userProvidedSidecarPort;
     protected boolean useOpenSsl;
@@ -166,6 +167,7 @@ public class BulkSparkConf implements Serializable
         this.ringRetryCount = getInt(RING_RETRY_COUNT, DEFAULT_RING_RETRY_COUNT);
         this.ttl = MapUtils.getOrDefault(options, WriterOptions.TTL.name(), null);
         this.timestamp = MapUtils.getOrDefault(options, WriterOptions.TIMESTAMP.name(), null);
+        this.quoteIdentifiers = MapUtils.getBoolean(options, WriterOptions.QUOTE_IDENTIFIERS.name(), false, "quote identifiers");
         validateEnvironment();
     }
 

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/CassandraJobInfo.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/CassandraJobInfo.java
@@ -113,9 +113,20 @@ public class CassandraJobInfo implements JobInfo
     }
 
     @Override
-    @NotNull
-    public String getFullTableName()
+    public boolean quoteIdentifiers()
     {
-        return conf.keyspace + "." + conf.table;
+        return conf.quoteIdentifiers;
+    }
+
+    @Override
+    public String keyspace()
+    {
+        return conf.keyspace;
+    }
+
+    @Override
+    public String tableName()
+    {
+        return conf.table;
     }
 }

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/JobInfo.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/JobInfo.java
@@ -52,6 +52,17 @@ public interface JobInfo extends Serializable
 
     boolean skipExtendedVerify();
 
-    String getFullTableName();
+    boolean quoteIdentifiers();
+
+    String keyspace();
+
+    String tableName();
+
+    @NotNull
+    default String getFullTableName()
+    {
+        return keyspace() + "." + tableName();
+    }
+
     boolean getSkipClean();
 }

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/TTLOption.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/TTLOption.java
@@ -22,6 +22,7 @@ package org.apache.cassandra.spark.bulkwriter;
 
 import java.io.Serializable;
 import java.time.Duration;
+import java.util.function.Function;
 
 public final class TTLOption implements Serializable
 {
@@ -111,12 +112,11 @@ public final class TTLOption implements Serializable
                 && (ttlColumnName != null || ttlInSeconds != null);
     }
 
-    @Override
-    public String toString()
+    public String toCQLString(Function<String, String> maybeQuoteFunction)
     {
         if (ttlColumnName != null && !ttlColumnName.isEmpty())
         {
-            return ":" + ttlColumnName;
+            return ":" + maybeQuoteFunction.apply(ttlColumnName);
         }
         if (ttlInSeconds != null)
         {

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/TimestampOption.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/TimestampOption.java
@@ -22,6 +22,7 @@ package org.apache.cassandra.spark.bulkwriter;
 import java.io.Serializable;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
+import java.util.function.Function;
 
 public final class TimestampOption implements Serializable
 {
@@ -109,12 +110,11 @@ public final class TimestampOption implements Serializable
                 && (timestampColumnName != null || timeStampInMicroSeconds != null);
     }
 
-    @Override
-    public String toString()
+    public String toCQLString(Function<String, String> maybeQuoteFunction)
     {
         if (timestampColumnName != null && !timestampColumnName.isEmpty())
         {
-            return ":" + timestampColumnName;
+            return ":" + maybeQuoteFunction.apply(timestampColumnName);
         }
         if (timeStampInMicroSeconds != null)
         {

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/WriterOptions.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/WriterOptions.java
@@ -45,5 +45,10 @@ public enum WriterOptions implements WriterOption
     ROW_BUFFER_MODE,
     SSTABLE_DATA_SIZE_IN_MB,
     TTL,
-    TIMESTAMP
+    TIMESTAMP,
+    /**
+     * Option that specifies whether the identifiers (i.e. keyspace, table name, column names) should be quoted to
+     * support mixed case and reserved keyword names for these fields.
+     */
+    QUOTE_IDENTIFIERS,
 }

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/util/SbwKryoRegistrator.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/util/SbwKryoRegistrator.java
@@ -53,7 +53,7 @@ public class SbwKryoRegistrator implements KryoRegistrator
     {
         LOGGER.debug("Registering Spark Bulk Writer classes with Kryo which require use of Java Serializer");
         // NOTE: The order of calls to `register` matters, so we sort by class name just to make sure we always
-        //       register classess in the same order - HashSet doesn't guarantee its iteration order
+        //       register classes in the same order - HashSet doesn't guarantee its iteration order
         javaSerializableClasses.stream()
                 .sorted(Comparator.comparing(Class::getCanonicalName))
                 .forEach(javaSerializableClass -> kryo.register(javaSerializableClass, new SbwJavaSerializer()));

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/BulkSparkConfTest.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/BulkSparkConfTest.java
@@ -268,6 +268,17 @@ public class BulkSparkConfTest
         assertEquals(bulkSparkConf.rowBufferMode, RowBufferMode.BUFFERED);
     }
 
+    @Test
+    void testQuoteIdentifiers()
+    {
+        assertFalse(bulkSparkConf.quoteIdentifiers);
+        Map<String, String> options = copyDefaultOptions();
+        options.put(WriterOptions.QUOTE_IDENTIFIERS.name(), "true");
+        BulkSparkConf bulkSparkConf = new BulkSparkConf(sparkConf, options);
+        assertNotNull(bulkSparkConf);
+        assertTrue(bulkSparkConf.quoteIdentifiers);
+    }
+
     private Map<String, String> copyDefaultOptions()
     {
         TreeMap<String, String> map = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);

--- a/cassandra-analytics-integration-tests/src/test/java/org/apache/cassandra/analytics/BulkWriteTtlTest.java
+++ b/cassandra-analytics-integration-tests/src/test/java/org/apache/cassandra/analytics/BulkWriteTtlTest.java
@@ -64,7 +64,7 @@ public class BulkWriteTtlTest extends IntegrationTestBase
                              + "          marks BIGINT\n"
                              + "     )  WITH default_time_to_live = 1;"
         );
-        waitForKeyspaceAndTable(keyspace, table);
+        waitUntilSidecarPicksUpSchemaChange(keyspace);
         boolean addTTLColumn = false;
         boolean addTimestampColumn = false;
         IntegrationTestJob.builder((recordNum) -> generateCourse(recordNum, null, null),
@@ -96,7 +96,7 @@ public class BulkWriteTtlTest extends IntegrationTestBase
                              + "          marks BIGINT\n"
                              + "     );"
         );
-        waitForKeyspaceAndTable(keyspace, table);
+        waitUntilSidecarPicksUpSchemaChange(keyspace);
         Map<String, String> writerOptions = ImmutableMap.of(WriterOptions.TTL.name(), TTLOption.constant(1));
         boolean addTTLColumn = false;
         boolean addTimestampColumn = false;
@@ -129,7 +129,7 @@ public class BulkWriteTtlTest extends IntegrationTestBase
                              + "          marks BIGINT\n"
                              + "     );"
         );
-        waitForKeyspaceAndTable(keyspace, table);
+        waitUntilSidecarPicksUpSchemaChange(keyspace);
         Map<String, String> writerOptions = ImmutableMap.of(WriterOptions.TTL.name(), TTLOption.perRow("ttl"));
         boolean addTTLColumn = true;
         boolean addTimestampColumn = false;

--- a/cassandra-analytics-integration-tests/src/test/java/org/apache/cassandra/analytics/QuoteIdentifiersWriteTest.java
+++ b/cassandra-analytics-integration-tests/src/test/java/org/apache/cassandra/analytics/QuoteIdentifiersWriteTest.java
@@ -1,0 +1,171 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cassandra.analytics;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.LongStream;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.vertx.junit5.VertxExtension;
+import org.apache.cassandra.distributed.api.ConsistencyLevel;
+import org.apache.cassandra.sidecar.testing.QualifiedName;
+import org.apache.cassandra.testing.CassandraIntegrationTest;
+import org.apache.spark.SparkContext;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.api.java.function.Function2;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.RowFactory;
+import org.apache.spark.sql.SQLContext;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.types.StructType;
+
+import static org.apache.spark.sql.types.DataTypes.BinaryType;
+import static org.apache.spark.sql.types.DataTypes.LongType;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests the bulk writer behavior when requiring quoted identifiers for keyspace, table name, and column names.
+ *
+ * <p>These tests exercise a full integration test, which includes testing Sidecar behavior when dealing with quoted
+ * identifiers.
+ */
+@ExtendWith(VertxExtension.class)
+class QuoteIdentifiersWriteTest extends SparkIntegrationTestBase
+{
+    static final int ROW_COUNT = 10_000;
+
+    @CassandraIntegrationTest(nodesPerDc = 1, gossip = true)
+    void testWriteWithMixedCaseKeyspaceName()
+    {
+        QualifiedName qualifiedTableName = uniqueTestTableFullName("QuOtEd_KeYsPaCe");
+        runWriteTestScenario(qualifiedTableName);
+    }
+
+    @CassandraIntegrationTest(nodesPerDc = 1, gossip = true)
+    void testWriteWithReservedWordKeyspaceName()
+    {
+        // keyspace is a reserved word
+        QualifiedName qualifiedTableName = uniqueTestTableFullName("keyspace");
+        runWriteTestScenario(qualifiedTableName);
+    }
+
+    @CassandraIntegrationTest(nodesPerDc = 1, gossip = true)
+    void testWriteWithMixedCaseTableName()
+    {
+        QualifiedName qualifiedTableName = uniqueTestTableFullName(TEST_KEYSPACE, "QuOtEd_TaBlE");
+        runWriteTestScenario(qualifiedTableName);
+    }
+
+    @CassandraIntegrationTest(nodesPerDc = 1, gossip = true)
+    void testWriteWithReservedWordTableName()
+    {
+        // table is a reserved word
+        runWriteTestScenario(new QualifiedName(TEST_KEYSPACE, "table"));
+    }
+
+    void runWriteTestScenario(QualifiedName tableName)
+    {
+        String quotedKeyspace = tableName.maybeQuotedKeyspace();
+        createTestKeyspace(quotedKeyspace, ImmutableMap.of("datacenter1", 1));
+        createTestTable(String.format("CREATE TABLE IF NOT EXISTS %s (\"IdEnTiFiEr\" bigint, course blob, \"limit\" bigint, PRIMARY KEY(\"IdEnTiFiEr\"));",
+                                      tableName));
+        waitUntilSidecarPicksUpSchemaChange(tableName.maybeQuotedKeyspace());
+
+        SparkSession spark = getOrCreateSparkSession();
+        SparkContext sc = spark.sparkContext();
+        JavaSparkContext javaSparkContext = JavaSparkContext.fromSparkContext(sc);
+        SQLContext sql = spark.sqlContext();
+
+        int parallelism = sc.defaultParallelism();
+        JavaRDD<Row> rows = genDataset(javaSparkContext, ROW_COUNT, parallelism);
+        Dataset<Row> df = sql.createDataFrame(rows, writeSchema());
+
+        bulkWriterDataFrameWriter(df, tableName).option("quote_identifiers", "true")
+                                                .save();
+        validateWrites(tableName, rows);
+    }
+
+    private void validateWrites(QualifiedName tableName, JavaRDD<Row> rowsWritten)
+    {
+        // build a set of entries read from Cassandra into a set
+        Set<String> actualEntries = Arrays.stream(sidecarTestContext.cassandraTestContext()
+                                                                    .cluster()
+                                                                    .coordinator(1)
+                                                                    .execute(String.format("SELECT * FROM %s;", tableName), ConsistencyLevel.LOCAL_QUORUM))
+                                          .map((Object[] columns) -> String.format("%s:%s:%s",
+                                                                                   new String(((ByteBuffer) columns[1]).array(), StandardCharsets.UTF_8),
+                                                                                   columns[0],
+                                                                                   columns[2]))
+                                          .collect(Collectors.toSet());
+
+        // Number of entries in Cassandra must match the original datasource
+        assertThat(actualEntries.size()).isEqualTo(rowsWritten.count());
+
+        // remove from actual entries to make sure that the data read is the same as the data written
+        rowsWritten.collect()
+                   .forEach(row -> {
+                       String key = String.format("%s:%d:%d",
+                                                  new String((byte[]) row.get(0), StandardCharsets.UTF_8),
+                                                  row.getLong(1),
+                                                  row.getLong(2));
+                       assertThat(actualEntries.remove(key)).as(key + " is expected to exist in the actual entries")
+                                                            .isTrue();
+                   });
+
+        // If this fails, it means there was more data in the database than we expected
+        assertThat(actualEntries).as("All entries are expected to be read from database")
+                                 .isEmpty();
+    }
+
+    static StructType writeSchema()
+    {
+        return new StructType()
+               .add("course", BinaryType, false)
+               .add("IdEnTiFiEr", LongType, false) // case-sensitive struct
+               .add("limit", LongType, false); // limit is a reserved word in Cassandra
+    }
+
+    private static JavaRDD<Row> genDataset(JavaSparkContext sc, int recordCount, Integer parallelism)
+    {
+        long recordsPerPartition = recordCount / parallelism;
+        long remainder = recordCount - (recordsPerPartition * parallelism);
+        List<Integer> seq = IntStream.range(0, parallelism).boxed().collect(Collectors.toList());
+        return sc.parallelize(seq, parallelism).mapPartitionsWithIndex(
+        (Function2<Integer, Iterator<Integer>, Iterator<Row>>) (index, integerIterator) -> {
+            long firstRecordNumber = index * recordsPerPartition;
+            long recordsToGenerate = index.equals(parallelism) ? remainder : recordsPerPartition;
+            return LongStream.range(0, recordsToGenerate).mapToObj(offset -> {
+                long limit = firstRecordNumber + offset;
+                return RowFactory.create(("course-" + limit).getBytes(), limit, limit);
+            }).iterator();
+        }, false);
+    }
+}

--- a/cassandra-analytics-integration-tests/src/test/java/org/apache/cassandra/analytics/SparkBulkWriterSimpleTest.java
+++ b/cassandra-analytics-integration-tests/src/test/java/org/apache/cassandra/analytics/SparkBulkWriterSimpleTest.java
@@ -57,7 +57,7 @@ public class SparkBulkWriterSimpleTest extends IntegrationTestBase
                              + "          course BLOB,\n"
                              + "          marks BIGINT\n"
                              + "     );");
-        waitForKeyspaceAndTable(keyspace, table);
+        waitUntilSidecarPicksUpSchemaChange(keyspace);
         Map<String, String> writerOptions = new HashMap<>();
         // A constant timestamp and TTL can be used by adding the following options to the writerOptions map
         // writerOptions.put(WriterOptions.TTL.name(), TTLOption.constant(20));


### PR DESCRIPTION
Cassandra treats all identifiers as lower case unless explicitly quoted by the users,
(i.e. keyspace names, table names, column names, etc). We can define a case-sensitive
identifier or we can use a reserved word as an identifier by quoting it during DDL
creation.

In the analytics library, bulk writing fails when we encounter these identifiers. In
this commit, we fix the issue by property propagating the information about whether
identifiers need to be quoted by exposing a new dataframe option (`quote_identifiers`).
When set to `true`, it will _maybe_ quote the keyspace/table/column names and it will
properly be able to write data when using mixed-case or reserved words in the
identifiers.