### PR TITLE
[CASSANDRA-19377] Startup Validation Failures when Checking Sidecar Connectivity (Analytics)

### DIFF
--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/BulkSparkConf.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/BulkSparkConf.java
@@ -81,6 +81,7 @@ public class BulkSparkConf implements Serializable
     public static final int DEFAULT_SIDECAR_REQUEST_RETRIES = 10;
     public static final long DEFAULT_SIDECAR_REQUEST_RETRY_DELAY_MILLIS = TimeUnit.SECONDS.toMillis(1L);
     public static final long DEFAULT_SIDECAR_REQUEST_MAX_RETRY_DELAY_MILLIS = TimeUnit.SECONDS.toMillis(60L);
+    public static final int DEFAULT_SIDECAR_REQUEST_TIMEOUT_SECONDS = 300;
     public static final int DEFAULT_COMMIT_BATCH_SIZE = 10_000;
     public static final int DEFAULT_RING_RETRY_COUNT = 3;
     public static final RowBufferMode DEFAULT_ROW_BUFFER_MODE = RowBufferMode.UNBUFFERED;
@@ -98,6 +99,7 @@ public class BulkSparkConf implements Serializable
     public static final String SIDECAR_REQUEST_RETRIES                 = SETTING_PREFIX + "sidecar.request.retries";
     public static final String SIDECAR_REQUEST_RETRY_DELAY_MILLIS      = SETTING_PREFIX + "sidecar.request.retries.delay.milliseconds";
     public static final String SIDECAR_REQUEST_MAX_RETRY_DELAY_MILLIS  = SETTING_PREFIX + "sidecar.request.retries.max.delay.milliseconds";
+    public static final String SIDECAR_REQUEST_TIMEOUT_SECONDS         = SETTING_PREFIX + "sidecar.request.timeout.seconds";
     public static final String SKIP_CLEAN                              = SETTING_PREFIX + "job.skip_clean";
     public static final String USE_OPENSSL                             = SETTING_PREFIX + "use_openssl";
     public static final String RING_RETRY_COUNT                        = SETTING_PREFIX + "ring_retry_count";
