### PR TITLE
CASSANDRA-19048 - Audit table properties passed through Analytics CqlUtils

### DIFF
--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/CassandraClusterInfo.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/CassandraClusterInfo.java
@@ -252,7 +252,7 @@ public class CassandraClusterInfo implements ClusterInfo, Closeable
         String keyspaceSchema = getKeyspaceSchema(true);
         if (keyspaceSchema == null)
         {
-            throw new RuntimeException(String.format("Could not keyspace schema information for keyspace %s",
+            throw new RuntimeException(String.format("Could not retrieve keyspace schema information for keyspace %s",
                                                      conf.keyspace));
         }
         return CqlUtils.extractReplicationFactor(keyspaceSchema, conf.keyspace);

--- a/cassandra-analytics-integration-framework/build.gradle
+++ b/cassandra-analytics-integration-framework/build.gradle
@@ -19,8 +19,6 @@ import java.nio.file.Paths
  * under the License.
  */
 
-import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
-
 project(':cassandra-analytics-integration-framework') {
     apply(plugin: 'java-library')
     apply(plugin: 'com.github.johnrengelman.shadow')

--- a/cassandra-analytics-integration-framework/src/main/java/org/apache/cassandra/testing/CassandraTestTemplate.java
+++ b/cassandra-analytics-integration-framework/src/main/java/org/apache/cassandra/testing/CassandraTestTemplate.java
@@ -310,5 +310,12 @@ public class CassandraTestTemplate implements TestTemplateInvocationContextProvi
         System.setProperty("cassandra.test.dtest_jar_path", System.getProperty("cassandra.test.dtest_jar_path", "dtest-jars"));
         // Disable tcnative in netty as it can cause jni issues and logs lots errors
         System.setProperty("cassandra.disable_tcactive_openssl", "true");
+        // As we enable gossip by default, make the checks happen faster
+        System.setProperty("cassandra.gossip_settle_min_wait_ms", "500"); // Default 5000
+        System.setProperty("cassandra.gossip_settle_interval_ms", "250"); // Default 1000
+        System.setProperty("cassandra.gossip_settle_poll_success_required", "6"); // Default 3
+        // Using direct memory in in-jvm dtests has caused numerous OOMs
+        // Using the heap allocator instead resolves these issues.
+        System.setProperty("cassandra.netty_use_heap_allocator", "true");
     }
 }

--- a/cassandra-analytics-integration-tests/src/test/java/org/apache/cassandra/analytics/BulkWriteTtlTest.java
+++ b/cassandra-analytics-integration-tests/src/test/java/org/apache/cassandra/analytics/BulkWriteTtlTest.java
@@ -25,7 +25,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Function;
 
 import com.google.common.collect.ImmutableMap;
 import org.junit.jupiter.api.Assertions;
@@ -38,7 +37,6 @@ import org.apache.cassandra.sidecar.testing.IntegrationTestBase;
 import org.apache.cassandra.spark.bulkwriter.TTLOption;
 import org.apache.cassandra.spark.bulkwriter.WriterOptions;
 import org.apache.cassandra.testing.CassandraIntegrationTest;
-import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.RowFactory;
 import org.apache.spark.sql.types.StructType;
@@ -74,7 +72,6 @@ public class BulkWriteTtlTest extends IntegrationTestBase
                           .withTable(table)
                           .withSidecarPort(server.actualPort())
                           .withExtraWriterOptions(Collections.emptyMap())
-//                          .withPostWriteDfMods(writeToReadDfFunc(addTTLColumn, addTimestampColumn))
                           .shouldRead(false)
                           .run();
         // Wait to make sure TTLs have expired
@@ -108,7 +105,6 @@ public class BulkWriteTtlTest extends IntegrationTestBase
                           .withTable(table)
                           .withSidecarPort(server.actualPort())
                           .withExtraWriterOptions(writerOptions)
-//                          .withPostWriteDatasetModifier(writeToReadDfFunc(addTTLColumn, addTimestampColumn))
                           .shouldRead(false)
                           .run();
         // Wait to make sure TTLs have expired
@@ -142,7 +138,6 @@ public class BulkWriteTtlTest extends IntegrationTestBase
                           .withTable(table)
                           .withSidecarPort(server.actualPort())
                           .withExtraWriterOptions(writerOptions)
-                          .withPostWriteDatasetModifier(buildColumnRemovalFunction(addTTLColumn, addTimestampColumn))
                           .shouldRead(false)
                           .run();
         // Wait to make sure TTLs have expired
@@ -198,29 +193,5 @@ public class BulkWriteTtlTest extends IntegrationTestBase
             buffer.put(stringBytes);
         }
         return buffer.array();
