### PR TITLE
CASSANDRA-19257 Fixes handling of blocked instances during CL validat…

### DIFF
--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/BulkWriteValidator.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/BulkWriteValidator.java
@@ -122,27 +122,43 @@ public class BulkWriteValidator
 
     private void validateAvailabilityAndUpdateFailures(RingInstance instance, InstanceAvailability availability)
     {
-        if (availability == InstanceAvailability.INVALID_STATE)
+        switch (availability)
         {
-            // If we find any nodes in a totally invalid state, just throw as we can't continue
-            String message = String.format("Instance (%s) is in an invalid state (%s) during import. "
-                                           + "Please rerun import once topology changes are complete.",
-                                           instance.getNodeName(), cluster.getInstanceState(instance));
-            throw new RuntimeException(message);
-        }
+            case INVALID_STATE:
+                // If we find any nodes in a totally invalid state, just throw as we can't continue
+                String errorMessage = String.format("Instance (%s) is in an invalid state (%s) during import. "
+                                                    + "Please rerun import once topology changes are complete.",
+                                                    instance.getNodeName(), cluster.getInstanceState(instance));
+                throw new RuntimeException(errorMessage);
 
-        if (availability == InstanceAvailability.UNAVAILABLE_BLOCKED
-            || availability == InstanceAvailability.UNAVAILABLE_DOWN)
-        {
-            Collection<Range<BigInteger>> failedRanges = cluster.getTokenRangeMapping(true)
-                                                                .getTokenRanges()
-                                                                .get(instance);
-            failedRanges.forEach(failedRange -> {
-                String nodeDisplayName = instance.getNodeName();
-                String message = String.format("%s %s", nodeDisplayName, availability.getMessage());
-                LOGGER.warn("{} failed in phase {} on {} because {}", failedRange, phase, nodeDisplayName, message);
-                failureHandler.addFailure(failedRange, instance, message);
-            });
+            // Check for blocked instances and ranges for the purpose of logging only.
+            // We check for blocked instances while validating consistency level requirements
+            case UNAVAILABLE_BLOCKED:
+                Collection<Range<BigInteger>> rangesInBlockedInstance = cluster.getTokenRangeMapping(true)
+                                                                               .getTokenRanges()
+                                                                               .get(instance);
+                rangesInBlockedInstance.forEach(failedRange -> {
+                    String nodeDisplayName = instance.getNodeName();
+                    String message = String.format("%s %s", nodeDisplayName, availability.getMessage());
+                    LOGGER.warn("{} failed in phase {} on {} because {}", failedRange, phase, nodeDisplayName, message);
+                });
+                break;
+
+            case UNAVAILABLE_DOWN:
+                Collection<Range<BigInteger>> failedRanges = cluster.getTokenRangeMapping(true)
+                                                                    .getTokenRanges()
+                                                                    .get(instance);
+                failedRanges.forEach(failedRange -> {
+                    String nodeDisplayName = instance.getNodeName();
+                    String message = String.format("%s %s", nodeDisplayName, availability.getMessage());
+                    LOGGER.warn("{} failed in phase {} on {} because {}", failedRange, phase, nodeDisplayName, message);
+                    failureHandler.addFailure(failedRange, instance, message);
+                });
+                break;
+
+            default:
+                // DO NOTHING
+                break;
         }
     }
 }

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/BulkWriteValidator.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/BulkWriteValidator.java
@@ -134,25 +134,20 @@ public class BulkWriteValidator
             // Check for blocked instances and ranges for the purpose of logging only.
             // We check for blocked instances while validating consistency level requirements
             case UNAVAILABLE_BLOCKED:
-                Collection<Range<BigInteger>> rangesInBlockedInstance = cluster.getTokenRangeMapping(true)
-                                                                               .getTokenRanges()
-                                                                               .get(instance);
-                rangesInBlockedInstance.forEach(failedRange -> {
-                    String nodeDisplayName = instance.getNodeName();
-                    String message = String.format("%s %s", nodeDisplayName, availability.getMessage());
-                    LOGGER.warn("{} failed in phase {} on {} because {}", failedRange, phase, nodeDisplayName, message);
-                });
-                break;
-
             case UNAVAILABLE_DOWN:
-                Collection<Range<BigInteger>> failedRanges = cluster.getTokenRangeMapping(true)
-                                                                    .getTokenRanges()
-                                                                    .get(instance);
-                failedRanges.forEach(failedRange -> {
+                boolean shouldAddFailure = availability == InstanceAvailability.UNAVAILABLE_DOWN;
+
+                Collection<Range<BigInteger>> unavailableRanges = cluster.getTokenRangeMapping(true)
+                                                                         .getTokenRanges()
+                                                                         .get(instance);
+                unavailableRanges.forEach(failedRange -> {
                     String nodeDisplayName = instance.getNodeName();
                     String message = String.format("%s %s", nodeDisplayName, availability.getMessage());
                     LOGGER.warn("{} failed in phase {} on {} because {}", failedRange, phase, nodeDisplayName, message);
-                    failureHandler.addFailure(failedRange, instance, message);
+                    if (shouldAddFailure)
+                    {
+                        failureHandler.addFailure(failedRange, instance, message);
+                    }
                 });
                 break;
 

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/StreamSession.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/StreamSession.java
@@ -169,7 +169,9 @@ public class StreamSession
         List<RingInstance> replicasForTokenRange = overlappingRanges.values().stream()
                                                                     .flatMap(Collection::stream)
                                                                     .distinct()
-                                                                    .filter(instance -> !isExclusion(instance, failedInstances))
+                                                                    .filter(instance -> !isExclusion(instance,
+                                                                                                     failedInstances,
+                                                                                                     tokenRangeMapping.getBlockedInstances()))
                                                                     .collect(Collectors.toList());
 
         Preconditions.checkState(!replicasForTokenRange.isEmpty(),
@@ -183,11 +185,16 @@ public class StreamSession
     /**
      * Evaluates if the given instance should be excluded from writes by checking if it is either blocked or
      * has a failure
+     *
+     * @param ringInstance the instance being evaluated
+     * @param failedInstances set of failed instances
+     * @param blockedInstanceIps set of IP addresses of blocked instances
+     * @return true if the provided instance is either a failed or blocked instance
      */
-    private boolean isExclusion(RingInstance ringInstance, Set<RingInstance> failedInstances)
+    private boolean isExclusion(RingInstance ringInstance, Set<RingInstance> failedInstances, Set<String> blockedInstanceIps)
     {
         return failedInstances.contains(ringInstance)
-               || tokenRangeMapping.getBlockedInstances().contains(ringInstance.getIpAddress());
+               || blockedInstanceIps.contains(ringInstance.getIpAddress());
     }
 
     private void sendSSTables(BulkWriterContext writerContext, SSTableWriter ssTableWriter)

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/StreamSession.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/StreamSession.java
@@ -158,6 +158,7 @@ public class StreamSession
     List<RingInstance> getReplicas()
     {
         Set<RingInstance> failedInstances = failureHandler.getFailedInstances();
+        Set<String> blockedInstances = tokenRangeMapping.getBlockedInstances();
         // Get ranges that intersect with the partition's token range
         Map<Range<BigInteger>, List<RingInstance>> overlappingRanges = tokenRangeMapping.getSubRanges(tokenRange).asMapOfRanges();
 
@@ -171,7 +172,7 @@ public class StreamSession
                                                                     .distinct()
                                                                     .filter(instance -> !isExclusion(instance,
                                                                                                      failedInstances,
-                                                                                                     tokenRangeMapping.getBlockedInstances()))
+                                                                                                     blockedInstances))
                                                                     .collect(Collectors.toList());
 
         Preconditions.checkState(!replicasForTokenRange.isEmpty(),

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/RecordWriterTest.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/RecordWriterTest.java
@@ -123,7 +123,7 @@ public class RecordWriterTest
     }
 
     @Test
-        public void testWriteWithBlockedInstances()
+    public void testWriteWithBlockedInstances()
     {
 
         int numBlockedInstances = 1;

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/RecordWriterTest.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/RecordWriterTest.java
@@ -52,14 +52,12 @@ import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructType;
 import scala.Tuple2;
 
-import static java.util.function.Predicate.not;
 import static org.apache.cassandra.spark.bulkwriter.MockBulkWriterContext.DEFAULT_CASSANDRA_VERSION;
 import static org.apache.cassandra.spark.bulkwriter.SqlToCqlTypeConverter.DATE;
 import static org.apache.cassandra.spark.bulkwriter.SqlToCqlTypeConverter.INT;
 import static org.apache.cassandra.spark.bulkwriter.SqlToCqlTypeConverter.VARCHAR;
 import static org.apache.cassandra.spark.bulkwriter.TableSchemaTestCommon.mockCqlType;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.startsWith;
 import static org.hamcrest.Matchers.endsWith;
@@ -70,7 +68,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.Mockito.when;
 
 public class RecordWriterTest

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/TokenRangeMappingUtils.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/TokenRangeMappingUtils.java
@@ -49,7 +49,7 @@ public final class TokenRangeMappingUtils
         throw new IllegalStateException(getClass() + " is static utility class and shall not be instantiated");
     }
 
-    public static TokenRangeMapping<RingInstance> buildTokenRangeMapping(final int initialToken, final ImmutableMap<String, Integer> rfByDC, int instancesPerDC)
+    public static TokenRangeMapping<RingInstance> buildTokenRangeMapping(int initialToken, ImmutableMap<String, Integer> rfByDC, int instancesPerDC)
     {
         return buildTokenRangeMapping(initialToken, rfByDC, instancesPerDC, false, -1);
     }
@@ -58,7 +58,7 @@ public final class TokenRangeMappingUtils
                                                                                             ImmutableMap<String, Integer> rfByDC,
                                                                                             int instancesPerDC)
     {
-        final List<RingInstance> instances = getInstances(initialToken, rfByDC, instancesPerDC);
+        List<RingInstance> instances = getInstances(initialToken, rfByDC, instancesPerDC);
         ReplicationFactor replicationFactor = getReplicationFactor(rfByDC);
         Map<String, Set<String>> writeReplicas =
         instances.stream().collect(Collectors.groupingBy(RingInstance::getDataCenter,
@@ -93,7 +93,7 @@ public final class TokenRangeMappingUtils
                                                                                      ImmutableMap<String, Integer> rfByDC,
                                                                                      int instancesPerDC)
     {
-        final List<RingInstance> instances = getInstances(initialToken, rfByDC, instancesPerDC);
+        List<RingInstance> instances = getInstances(initialToken, rfByDC, instancesPerDC);
         RingInstance instance = instances.remove(0);
         RingEntry entry = instance.getRingInstance();
         RingEntry newEntry = new RingEntry.Builder()
@@ -148,7 +148,7 @@ public final class TokenRangeMappingUtils
                                                                          int moveTargetToken)
     {
 
-        final List<RingInstance> instances = getInstances(initialToken, rfByDC, instancesPerDC);
+        List<RingInstance> instances = getInstances(initialToken, rfByDC, instancesPerDC);
         if (shouldUpdateToken)
         {
             RingInstance instance = instances.remove(0);
@@ -215,9 +215,9 @@ public final class TokenRangeMappingUtils
         }
         else if (replicationFactor.getReplicationStrategy() == ReplicationFactor.ReplicationStrategy.NetworkTopologyStrategy)
         {
-            for (final String dataCenter : replicationFactor.getOptions().keySet())
+            for (String dataCenter : replicationFactor.getOptions().keySet())
             {
-                final int rf = replicationFactor.getOptions().get(dataCenter);
+                int rf = replicationFactor.getOptions().get(dataCenter);
                 if (rf == 0)
                 {
                     // Apparently, its valid to have zero replication factor in Cassandra
@@ -254,7 +254,7 @@ public final class TokenRangeMappingUtils
         int dcOffset = 0;
         for (Map.Entry<String, Integer> rfForDC : rfByDC.entrySet())
         {
-            final String datacenter = rfForDC.getKey();
+            String datacenter = rfForDC.getKey();
             for (int i = 0; i < instancesPerDc; i++)
             {
                 RingEntry.Builder ringEntry = new RingEntry.Builder()

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/TokenRangeMappingUtils.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/TokenRangeMappingUtils.java
@@ -56,9 +56,13 @@ public final class TokenRangeMappingUtils
 
     public static TokenRangeMapping<RingInstance> buildTokenRangeMappingWithBlockedInstance(int initialToken,
                                                                                             ImmutableMap<String, Integer> rfByDC,
-                                                                                            int instancesPerDC)
+                                                                                            int instancesPerDC, String blockedInstanceIp)
     {
         List<RingInstance> instances = getInstances(initialToken, rfByDC, instancesPerDC);
+        RingInstance blockedInstance = instances.stream()
+                                                .filter(i -> i.getIpAddress().equals(blockedInstanceIp))
+                                                .findFirst()
+                                                .get();
         ReplicationFactor replicationFactor = getReplicationFactor(rfByDC);
         Map<String, Set<String>> writeReplicas =
         instances.stream().collect(Collectors.groupingBy(RingInstance::getDataCenter,
@@ -85,7 +89,7 @@ public final class TokenRangeMappingUtils
                                        Collections.emptyMap(),
                                        tokenRanges,
                                        replicaMetadata,
-                                       Collections.singleton(instances.get(0)),
+                                       Collections.singleton(blockedInstance),
                                        Collections.emptySet());
     }
 


### PR DESCRIPTION
…ions

The patch fixes double counting of blocked instances along with failed instances that was causing failures during CL validations.

## Testing
- Added relevant unit tests