@@ -383,6 +385,11 @@ public class BulkSparkConf implements Serializable
     public long getSidecarRequestMaxRetryDelayMillis()
     {
         return getLong(SIDECAR_REQUEST_MAX_RETRY_DELAY_MILLIS, DEFAULT_SIDECAR_REQUEST_MAX_RETRY_DELAY_MILLIS);
+    }
+
+    public int getSidecarRequestTimeoutSeconds()
+    {
+        return getInt(SIDECAR_REQUEST_TIMEOUT_SECONDS, DEFAULT_SIDECAR_REQUEST_TIMEOUT_SECONDS);
     }
 
     public int getHttpConnectionTimeoutMs()

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/CassandraContext.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/CassandraContext.java
@@ -111,8 +111,9 @@ public class CassandraContext implements StartupValidatable, Closeable
     @Override
     public void startupValidate()
     {
-        StartupValidator.instance().register(new SidecarValidation(sidecarClient));
-        StartupValidator.instance().register(new CassandraValidation(sidecarClient));
+        int timeoutSeconds = conf.getSidecarRequestTimeoutSeconds();
+        StartupValidator.instance().register(new SidecarValidation(sidecarClient, timeoutSeconds));
+        StartupValidator.instance().register(new CassandraValidation(sidecarClient, timeoutSeconds));
         StartupValidator.instance().perform();
     }
 }

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/data/CassandraDataLayer.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/data/CassandraDataLayer.java
@@ -629,8 +629,9 @@ public class CassandraDataLayer extends PartitionedDataLayer implements StartupV
     @Override
     public void startupValidate()
     {
-        StartupValidator.instance().register(new SidecarValidation(sidecar));
-        StartupValidator.instance().register(new CassandraValidation(sidecar));
+        int timeoutSeconds = sidecarClientConfig.timeoutSeconds();
+        StartupValidator.instance().register(new SidecarValidation(sidecar, timeoutSeconds));
+        StartupValidator.instance().register(new CassandraValidation(sidecar, timeoutSeconds));
         StartupValidator.instance().perform();
     }
 

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/validation/CassandraValidation.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/validation/CassandraValidation.java
@@ -29,7 +29,7 @@ import org.apache.cassandra.sidecar.common.data.HealthResponse;
  */
 public class CassandraValidation implements StartupValidation
 {
-    private static final int TIMEOUT_SECONDS = 60;
+    private static final int TIMEOUT_SECONDS = 300;
 
     private final SidecarClient sidecar;
 

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/validation/CassandraValidation.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/validation/CassandraValidation.java
@@ -29,13 +29,13 @@ import org.apache.cassandra.sidecar.common.data.HealthResponse;
  */
 public class CassandraValidation implements StartupValidation
 {
-    private static final int TIMEOUT_SECONDS = 300;
-
     private final SidecarClient sidecar;
+    private final int timeoutSeconds;
 
-    public CassandraValidation(SidecarClient sidecar)
+    public CassandraValidation(SidecarClient sidecar, int timeoutSeconds)
     {
         this.sidecar = sidecar;
+        this.timeoutSeconds = timeoutSeconds;
     }
 
     @Override
@@ -44,7 +44,7 @@ public class CassandraValidation implements StartupValidation
         HealthResponse health;
         try
         {
-            health = sidecar.cassandraHealth().get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            health = sidecar.cassandraHealth().get(timeoutSeconds, TimeUnit.SECONDS);
         }
         catch (Throwable throwable)
         {

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/validation/CassandraValidation.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/validation/CassandraValidation.java
@@ -29,7 +29,7 @@ import org.apache.cassandra.sidecar.common.data.HealthResponse;
  */
 public class CassandraValidation implements StartupValidation
 {
-    private static final int TIMEOUT_SECONDS = 30;
+    private static final int TIMEOUT_SECONDS = 60;
 
     private final SidecarClient sidecar;
 

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/validation/SidecarValidation.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/validation/SidecarValidation.java
@@ -29,7 +29,7 @@ import org.apache.cassandra.sidecar.common.data.HealthResponse;
  */
 public class SidecarValidation implements StartupValidation
 {
-    private static final int TIMEOUT_SECONDS = 30;
+    private static final int TIMEOUT_SECONDS = 60;
 
     private final SidecarClient sidecar;
 

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/validation/SidecarValidation.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/validation/SidecarValidation.java
@@ -29,7 +29,7 @@ import org.apache.cassandra.sidecar.common.data.HealthResponse;
  */
 public class SidecarValidation implements StartupValidation
 {
-    private static final int TIMEOUT_SECONDS = 60;
+    private static final int TIMEOUT_SECONDS = 300;
 
     private final SidecarClient sidecar;
 

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/validation/SidecarValidation.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/validation/SidecarValidation.java
@@ -29,13 +29,13 @@ import org.apache.cassandra.sidecar.common.data.HealthResponse;
  */
 public class SidecarValidation implements StartupValidation
 {
-    private static final int TIMEOUT_SECONDS = 300;
-
     private final SidecarClient sidecar;
+    private final int timeoutSeconds;
 
-    public SidecarValidation(SidecarClient sidecar)
+    public SidecarValidation(SidecarClient sidecar, int timeoutSeconds)
     {
         this.sidecar = sidecar;
+        this.timeoutSeconds = timeoutSeconds;
     }
 
     @Override
@@ -44,7 +44,7 @@ public class SidecarValidation implements StartupValidation
         HealthResponse health;
         try
         {
-            health = sidecar.sidecarHealth().get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            health = sidecar.sidecarHealth().get(timeoutSeconds, TimeUnit.SECONDS);
         }
         catch (Throwable throwable)
         {

--- a/scripts/build-sidecar.sh
+++ b/scripts/build-sidecar.sh
@@ -24,7 +24,7 @@ else
   SCRIPT_DIR=$( dirname -- "$( readlink -f -- "$0"; )"; )
   SIDECAR_REPO="${SIDECAR_REPO:-https://github.com/apache/cassandra-sidecar.git}"
   SIDECAR_BRANCH="${SIDECAR_BRANCH:-trunk}"
-  SIDECAR_COMMIT="${SIDECAR_COMMIT:-cd716c4c8a9f416e9af04f6e45ca7e89ace26829}"
+  SIDECAR_COMMIT="${SIDECAR_COMMIT:-2eb3474d7037a2887bcd9dee1f64c2a36a7e8d26}"
   SIDECAR_JAR_DIR="$(dirname "${SCRIPT_DIR}/")/dependencies"
   SIDECAR_JAR_DIR=${CASSANDRA_DEP_DIR:-$SIDECAR_JAR_DIR}
   SIDECAR_BUILD_DIR="${SIDECAR_JAR_DIR}/sidecar-build"


### PR DESCRIPTION
Increased the overall timeout for Sidecar health checks from current 30 seconds to 5 minutes and made it configurable.