-    }
-
-    /**
-     * Because the read part of the integration test job doesn't read ttl and timestamp columns, we need to remove them
-     * from the Dataset after it's saved.
-     * NOTE: This is here for demonstration purposes as we're not actually _using_ this (since we set `shouldRead`
-     * to `false` so the read doesn't actually happen any more.
-     * @param addedTTLColumn
-     * @param addedTimestampColumn
-     * @return
-     */
-    private Function<Dataset<Row>, Dataset<Row>> buildColumnRemovalFunction(boolean addedTTLColumn, boolean addedTimestampColumn)
-    {
-        return (Dataset<Row> df) -> {
-            if (addedTTLColumn)
-            {
-                df = df.drop("ttl");
-            }
-            if (addedTimestampColumn)
-            {
-                df = df.drop("timestamp");
-            }
-            return df;
-        };
     }
 }

--- a/cassandra-analytics-integration-tests/src/test/java/org/apache/cassandra/analytics/BulkWriteTtlTest.java
+++ b/cassandra-analytics-integration-tests/src/test/java/org/apache/cassandra/analytics/BulkWriteTtlTest.java
@@ -1,0 +1,226 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cassandra.analytics;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.jupiter.api.Assertions;
+
+import org.apache.cassandra.distributed.UpgradeableCluster;
+import org.apache.cassandra.distributed.api.ConsistencyLevel;
+import org.apache.cassandra.distributed.api.SimpleQueryResult;
+import org.apache.cassandra.distributed.shared.Uninterruptibles;
+import org.apache.cassandra.sidecar.testing.IntegrationTestBase;
+import org.apache.cassandra.spark.bulkwriter.TTLOption;
+import org.apache.cassandra.spark.bulkwriter.WriterOptions;
+import org.apache.cassandra.testing.CassandraIntegrationTest;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.RowFactory;
+import org.apache.spark.sql.types.StructType;
+import org.jetbrains.annotations.NotNull;
+
+import static org.apache.spark.sql.types.DataTypes.BinaryType;
+import static org.apache.spark.sql.types.DataTypes.IntegerType;
+import static org.apache.spark.sql.types.DataTypes.LongType;
+
+public class BulkWriteTtlTest extends IntegrationTestBase
+{
+    @CassandraIntegrationTest(nodesPerDc = 3)
+    public void testTableDefaultTtl()
+    {
+        UpgradeableCluster cluster = sidecarTestContext.cluster();
+        String keyspace = "spark_test";
+        String table = "test_default_ttl";
+        cluster.schemaChange("  CREATE KEYSPACE " + keyspace + " WITH replication = "
+                             + "{'class': 'NetworkTopologyStrategy', 'datacenter1': '3'}\n"
+                             + "      AND durable_writes = true;");
+        String qualifiedTableName = keyspace + '.' + table;
+        cluster.schemaChange("CREATE TABLE " + qualifiedTableName + " (\n"
+                             + "          id BIGINT PRIMARY KEY,\n"
+                             + "          course BLOB,\n"
+                             + "          marks BIGINT\n"
+                             + "     )  WITH default_time_to_live = 1;"
+        );
+        waitForKeyspaceAndTable(keyspace, table);
+        boolean addTTLColumn = false;
+        boolean addTimestampColumn = false;
+        IntegrationTestJob.builder((recordNum) -> generateCourse(recordNum, null, null),
+                                   getWriteSchema(addTTLColumn, addTimestampColumn))
+                          .withTable(table)
+                          .withSidecarPort(server.actualPort())
+                          .withExtraWriterOptions(Collections.emptyMap())
+//                          .withPostWriteDfMods(writeToReadDfFunc(addTTLColumn, addTimestampColumn))
+                          .shouldRead(false)
+                          .run();
+        // Wait to make sure TTLs have expired
+        Uninterruptibles.sleepUninterruptibly(1100, TimeUnit.MILLISECONDS);
+        SimpleQueryResult result = cluster.coordinator(1).executeWithResult("select * from " + qualifiedTableName, ConsistencyLevel.ALL);
+        Assertions.assertFalse(result.hasNext());
+    }
+
+    @CassandraIntegrationTest(nodesPerDc = 3)
+    public void testTtlOptionConstant()
+    {
+        UpgradeableCluster cluster = sidecarTestContext.cluster();
+        String keyspace = "spark_test";
+        String table = "test_ttl_constant";
+        cluster.schemaChange("  CREATE KEYSPACE " + keyspace + " WITH replication = "
+                             + "{'class': 'NetworkTopologyStrategy', 'datacenter1': '3'}\n"
+                             + "      AND durable_writes = true;");
+        String qualifiedTableName = keyspace + '.' + table;
+        cluster.schemaChange("CREATE TABLE " + qualifiedTableName + " (\n"
+                             + "          id BIGINT PRIMARY KEY,\n"
+                             + "          course BLOB,\n"
+                             + "          marks BIGINT\n"
+                             + "     );"
+        );
+        waitForKeyspaceAndTable(keyspace, table);
+        Map<String, String> writerOptions = ImmutableMap.of(WriterOptions.TTL.name(), TTLOption.constant(1));
+        boolean addTTLColumn = false;
+        boolean addTimestampColumn = false;
+        IntegrationTestJob.builder((recordNum) -> generateCourse(recordNum, null, null),
+                                   getWriteSchema(addTTLColumn, addTimestampColumn))
+                          .withTable(table)
+                          .withSidecarPort(server.actualPort())
+                          .withExtraWriterOptions(writerOptions)
+//                          .withPostWriteDatasetModifier(writeToReadDfFunc(addTTLColumn, addTimestampColumn))
+                          .shouldRead(false)
+                          .run();
+        // Wait to make sure TTLs have expired
+        Uninterruptibles.sleepUninterruptibly(1100, TimeUnit.MILLISECONDS);
+        SimpleQueryResult result = cluster.coordinator(1).executeWithResult("select * from " + qualifiedTableName, ConsistencyLevel.ALL);
+        Assertions.assertFalse(result.hasNext());
+    }
+
+    @CassandraIntegrationTest(nodesPerDc = 3)
+    public void testTtlOptionPerRow()
+    {
+        UpgradeableCluster cluster = sidecarTestContext.cluster();
+        String keyspace = "spark_test";
+        String table = "test_ttl_per_row";
+        cluster.schemaChange("  CREATE KEYSPACE " + keyspace + " WITH replication = "
+                             + "{'class': 'NetworkTopologyStrategy', 'datacenter1': '3'}\n"
+                             + "      AND durable_writes = true;");
+        String qualifiedTableName = keyspace + '.' + table;
+        cluster.schemaChange("CREATE TABLE " + qualifiedTableName + " (\n"
+                             + "          id BIGINT PRIMARY KEY,\n"
+                             + "          course BLOB,\n"
+                             + "          marks BIGINT\n"
+                             + "     );"
+        );
+        waitForKeyspaceAndTable(keyspace, table);
+        Map<String, String> writerOptions = ImmutableMap.of(WriterOptions.TTL.name(), TTLOption.perRow("ttl"));
+        boolean addTTLColumn = true;
+        boolean addTimestampColumn = false;
+        IntegrationTestJob.builder((recordNum) -> generateCourse(recordNum, 1, null),
+                                   getWriteSchema(addTTLColumn, addTimestampColumn))
+                          .withTable(table)
+                          .withSidecarPort(server.actualPort())
+                          .withExtraWriterOptions(writerOptions)
+                          .withPostWriteDatasetModifier(buildColumnRemovalFunction(addTTLColumn, addTimestampColumn))
+                          .shouldRead(false)
+                          .run();
+        // Wait to make sure TTLs have expired
+        Uninterruptibles.sleepUninterruptibly(1100, TimeUnit.MILLISECONDS);
+        SimpleQueryResult result = cluster.coordinator(1).executeWithResult("select * from " + qualifiedTableName, ConsistencyLevel.ALL);
+        Assertions.assertFalse(result.hasNext());
+    }
+
+    @SuppressWarnings("SameParameterValue")
+    private static StructType getWriteSchema(boolean addTTLColumn, boolean addTimestampColumn)
+    {
+        StructType schema = new StructType()
+                            .add("id", LongType, false)
+                            .add("course", BinaryType, false)
+                            .add("marks", LongType, false);
+        if (addTTLColumn)
+        {
+            schema = schema.add("ttl", IntegerType, false);
+        }
+        if (addTimestampColumn)
+        {
+            schema = schema.add("timestamp", LongType, false);
+        }
+        return schema;
+    }
+
+    @NotNull
+    @SuppressWarnings("SameParameterValue")
+    private static Row generateCourse(long recordNumber, Integer ttl, Long timestamp)
+    {
+        String courseNameString = String.valueOf(recordNumber);
+        int courseNameStringLen = courseNameString.length();
+        int courseNameMultiplier = 1000 / courseNameStringLen;
+        byte[] courseName = dupStringAsBytes(courseNameString, courseNameMultiplier);
+        ArrayList<Object> values = new ArrayList<>(Arrays.asList(recordNumber, courseName, recordNumber));
+        if (ttl != null)
+        {
+            values.add(ttl);
+        }
+        if (timestamp != null)
+        {
+            values.add(timestamp);
+        }
+        return RowFactory.create(values.toArray());
+    }
+
+    private static byte[] dupStringAsBytes(String string, Integer times)
+    {
+        byte[] stringBytes = string.getBytes();
+        ByteBuffer buffer = ByteBuffer.allocate(stringBytes.length * times);
+        for (int time = 0; time < times; time++)
+        {
+            buffer.put(stringBytes);
+        }
+        return buffer.array();
+    }
+
+    /**
+     * Because the read part of the integration test job doesn't read ttl and timestamp columns, we need to remove them
+     * from the Dataset after it's saved.
+     * NOTE: This is here for demonstration purposes as we're not actually _using_ this (since we set `shouldRead`
+     * to `false` so the read doesn't actually happen any more.
+     * @param addedTTLColumn
+     * @param addedTimestampColumn
+     * @return
+     */
+    private Function<Dataset<Row>, Dataset<Row>> buildColumnRemovalFunction(boolean addedTTLColumn, boolean addedTimestampColumn)
+    {
+        return (Dataset<Row> df) -> {
+            if (addedTTLColumn)
+            {
+                df = df.drop("ttl");
+            }
+            if (addedTimestampColumn)
+            {
+                df = df.drop("timestamp");
+            }
+            return df;
+        };
+    }
+}

--- a/cassandra-analytics-integration-tests/src/test/java/org/apache/cassandra/analytics/IntegrationTestJob.java
+++ b/cassandra-analytics-integration-tests/src/test/java/org/apache/cassandra/analytics/IntegrationTestJob.java
@@ -351,4 +351,29 @@ public final class IntegrationTestJob implements Serializable
             build().run();
         }
     }
+
+    /**
+     * An exmaple of a postWriteDatasetModifier.
+     * This function will remove `ttl` and `timestamp` columns from the dataframe after write, as
+     * the read part of the integration test job doesn't read ttl and timestamp columns, we need to remove them
+     * from the Dataset after it's saved so the final comparison works.
+     * @param addedTTLColumn if the "ttl" column was added to the dataframe.
+     * @param addedTimestampColumn if the "timestamp" column was added to the dataframe.
+     * @return the modified dataset
+     */
+    @SuppressWarnings("unused")
+    public static Function<Dataset<Row>, Dataset<Row>> ttlRemovalModifier(boolean addedTTLColumn, boolean addedTimestampColumn)
+    {
+        return (Dataset<Row> df) -> {
+            if (addedTTLColumn)
+            {
+                df = df.drop("ttl");
+            }
+            if (addedTimestampColumn)
+            {
+                df = df.drop("timestamp");
+            }
+            return df;
+        };
+    }
 }

--- a/cassandra-analytics-integration-tests/src/test/java/org/apache/cassandra/analytics/IntegrationTestJob.java
+++ b/cassandra-analytics-integration-tests/src/test/java/org/apache/cassandra/analytics/IntegrationTestJob.java
@@ -19,12 +19,13 @@
 
 package org.apache.cassandra.analytics;
 
-import java.nio.ByteBuffer;
-import java.util.ArrayList;
-import java.util.Arrays;
+import java.io.Serializable;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.LongStream;
@@ -34,9 +35,6 @@ import org.slf4j.LoggerFactory;
 
 import org.apache.cassandra.spark.KryoRegister;
 import org.apache.cassandra.spark.bulkwriter.BulkSparkConf;
-import org.apache.cassandra.spark.bulkwriter.TTLOption;
-import org.apache.cassandra.spark.bulkwriter.TimestampOption;
-import org.apache.cassandra.spark.bulkwriter.WriterOptions;
 import org.apache.spark.SparkConf;
 import org.apache.spark.SparkContext;
 import org.apache.spark.api.java.JavaRDD;
@@ -45,146 +43,104 @@ import org.apache.spark.api.java.function.Function2;
 import org.apache.spark.sql.DataFrameWriter;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
-import org.apache.spark.sql.RowFactory;
 import org.apache.spark.sql.SQLContext;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.types.StructType;
-
-import static org.apache.spark.sql.types.DataTypes.BinaryType;
-import static org.apache.spark.sql.types.DataTypes.IntegerType;
-import static org.apache.spark.sql.types.DataTypes.LongType;
+import org.jetbrains.annotations.NotNull;
 
 /**
- * Example showcasing the Cassandra Spark Analytics write and read capabilities
- * <p>
- * Prepare your environment by creating the following keyspace and table
- * <p>
- * Schema for the {@code keyspace}:
- * <pre>
- *     CREATE KEYSPACE spark_test WITH replication = {'class': 'NetworkTopologyStrategy', 'datacenter1': '3'}
- *     AND durable_writes = true;
- * </pre>
- * <p>
- * Schema for the {@code table}:
- * <pre>
- *     CREATE TABLE spark_test.test (
- *         id BIGINT PRIMARY KEY,
- *         course BLOB,
- *         marks BIGINT
- *     );
- * </pre>
+ * Spark job for use in integration tests. It contains a framework for generating data,
+ * writing using the bulk writer, and then reading that data back using the reader.
+ * It has extension points for the actual row and schema generation.
  */
-public final class IntegrationTestJob
+public final class IntegrationTestJob implements Serializable
 {
     private static final Logger LOGGER = LoggerFactory.getLogger(IntegrationTestJob.class);
-    private static int sidecarPort;
+    @NotNull
+    private final RowGenerator rowGenerator;
+    // Transient because we only need it on the driver.
+    @NotNull
+    private final transient Function<Dataset<Row>, Dataset<Row>> postWriteDatasetModifier;
+    private final int rowCount;
+    private final int sidecarPort;
+    private final StructType writeSchema;
+    @NotNull
+    private final Map<String, String> extraWriterOptions;
+    private final boolean shouldWrite;
+    private final boolean shouldRead;
+    private final String table;
+    private String keyspace;
 
-    private IntegrationTestJob()
+    //CHECKSTYLE IGNORE: This is only called from the Builder
+    private IntegrationTestJob(@NotNull RowGenerator rowGenerator,
+                               @NotNull StructType writeSchema,
+                               @NotNull Function<Dataset<Row>, Dataset<Row>> postWriteDatasetModifier,
+                               @NotNull int rowCount,
+                               @NotNull int sidecarPort,
+                               @NotNull Map<String, String> extraWriterOptions,
+                               boolean shouldWrite,
+                               boolean shouldRead, String keyspace, String table)
     {
-        throw new IllegalStateException(getClass() + " is static utility class and shall not be instantiated");
+        this.rowGenerator = rowGenerator;
+        this.postWriteDatasetModifier = postWriteDatasetModifier;
+        this.rowCount = rowCount;
+        this.sidecarPort = sidecarPort;
+        this.writeSchema = writeSchema;
+        this.extraWriterOptions = extraWriterOptions;
+        this.shouldWrite = shouldWrite;
+        this.shouldRead = shouldRead;
+        this.keyspace = keyspace;
+        this.table = table;
     }
 
-    public static void main(String[] args)
+    public static Builder builder(RowGenerator rowGenerator, StructType writeSchema)
     {
-        if (args.length < 1)
+        return new Builder(rowGenerator, writeSchema);
+    }
+
+    private static void checkSmallDataFrameEquality(Dataset<Row> expected, Dataset<Row> actual)
+    {
+        if (actual == null)
         {
-            sidecarPort = 9043;
+            throw new NullPointerException("actual dataframe is null");
         }
-        else
+        if (expected == null)
         {
-            sidecarPort = Integer.parseInt(args[0]);
+            throw new NullPointerException("expected dataframe is null");
         }
-        LOGGER.info("Starting Spark job with args={}", Arrays.toString(args));
-
-        SparkConf sparkConf = new SparkConf().setAppName("Sample Spark Cassandra Bulk Reader Job")
-                                             .set("spark.master", "local[8]");
-
-        // Add SBW-specific settings
-        // TODO: Simplify setting up spark conf
-        BulkSparkConf.setupSparkConf(sparkConf, true);
-        KryoRegister.setup(sparkConf);
-
-        SparkSession spark = SparkSession
-                             .builder()
-                             .config(sparkConf)
-                             .getOrCreate();
-        SparkContext sc = spark.sparkContext();
-        SQLContext sql = spark.sqlContext();
-        LOGGER.info("Spark Conf: " + sparkConf.toDebugString());
-        int rowCount = 10_000;
-
-        try
+        // Simulate `actual` having fewer rows, but all match rows in `expected`.
+        // The previous implementation would consider these equal
+        // actual = actual.limit(1000);
+        if (!actual.exceptAll(expected).isEmpty() || !expected.exceptAll(actual).isEmpty())
         {
-            Dataset<Row> written = write(rowCount, sql, sc);
-            Dataset<Row> read = read(rowCount, sparkConf, sql, sc);
-            checkSmallDataFrameEquality(written, read);
-            LOGGER.info("Finished Spark job, shutting down...");
-            sc.stop();
-        }
-        catch (Throwable throwable)
-        {
-            LOGGER.error("Unexpected exception executing Spark job", throwable);
-            try
-            {
-                sc.stop();
-            }
-            catch (Throwable ignored)
-            {
-            }
-            throw throwable; // rethrow so the exception bubbles up to test usages.
+            throw new IllegalStateException("The content of the dataframes differs");
         }
     }
 
-    private static Dataset<Row> write(long rowCount, SQLContext sql, SparkContext sc)
+    private Dataset<Row> write(SQLContext sql, SparkContext sc)
     {
         JavaSparkContext javaSparkContext = JavaSparkContext.fromSparkContext(sc);
-        int parallelism = sc.defaultParallelism();
-        boolean addTTLColumn = false;
-        boolean addTimestampColumn = false;
-        JavaRDD<Row> rows = genDataset(javaSparkContext, rowCount, parallelism, addTTLColumn, addTimestampColumn);
-        Dataset<Row> df = sql.createDataFrame(rows, getWriteSchema(addTTLColumn, addTimestampColumn));
+        JavaRDD<Row> rows = genDataset(javaSparkContext, sc.defaultParallelism());
+        Dataset<Row> df = sql.createDataFrame(rows, writeSchema);
 
         DataFrameWriter<Row> dfWriter = df.write()
                                           .format("org.apache.cassandra.spark.sparksql.CassandraDataSink")
                                           .option("sidecar_instances", "localhost,localhost2,localhost3")
                                           .option("sidecar_port", sidecarPort)
-                                          .option("keyspace", "spark_test")
-                                          .option("table", "test")
+                                          .option("keyspace", keyspace)
+                                          .option("table", table)
                                           .option("local_dc", "datacenter1")
                                           .option("bulk_writer_cl", "LOCAL_QUORUM")
                                           .option("number_splits", "-1")
-                                          // A constant timestamp and TTL can be used by setting the following options.
-                                          // .option(WriterOptions.TTL.name(), TTLOption.constant(20))
-                                          // .option(WriterOptions.TIMESTAMP.name(), TimestampOption.constant(System.currentTimeMillis() * 1000))
                                           .mode("append");
-
-        List<String> addedColumns = new ArrayList<>();
-        if (addTTLColumn)
-        {
-            addedColumns.add("ttl");
-            dfWriter = dfWriter
-                       .option(WriterOptions.TTL.name(), TTLOption.perRow("ttl"));
-        }
-
-        if (addTimestampColumn)
-        {
-            addedColumns.add("timestamp");
-            dfWriter = dfWriter
-                       .option(WriterOptions.TIMESTAMP.name(), TimestampOption.perRow("timestamp"));
-        }
-
+        dfWriter.options(extraWriterOptions);
         dfWriter.save();
-
-        if (!addedColumns.isEmpty())
-        {
-            df = df.drop(addedColumns.toArray(new String[0]));
-        }
-
         return df;
     }
 
-    private static Dataset<Row> read(int expectedRowCount, SparkConf sparkConf, SQLContext sql, SparkContext sc)
+    private Dataset<Row> read(SparkConf sparkConf, SQLContext sql, SparkContext sc)
     {
+        int expectedRowCount = rowCount;
         int coresPerExecutor = sparkConf.getInt("spark.executor.cores", 1);
         int numExecutors = sparkConf.getInt("spark.dynamicAllocation.maxExecutors", sparkConf.getInt("spark.executor.instances", 1));
         int numCores = coresPerExecutor * numExecutors;
@@ -211,91 +167,188 @@ public final class IntegrationTestJob
 
         if (count != expectedRowCount)
         {
-                throw new RuntimeException(String.format("Expected %d records but found %d records",
-                                                         expectedRowCount,
-                                                         count));
+            throw new RuntimeException(String.format("Expected %d records but found %d records",
+                                                     expectedRowCount,
+                                                     count));
         }
         return df;
     }
 
-    private static StructType getWriteSchema(boolean addTTLColumn, boolean addTimestampColumn)
+    private JavaRDD<Row> genDataset(JavaSparkContext sc, int parallelism)
     {
-        StructType schema = new StructType()
-                            .add("id", LongType, false)
-                            .add("course", BinaryType, false)
-                            .add("marks", LongType, false);
-        if (addTTLColumn)
-        {
-            schema = schema.add("ttl", IntegerType, false);
-        }
-        if (addTimestampColumn)
-        {
-            schema = schema.add("timestamp", LongType, false);
-        }
-        return schema;
-    }
-
-    private static void checkSmallDataFrameEquality(Dataset<Row> expected, Dataset<Row> actual)
-    {
-        if (actual == null)
-        {
-            throw new NullPointerException("actual dataframe is null");
-        }
-        if (expected == null)
-        {
-            throw new NullPointerException("expected dataframe is null");
-        }
-        // Simulate `actual` having fewer rows, but all match rows in `expected`.
-        // The previous implementation would consider these equal
-        // actual = actual.limit(1000);
-        if (!actual.exceptAll(expected).isEmpty() || !expected.exceptAll(actual).isEmpty())
-        {
-            throw new IllegalStateException("The content of the dataframes differs");
-        }
-    }
-
-    private static JavaRDD<Row> genDataset(JavaSparkContext sc, long records, Integer parallelism,
-                                           boolean addTTLColumn, boolean addTimestampColumn)
-    {
-        long recordsPerPartition = records / parallelism;
-        long remainder = records - (recordsPerPartition * parallelism);
+        long recordsPerPartition = rowCount / parallelism;
+        long remainder = rowCount - (recordsPerPartition * parallelism);
         List<Integer> seq = IntStream.range(0, parallelism).boxed().collect(Collectors.toList());
-        int ttl = 120; // data will not be queryable in two minutes
-        long timeStamp = System.currentTimeMillis() * 1000;
         JavaRDD<Row> dataset = sc.parallelize(seq, parallelism).mapPartitionsWithIndex(
         (Function2<Integer, Iterator<Integer>, Iterator<Row>>) (index, integerIterator) -> {
             long firstRecordNumber = index * recordsPerPartition;
             long recordsToGenerate = index.equals(parallelism) ? remainder : recordsPerPartition;
             java.util.Iterator<Row> rows = LongStream.range(0, recordsToGenerate).mapToObj(offset -> {
                 long recordNumber = firstRecordNumber + offset;
-                String courseNameString = String.valueOf(recordNumber);
-                Integer courseNameStringLen = courseNameString.length();
-                Integer courseNameMultiplier = 1000 / courseNameStringLen;
-                byte[] courseName = dupStringAsBytes(courseNameString, courseNameMultiplier);
-                ArrayList<Object> values = new ArrayList<>(Arrays.asList(recordNumber, courseName, recordNumber));
-                if (addTTLColumn)
-                {
-                    values.add(ttl);
-                }
-                if (addTimestampColumn)
-                {
-                    values.add(timeStamp);
-                }
-                return RowFactory.create(values.toArray());
+                return rowGenerator.rowFor(recordNumber);
             }).iterator();
             return rows;
         }, false);
         return dataset;
     }
 
-    private static byte[] dupStringAsBytes(String string, Integer times)
+    public void run()
     {
-        byte[] stringBytes = string.getBytes();
-        ByteBuffer buffer = ByteBuffer.allocate(stringBytes.length * times);
-        for (int time = 0; time < times; time++)
+        LOGGER.info("Starting Spark job with args={}", this);
+
+        SparkConf sparkConf = new SparkConf().setAppName("Sample Spark Cassandra Bulk Reader Job")
+                                             .set("spark.master", "local[8]");
+
+        // Add SBW-specific settings
+        // TODO: Simplify setting up spark conf
+        BulkSparkConf.setupSparkConf(sparkConf, true);
+        KryoRegister.setup(sparkConf);
+
+        SparkSession spark = SparkSession
+                             .builder()
+                             .config(sparkConf)
+                             .getOrCreate();
+        SparkContext sc = spark.sparkContext();
+        SQLContext sql = spark.sqlContext();
+        LOGGER.info("Spark Conf: " + sparkConf.toDebugString());
+
+        try
         {
-            buffer.put(stringBytes);
+            Dataset<Row> written = null;
+            Dataset<Row> read = null;
+            if (shouldWrite)
+            {
+                written = write(sql, sc);
+                written = postWriteDatasetModifier.apply(written);
+            }
+
+            if (shouldRead)
+            {
+                read = read(sparkConf, sql, sc);
+            }
+            if (read != null && written != null)
+            {
+                checkSmallDataFrameEquality(written, read);
+            }
+            LOGGER.info("Finished Spark job, shutting down...");
+            sc.stop();
         }
-        return buffer.array();
+        catch (Throwable throwable)
+        {
+            LOGGER.error("Unexpected exception executing Spark job", throwable);
+            try
+            {
+                sc.stop();
+            }
+            catch (Throwable ignored)
+            {
+            }
+            throw throwable; // rethrow so the exception bubbles up to test usages.
+        }
+    }
+
+    @Override
+    public String toString()
+    {
+        return "IntegrationTestJob: { \n " +
+               "    rowCount:%d,\n" +
+               "    parallelism:%d,\n" +
+               "    ttl:%d,\n" +
+               "    timestamp:%d,\n" +
+               "    sidecarPort:%d\n" +
+               "}";
+    }
+
+    @FunctionalInterface
+    public interface RowGenerator extends Serializable
+    {
+        Row rowFor(long recordNumber);
+    }
+
+    public static class Builder
+    {
+        private final RowGenerator rowGenerator;
+        private final StructType writeSchema;
+        private int rowCount = 10_000;
+        private int sidecarPort = 9043;
+        private Map<String, String> extraWriterOptions;
+        private Function<Dataset<Row>, Dataset<Row>> postWriteDatasetModifier = Function.identity();
+        private boolean shouldWrite = true;
+        private boolean shouldRead = true;
+        private String keyspace = "spark_test";
+        private String table = "test";
+
+        Builder(@NotNull RowGenerator rowGenerator, StructType writeSchema)
+        {
+            this.rowGenerator = rowGenerator;
+            this.writeSchema = writeSchema;
+        }
+
+        public Builder withKeyspace(String keyspace)
+        {
+            return update(builder -> builder.keyspace = keyspace);
+        }
+
+        public Builder withTable(String table)
+        {
+            return update(builder -> builder.table = table);
+        }
+
+        public Builder withRowCount(int rowCount)
+        {
+            return update(builder -> builder.rowCount = rowCount);
+        }
+
+        public Builder withSidecarPort(int sidecarPort)
+        {
+            return update(builder -> builder.sidecarPort = sidecarPort);
+        }
+
+        private Builder update(Consumer<Builder> update)
+        {
+            update.accept(this);
+            return this;
+        }
+
+        public Builder withExtraWriterOptions(Map<String, String> writerOptions)
+        {
+            return update(builder -> builder.extraWriterOptions = writerOptions);
+        }
+
+        public Builder withPostWriteDatasetModifier(Function<Dataset<Row>, Dataset<Row>> dataSetModifier)
+        {
+            return update(builder -> builder.postWriteDatasetModifier = dataSetModifier);
+        }
+
+
+        public Builder shouldWrite(boolean shouldWrite)
+        {
+            return update(builder -> builder.shouldWrite = shouldWrite);
+        }
+
+        public Builder shouldRead(boolean shouldRead)
+        {
+            return update(builder -> builder.shouldRead = shouldRead);
+        }
+
+
+        public IntegrationTestJob build()
+        {
+            return new IntegrationTestJob(this.rowGenerator,
+                                          this.writeSchema,
+                                          this.postWriteDatasetModifier,
+                                          this.rowCount,
+                                          this.sidecarPort,
+                                          this.extraWriterOptions,
+                                          this.shouldWrite,
+                                          this.shouldRead,
+                                          this.keyspace,
+                                          this.table);
+        }
+
+        public void run()
+        {
+            build().run();
+        }
     }
 }

--- a/cassandra-analytics-integration-tests/src/test/java/org/apache/cassandra/analytics/SparkBulkWriterSimpleTest.java
+++ b/cassandra-analytics-integration-tests/src/test/java/org/apache/cassandra/analytics/SparkBulkWriterSimpleTest.java
@@ -19,14 +19,31 @@
 
 package org.apache.cassandra.analytics;
 
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
 import org.apache.cassandra.distributed.UpgradeableCluster;
 import org.apache.cassandra.sidecar.testing.IntegrationTestBase;
 import org.apache.cassandra.testing.CassandraIntegrationTest;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.RowFactory;
+import org.apache.spark.sql.types.StructType;
+import org.jetbrains.annotations.NotNull;
+
+import static org.apache.spark.sql.types.DataTypes.BinaryType;
+import static org.apache.spark.sql.types.DataTypes.IntegerType;
+import static org.apache.spark.sql.types.DataTypes.LongType;
 
 public class SparkBulkWriterSimpleTest extends IntegrationTestBase
 {
+
     @CassandraIntegrationTest(nodesPerDc = 3)
-    public void runSampleJob() throws InterruptedException
+    public void runSampleJob()
     {
         UpgradeableCluster cluster = sidecarTestContext.cluster();
         String keyspace = "spark_test";
@@ -41,6 +58,88 @@ public class SparkBulkWriterSimpleTest extends IntegrationTestBase
                              + "          marks BIGINT\n"
                              + "     );");
         waitForKeyspaceAndTable(keyspace, table);
-        IntegrationTestJob.main(new String[]{String.valueOf(server.actualPort())});
+        Map<String, String> writerOptions = new HashMap<>();
+        // A constant timestamp and TTL can be used by adding the following options to the writerOptions map
+        // writerOptions.put(WriterOptions.TTL.name(), TTLOption.constant(20));
+        // writerOptions.put(WriterOptions.TIMESTAMP.name(), TimestampOption.constant(System.currentTimeMillis() * 1000));
+        // Then, set ttl or timestamp to non-null values.
+        Integer ttl = null;
+        Long timestamp = null;
+        @SuppressWarnings("ConstantValue")
+        boolean addTTLColumn = ttl != null;
+        @SuppressWarnings("ConstantValue")
+        boolean addTimestampColumn = timestamp != null;
+        IntegrationTestJob.builder((recordNum) -> generateCourse(recordNum, ttl, timestamp),
+                                   getWriteSchema(addTTLColumn, addTimestampColumn))
+                          .withSidecarPort(server.actualPort())
+                          .withExtraWriterOptions(writerOptions)
+                          .withPostWriteDatasetModifier(writeToReadDfFunc(addTTLColumn, addTimestampColumn))
+                          .run();
+    }
+
+    // Because the read part of the integration test job doesn't read ttl and timestamp columns, we need to remove them
+    // from the Dataset after it's saved.
+    private Function<Dataset<Row>, Dataset<Row>> writeToReadDfFunc(boolean addedTTLColumn, boolean addedTimestampColumn)
+    {
+        return (Dataset<Row> df) -> {
+            if (addedTTLColumn)
+            {
+                df = df.drop("ttl");
+            }
+            if (addedTimestampColumn)
+            {
+                df = df.drop("timestamp");
+            }
+            return df;
+        };
+    }
+
+    @SuppressWarnings("SameParameterValue")
+    private static StructType getWriteSchema(boolean addTTLColumn, boolean addTimestampColumn)
+    {
+        StructType schema = new StructType()
+                            .add("id", LongType, false)
+                            .add("course", BinaryType, false)
+                            .add("marks", LongType, false);
+        if (addTTLColumn)
+        {
+            schema = schema.add("ttl", IntegerType, false);
+        }
+        if (addTimestampColumn)
+        {
+            schema = schema.add("timestamp", LongType, false);
+        }
+        return schema;
+    }
+
+    @NotNull
+    @SuppressWarnings("SameParameterValue")
+    private static Row generateCourse(long recordNumber, Integer ttl, Long timestamp)
+    {
+        String courseNameString = String.valueOf(recordNumber);
+        int courseNameStringLen = courseNameString.length();
+        int courseNameMultiplier = 1000 / courseNameStringLen;
+        byte[] courseName = dupStringAsBytes(courseNameString, courseNameMultiplier);
+        ArrayList<Object> values = new ArrayList<>(Arrays.asList(recordNumber, courseName, recordNumber));
+        if (ttl != null)
+        {
+            values.add(ttl);
+        }
+        if (timestamp != null)
+        {
+            values.add(timestamp);
+        }
+        return RowFactory.create(values.toArray());
+    }
+
+    private static byte[] dupStringAsBytes(String string, Integer times)
+    {
+        byte[] stringBytes = string.getBytes();
+        ByteBuffer buffer = ByteBuffer.allocate(stringBytes.length * times);
+        for (int time = 0; time < times; time++)
+        {
+            buffer.put(stringBytes);
+        }
+        return buffer.array();
     }
 }


### PR DESCRIPTION
The following properties have an effect on the files generated by the bulk writer, and therefore need to be retained when cleaning the table schema:

bloom_filter_fp_chance
cdc
compression
default_time_to_live
min_index_interval
max_index_interval

Additionally, this commit adds tests to make sure all available TTL paths, including table default TTLs and constant/per-row options, work as designed.