### PR TITLE
CASSANDRA-19273 Allow setting TTL for snapshots created through reader

### DIFF
--- a/DEV-README.md
+++ b/DEV-README.md
@@ -89,6 +89,18 @@ To enable git hooks, run the following command at project root.
 git config core.hooksPath githooks
 ```
 
+## Running Integration Tests
+
+To run integration tests, build dependencies with instructions under Dependencies section and configure IP aliases 
+needed for integration tests.
+
+### macOS network aliases
+create a temporary alias for every node except the first:
+
+```shell
+ for i in {2..20}; do sudo ifconfig lo0 alias "127.0.0.${i}"; done
+```
+
 ## IntelliJ
 
 The project is well-supported in IntelliJ.

--- a/cassandra-analytics-core/build.gradle
+++ b/cassandra-analytics-core/build.gradle
@@ -70,6 +70,7 @@ project(':cassandra-analytics-core') {
         testImplementation("org.junit.jupiter:junit-jupiter-api:${project.junitVersion}")
         testImplementation("org.junit.jupiter:junit-jupiter-params:${project.junitVersion}")
         testImplementation("org.junit.jupiter:junit-jupiter-engine:${project.junitVersion}")
+        testImplementation("org.assertj:assertj-core:3.24.2")
         testImplementation(group: 'org.quicktheories', name: 'quicktheories', version: "${project.rootProject.quickTheoriesVersion}")
         testImplementation(group: 'org.slf4j', name: 'slf4j-simple', version: '1.7.26')
         testImplementation(group: 'org.mockito', name: 'mockito-core', version: "${project.rootProject.mockitoVersion}")

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/data/CassandraDataLayer.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/data/CassandraDataLayer.java
@@ -350,9 +350,9 @@ public class CassandraDataLayer extends PartitionedDataLayer implements StartupV
                     String resolvedSnapshotTtl = clearSnapshot ? effectiveSnapshotTtl : null;
                     if (!clearSnapshot && userProvidedSnapshotTtl != null)
                     {
-                        LOGGER.error("Snapshot TTL option was provided along with Clear Snapshot option, bulk reader" +
-                                     "can honor only one of the 2. Clear Snapshot takes precedence over Snapshot TTL, " +
-                                     "hence snapshot {} will not be removed after the specified snapshot TTL option", snapshotName);
+                        LOGGER.warn("Snapshot TTL option was provided along with Clear Snapshot option, bulk reader" +
+                                    "can honor only one of the 2. Clear Snapshot takes precedence over Snapshot TTL, " +
+                                    "hence snapshot {} will not be removed after the specified snapshot TTL option", snapshotName);
                     }
                     createSnapshotFuture = sidecar.createSnapshot(sidecarInstance, maybeQuotedKeyspace,
                                                                   maybeQuotedTable, snapshotName, resolvedSnapshotTtl)

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/data/CassandraDataLayer.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/data/CassandraDataLayer.java
@@ -291,9 +291,7 @@ public class CassandraDataLayer extends PartitionedDataLayer implements StartupV
     protected void shutdownHook(ClientConfig options)
     {
         ClientConfig.ClearSnapshotStrategy clearSnapshotStrategy = options.clearSnapshotStrategy();
-        boolean clearOnCompletion = ClientConfig.ClearSnapshotStrategyType.onCompletion.equals(clearSnapshotStrategy.type());
-        boolean clearOnCompletionOrTTL = ClientConfig.ClearSnapshotStrategyType.onCompletionOrTTL.equals(clearSnapshotStrategy.type());
-        if (clearOnCompletion || clearOnCompletionOrTTL)
+        if (clearSnapshotStrategy.shouldClearOnCompletion())
         {
             if (options.createSnapshot())
             {
@@ -307,9 +305,9 @@ public class CassandraDataLayer extends PartitionedDataLayer implements StartupV
                             snapshotName, keyspace, table, datacenter);
             }
         }
-        if (ClientConfig.ClearSnapshotStrategyType.TTL.equals(clearSnapshotStrategy.type()))
+        else if (clearSnapshotStrategy.hasTTL())
         {
-            LOGGER.warn("Skipping clearing snapshot because snapshot TTL was set to {}", clearSnapshotStrategy.ttl());
+            LOGGER.warn("Skipping clearing snapshot because clearSnapshotStrategy '{}' is used", clearSnapshotStrategy);
         }
 
         try

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/data/CassandraDataLayer.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/data/CassandraDataLayer.java
@@ -352,7 +352,7 @@ public class CassandraDataLayer extends PartitionedDataLayer implements StartupV
                     {
                         LOGGER.error("Snapshot TTL option was provided along with Clear Snapshot option, bulk reader" +
                                      "can honor only one of the 2. Clear Snapshot takes precedence over Snapshot TTL, " +
-                                     "hence snapshot {} will not be cleared with TTL", snapshotName);
+                                     "hence snapshot {} will not be removed after the specified snapshot TTL option", snapshotName);
                     }
                     createSnapshotFuture = sidecar.createSnapshot(sidecarInstance, maybeQuotedKeyspace,
                                                                   maybeQuotedTable, snapshotName, resolvedSnapshotTtl)

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/data/ClientConfig.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/data/ClientConfig.java
@@ -114,7 +114,7 @@ public final class ClientConfig
         this.clearSnapshot = MapUtils.getBoolean(options, CLEAR_SNAPSHOT_KEY, createSnapshot);
         String clearSnapshotStrategyOption = MapUtils.getOrDefault(options, CLEAR_SNAPSHOT_STRATEGY_KEY, null);
 
-        this.clearSnapshotStrategy = parseClearSnapshotStrategy(MapUtils.contains(options, CLEAR_SNAPSHOT_KEY),
+        this.clearSnapshotStrategy = parseClearSnapshotStrategy(MapUtils.containsKey(options, CLEAR_SNAPSHOT_KEY),
                                                                 clearSnapshot,
                                                                 clearSnapshotStrategyOption);
         this.defaultParallelism = MapUtils.getInt(options, DEFAULT_PARALLELISM_KEY, 1);

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/data/ClientConfig.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/data/ClientConfig.java
@@ -138,10 +138,13 @@ public final class ClientConfig
                                                              boolean clearSnapshot,
                                                              String clearSnapshotStrategyOption)
     {
-        if (hasDeprecatedOption && clearSnapshotStrategyOption == null)
+        if (hasDeprecatedOption)
         {
             LOGGER.warn("The deprecated option 'clearSnapshot' is set. Please set 'clearSnapshotStrategy' instead.");
-            return clearSnapshot ? ClearSnapshotStrategy.defaultStrategy() : new ClearSnapshotStrategy.NoOp();
+            if (clearSnapshotStrategyOption == null)
+            {
+                return clearSnapshot ? ClearSnapshotStrategy.defaultStrategy() : new ClearSnapshotStrategy.NoOp();
+            }
         }
         if (clearSnapshotStrategyOption == null)
         {

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/data/ClientConfig.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/data/ClientConfig.java
@@ -57,7 +57,6 @@ public final class ClientConfig
      * Valid units are {@code d}, {@code h}, {@code s}, {@code ms}, {@code us}, {@code µs}, {@code ns}, and {@code m}.
      */
     public static final String DEFAULT_SNAPSHOT_TTL_VALUE = "2d";
-    public static final String SNAPSHOT_TTL_PATTERN = "\\d+(d|h|m|s|ms|us|µs|ns)";
     public static final String DEFAULT_PARALLELISM_KEY = "defaultParallelism";
     public static final String NUM_CORES_KEY = "numCores";
     public static final String CONSISTENCY_LEVEL_KEY = "consistencyLevel";
@@ -136,12 +135,6 @@ public final class ClientConfig
         String snapshotTtl = strategyParts.length == 1
                              ? null
                              : strategyParts[1].substring(1, strategyParts[1].length() - 1);
-        if (!Pattern.matches(SNAPSHOT_TTL_PATTERN, snapshotTtl))
-        {
-            throw new RuntimeException("Incorrect value set for clearSnapshotStrategy, expected format is " +
-                                       "{strategy [snapshotTTLvalue]}. TTL value specified must contain unit along. " +
-                                       "For e.g. 2d represents a TTL for 2 days");
-        }
         return new ClearSnapshotStrategy(type, snapshotTtl);
 
     }

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/data/ClientConfig.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/data/ClientConfig.java
@@ -153,12 +153,12 @@ public final class ClientConfig
         String snapshotTTL = null;
         if (strategyParts.length == 1)
         {
-            strategyName = strategyParts[0].strip();
+            strategyName = strategyParts[0].trim();
         }
         else if (strategyParts.length == 2)
         {
-            strategyName = strategyParts[0].strip();
-            snapshotTTL = strategyParts[1].strip();
+            strategyName = strategyParts[0].trim();
+            snapshotTTL = strategyParts[1].trim();
             if (!Pattern.matches(SNAPSHOT_TTL_PATTERN, snapshotTTL))
             {
                 String msg = "Incorrect value set for clearSnapshotStrategy, expected format is " +
@@ -315,7 +315,7 @@ public final class ClientConfig
 
         static ClearSnapshotStrategy create(String name, String snapshotTTL)
         {
-            String stripped = name.strip();
+            String stripped = name.trim();
             if (stripped.equalsIgnoreCase(OnCompletion.class.getSimpleName()))
             {
                 return new OnCompletion();

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/data/ClientConfig.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/data/ClientConfig.java
@@ -59,10 +59,10 @@ public final class ClientConfig
     /**
      * TTL value is time to live option for the snapshot (available since Cassandra 4.1+). TTL value specified must
      * contain unit along. For e.g. 2d represents a TTL for 2 days; 1h represents a TTL of 1 hour, etc.
-     * Valid units are {@code d}, {@code h}, {@code s}, {@code ms}, {@code us}, {@code µs}, {@code ns}, and {@code m}.
+     * Valid units are {@code d}, {@code h}, {@code s} and {@code m}.
      */
     public static final String DEFAULT_SNAPSHOT_TTL_VALUE = "2d";
-    public static final String SNAPSHOT_TTL_PATTERN = "\\d+(d|h|m|s|ms)|(\\d+|\\d+\\.\\d+|\\.\\d+)[eE][+-](\\d+|\\d+\\.\\d+|\\.\\d+)(us|µs|ns)";
+    public static final String SNAPSHOT_TTL_PATTERN = "\\d+(d|h|m|s)";
     public static final String DEFAULT_PARALLELISM_KEY = "defaultParallelism";
     public static final String NUM_CORES_KEY = "numCores";
     public static final String CONSISTENCY_LEVEL_KEY = "consistencyLevel";
@@ -134,9 +134,9 @@ public final class ClientConfig
         this.quoteIdentifiers = MapUtils.getBoolean(options, QUOTE_IDENTIFIERS, false);
     }
 
-    private ClearSnapshotStrategy parseClearSnapshotStrategy(boolean hasDeprecatedOption,
-                                                             boolean clearSnapshot,
-                                                             String clearSnapshotStrategyOption)
+    protected ClearSnapshotStrategy parseClearSnapshotStrategy(boolean hasDeprecatedOption,
+                                                               boolean clearSnapshot,
+                                                               String clearSnapshotStrategyOption)
     {
         if (hasDeprecatedOption)
         {
@@ -344,7 +344,7 @@ public final class ClientConfig
             }
         }
 
-        static ClearSnapshotStrategy defaultStrategy()
+        public static ClearSnapshotStrategy defaultStrategy()
         {
             LOGGER.info("A default TTL value of {} is added to the snapshot. If the job takes longer than {}, " +
                         "the snapshot will be cleared before job completion leading to errors.",
@@ -420,7 +420,7 @@ public final class ClientConfig
 
         static class TTL extends ClearSnapshotStrategy
         {
-            protected TTL(@NotNull String snapshotTTL)
+            protected TTL(@NotNull String snapshotTTL) // check NotNull not throwing error
             {
                 super(snapshotTTL);
             }

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/data/ClientConfig.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/data/ClientConfig.java
@@ -113,7 +113,8 @@ public final class ClientConfig
         this.createSnapshot = MapUtils.getBoolean(options, CREATE_SNAPSHOT_KEY, true);
         this.clearSnapshot = MapUtils.getBoolean(options, CLEAR_SNAPSHOT_KEY, createSnapshot);
         String clearSnapshotStrategyOption = MapUtils.getOrDefault(options, CLEAR_SNAPSHOT_STRATEGY_KEY, null);
-        this.clearSnapshotStrategy = parseClearSnapshotStrategy(options.containsKey(CLEAR_SNAPSHOT_KEY),
+
+        this.clearSnapshotStrategy = parseClearSnapshotStrategy(MapUtils.contains(options, CLEAR_SNAPSHOT_KEY),
                                                                 clearSnapshot,
                                                                 clearSnapshotStrategyOption);
         this.defaultParallelism = MapUtils.getInt(options, DEFAULT_PARALLELISM_KEY, 1);

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/data/ClientConfig.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/data/ClientConfig.java
@@ -43,6 +43,14 @@ public final class ClientConfig
     public static final String DC_KEY = "dc";
     public static final String CREATE_SNAPSHOT_KEY = "createSnapshot";
     public static final String CLEAR_SNAPSHOT_KEY = "clearSnapshot";
+    /**
+     * snapshotTTL a time to live option for the snapshot (available since Cassandra 4.1+).
+     * TTL value specified must contain unit along. For e.g. 2d represents a TTL for 2 days;
+     * 1h represents a TTL of 1 hour, etc. Valid units are {@code d}, {@code h}, {@code s},
+     * {@code ms}, {@code us}, {@code µs}, {@code ns}, and {@code m}.
+     */
+    public static final String SNAPSHOT_TTL = "snapshot_ttl";
+    public static final String DEFAULT_SNAPSHOT_TTL = "2d";
     public static final String DEFAULT_PARALLELISM_KEY = "defaultParallelism";
     public static final String NUM_CORES_KEY = "numCores";
     public static final String CONSISTENCY_LEVEL_KEY = "consistencyLevel";
@@ -67,6 +75,7 @@ public final class ClientConfig
     private final String datacenter;
     private final boolean createSnapshot;
     private final boolean clearSnapshot;
+    private final String snapshotTtl;
     private final int defaultParallelism;
     private final int numCores;
     private final ConsistencyLevel consistencyLevel;
@@ -91,6 +100,7 @@ public final class ClientConfig
         this.datacenter = options.get(MapUtils.lowerCaseKey(DC_KEY));
         this.createSnapshot = MapUtils.getBoolean(options, CREATE_SNAPSHOT_KEY, true);
         this.clearSnapshot = MapUtils.getBoolean(options, CLEAR_SNAPSHOT_KEY, createSnapshot);
+        this.snapshotTtl = MapUtils.getOrDefault(options, SNAPSHOT_TTL, DEFAULT_SNAPSHOT_TTL);
         this.defaultParallelism = MapUtils.getInt(options, DEFAULT_PARALLELISM_KEY, 1);
         this.numCores = MapUtils.getInt(options, NUM_CORES_KEY, 1);
         this.consistencyLevel = Optional.ofNullable(options.get(MapUtils.lowerCaseKey(CONSISTENCY_LEVEL_KEY)))
@@ -144,6 +154,11 @@ public final class ClientConfig
     public boolean clearSnapshot()
     {
         return clearSnapshot;
+    }
+
+    public String snapshotTtl()
+    {
+        return snapshotTtl;
     }
 
     public int defaultParallelism()

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/data/ClientConfig.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/data/ClientConfig.java
@@ -340,7 +340,7 @@ public final class ClientConfig
                 ClearSnapshotStrategy defaultStrategy = defaultStrategy();
                 LOGGER.warn("Unknown ClearSnapshotStrategy {} is passed. Fall back to default strategy {}.",
                             name, defaultStrategy);
-                return defaultStrategy;
+                throw new IllegalArgumentException("Invalid ClearSnapshotStrategy " + name + " passed");
             }
         }
 

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/data/ClientConfig.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/data/ClientConfig.java
@@ -49,7 +49,7 @@ public final class ClientConfig
      * 1h represents a TTL of 1 hour, etc. Valid units are {@code d}, {@code h}, {@code s},
      * {@code ms}, {@code us}, {@code µs}, {@code ns}, and {@code m}.
      */
-    public static final String SNAPSHOT_TTL = "snapshot_ttl";
+    public static final String USER_PROVIDED_SNAPSHOT_TTL = "snapshot_ttl";
     public static final String DEFAULT_SNAPSHOT_TTL = "2d";
     public static final String DEFAULT_PARALLELISM_KEY = "defaultParallelism";
     public static final String NUM_CORES_KEY = "numCores";
@@ -75,7 +75,8 @@ public final class ClientConfig
     private final String datacenter;
     private final boolean createSnapshot;
     private final boolean clearSnapshot;
-    private final String snapshotTtl;
+    private final String userProvidedSnapshotTtl;
+    private final String effectiveSnapshotTtl;
     private final int defaultParallelism;
     private final int numCores;
     private final ConsistencyLevel consistencyLevel;
@@ -100,7 +101,8 @@ public final class ClientConfig
         this.datacenter = options.get(MapUtils.lowerCaseKey(DC_KEY));
         this.createSnapshot = MapUtils.getBoolean(options, CREATE_SNAPSHOT_KEY, true);
         this.clearSnapshot = MapUtils.getBoolean(options, CLEAR_SNAPSHOT_KEY, createSnapshot);
-        this.snapshotTtl = MapUtils.getOrDefault(options, SNAPSHOT_TTL, DEFAULT_SNAPSHOT_TTL);
+        this.userProvidedSnapshotTtl = MapUtils.getOrDefault(options, USER_PROVIDED_SNAPSHOT_TTL, null);
+        this.effectiveSnapshotTtl = this.userProvidedSnapshotTtl == null ? DEFAULT_SNAPSHOT_TTL : USER_PROVIDED_SNAPSHOT_TTL;
         this.defaultParallelism = MapUtils.getInt(options, DEFAULT_PARALLELISM_KEY, 1);
         this.numCores = MapUtils.getInt(options, NUM_CORES_KEY, 1);
         this.consistencyLevel = Optional.ofNullable(options.get(MapUtils.lowerCaseKey(CONSISTENCY_LEVEL_KEY)))
@@ -156,9 +158,14 @@ public final class ClientConfig
         return clearSnapshot;
     }
 
-    public String snapshotTtl()
+    public String userProvidedSnapshotTtl()
     {
-        return snapshotTtl;
+        return userProvidedSnapshotTtl;
+    }
+
+    public String effectiveSnapshotTtl()
+    {
+        return effectiveSnapshotTtl;
     }
 
     public int defaultParallelism()

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/data/ClientConfig.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/data/ClientConfig.java
@@ -151,7 +151,7 @@ public final class ClientConfig
             LOGGER.debug("No clearSnapshotStrategy is set. Using the default strategy");
             return ClearSnapshotStrategy.defaultStrategy();
         }
-        String[] strategyParts = clearSnapshotStrategyOption.split(" ");
+        String[] strategyParts = clearSnapshotStrategyOption.split(" ", 2);
         String strategyName;
         String snapshotTTL = null;
         if (strategyParts.length == 1)
@@ -166,7 +166,7 @@ public final class ClientConfig
             {
                 String msg = "Incorrect value set for clearSnapshotStrategy, expected format is " +
                              "{strategy [snapshotTTLvalue]}. TTL value specified must contain unit along. " +
-                             "For e.g. 2d represents a TTL for 2 days";
+                             "For e.g. 2d represents a TTL for 2 days. Allowed units are d, h, m and s.";
                 throw new IllegalArgumentException(msg);
             }
         }
@@ -354,6 +354,17 @@ public final class ClientConfig
 
         abstract boolean shouldClearOnCompletion();
 
+        void validateTTLPresence(boolean expectTTL)
+        {
+            if (expectTTL && !hasTTL())
+            {
+                throw new IllegalArgumentException("Incorrect value set for clearSnapshotStrategy, expected format " +
+                                                   "is {strategy [snapshotTTLvalue]}. TTL value specified must " +
+                                                   "contain unit along. For e.g. 2d represents a TTL for 2 days. " +
+                                                   "Allowed units are d, h, m and s.");
+            }
+        }
+
         boolean hasTTL()
         {
             return snapshotTTL != null && !snapshotTTL.isEmpty();
@@ -409,6 +420,7 @@ public final class ClientConfig
             protected OnCompletionOrTTL(@NotNull String snapshotTTL)
             {
                 super(snapshotTTL);
+                validateTTLPresence(true);
             }
 
             @Override
@@ -423,6 +435,7 @@ public final class ClientConfig
             protected TTL(@NotNull String snapshotTTL) // check NotNull not throwing error
             {
                 super(snapshotTTL);
+                validateTTLPresence(true);
             }
 
             @Override

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/data/ClientConfig.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/data/ClientConfig.java
@@ -55,7 +55,7 @@ public final class ClientConfig
      * and in case of TTL based strategy, TTL value. For e.g. onCompletionOrTTL 2d, TTL 2d, noOp, onCompletion. For
      * clear snapshot strategies allowed check {@link ClearSnapshotStrategy}
      */
-    public static final String CLEAR_SNAPSHOT_STRATEGY = "clearSnapshotStrategy";
+    public static final String CLEAR_SNAPSHOT_STRATEGY_KEY = "clearSnapshotStrategy";
     /**
      * TTL value is time to live option for the snapshot (available since Cassandra 4.1+). TTL value specified must
      * contain unit along. For e.g. 2d represents a TTL for 2 days; 1h represents a TTL of 1 hour, etc.
@@ -112,7 +112,7 @@ public final class ClientConfig
         this.datacenter = options.get(MapUtils.lowerCaseKey(DC_KEY));
         this.createSnapshot = MapUtils.getBoolean(options, CREATE_SNAPSHOT_KEY, true);
         this.clearSnapshot = MapUtils.getBoolean(options, CLEAR_SNAPSHOT_KEY, createSnapshot);
-        String clearSnapshotStrategyOption = MapUtils.getOrDefault(options, CLEAR_SNAPSHOT_STRATEGY, null);
+        String clearSnapshotStrategyOption = MapUtils.getOrDefault(options, CLEAR_SNAPSHOT_STRATEGY_KEY, null);
         this.clearSnapshotStrategy = parseClearSnapshotStrategy(options.containsKey(CLEAR_SNAPSHOT_KEY),
                                                                 clearSnapshot,
                                                                 clearSnapshotStrategyOption);
@@ -365,7 +365,7 @@ public final class ClientConfig
         @Override
         public String toString()
         {
-            return this.getClass().getSimpleName() + (hasTTL() ? "" : ' ' + ttl());
+            return this.getClass().getSimpleName() + (hasTTL() ? ' ' + ttl() : "");
         }
 
         protected ClearSnapshotStrategy(String snapshotTTL)

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/data/ClientConfig.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/data/ClientConfig.java
@@ -138,7 +138,7 @@ public final class ClientConfig
                                                              boolean clearSnapshot,
                                                              String clearSnapshotStrategyOption)
     {
-        if (hasDeprecatedOption)
+        if (hasDeprecatedOption && clearSnapshotStrategyOption == null)
         {
             LOGGER.warn("The deprecated option 'clearSnapshot' is set. Please set 'clearSnapshotStrategy' instead.");
             return clearSnapshot ? ClearSnapshotStrategy.defaultStrategy() : new ClearSnapshotStrategy.NoOp();

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/data/ClientConfig.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/data/ClientConfig.java
@@ -102,7 +102,7 @@ public final class ClientConfig
         this.createSnapshot = MapUtils.getBoolean(options, CREATE_SNAPSHOT_KEY, true);
         this.clearSnapshot = MapUtils.getBoolean(options, CLEAR_SNAPSHOT_KEY, createSnapshot);
         this.userProvidedSnapshotTtl = MapUtils.getOrDefault(options, USER_PROVIDED_SNAPSHOT_TTL, null);
-        this.effectiveSnapshotTtl = this.userProvidedSnapshotTtl == null ? DEFAULT_SNAPSHOT_TTL : USER_PROVIDED_SNAPSHOT_TTL;
+        this.effectiveSnapshotTtl = this.userProvidedSnapshotTtl == null ? DEFAULT_SNAPSHOT_TTL : this.userProvidedSnapshotTtl;
         this.defaultParallelism = MapUtils.getInt(options, DEFAULT_PARALLELISM_KEY, 1);
         this.numCores = MapUtils.getInt(options, NUM_CORES_KEY, 1);
         this.consistencyLevel = Optional.ofNullable(options.get(MapUtils.lowerCaseKey(CONSISTENCY_LEVEL_KEY)))

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/data/ClientConfig.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/data/ClientConfig.java
@@ -433,7 +433,7 @@ public final class ClientConfig
 
         static class TTL extends ClearSnapshotStrategy
         {
-            protected TTL(@NotNull String snapshotTTL) // check NotNull not throwing error
+            protected TTL(@NotNull String snapshotTTL)
             {
                 super(snapshotTTL);
                 validateTTLPresence(true);

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/data/CassandraDataLayerTests.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/data/CassandraDataLayerTests.java
@@ -41,7 +41,7 @@ class CassandraDataLayerTests
     @Test
     void testDefaultClearSnapshotStrategy()
     {
-        final Map<String, String> options = new HashMap<>(REQUIRED_CLIENT_CONFIG_OPTIONS);
+        Map<String, String> options = new HashMap<>(REQUIRED_CLIENT_CONFIG_OPTIONS);
         ClientConfig clientConfig = ClientConfig.create(options);
         assertEquals("big-data", clientConfig.keyspace());
         assertEquals("customers", clientConfig.table());
@@ -55,7 +55,7 @@ class CassandraDataLayerTests
     @CsvSource({"false, NOOP", "true,ONCOMPLETIONORTTL 2d"})
     void testClearSnapshotOptionSupport(Boolean clearSnapshot, String expectedClearSnapshotStrategyOption)
     {
-        final Map<String, String> options = new HashMap<>(REQUIRED_CLIENT_CONFIG_OPTIONS);
+        Map<String, String> options = new HashMap<>(REQUIRED_CLIENT_CONFIG_OPTIONS);
         options.put("clearsnapshot", clearSnapshot.toString());
         ClientConfig clientConfig = ClientConfig.create(options);
         ClientConfig.ClearSnapshotStrategy clearSnapshotStrategy = clientConfig.clearSnapshotStrategy();

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/data/CassandraDataLayerTests.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/data/CassandraDataLayerTests.java
@@ -35,7 +35,7 @@ class CassandraDataLayerTests
     "sidecar_instances", "localhost");
 
     @Test
-    public void testDefaultSnapshotTTL()
+   void testDefaultSnapshotTTL()
     {
         final Map<String, String> options = new HashMap<>(REQUIRED_CLIENT_CONFIG_OPTIONS);
         ClientConfig clientConfig = ClientConfig.create(options);

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/data/CassandraDataLayerTests.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/data/CassandraDataLayerTests.java
@@ -35,13 +35,15 @@ class CassandraDataLayerTests
     "sidecar_instances", "localhost");
 
     @Test
-   void testDefaultSnapshotTTL()
+    void testDefaultClearSnapshotStrategy()
     {
         final Map<String, String> options = new HashMap<>(REQUIRED_CLIENT_CONFIG_OPTIONS);
         ClientConfig clientConfig = ClientConfig.create(options);
         assertEquals("big-data", clientConfig.keyspace());
         assertEquals("customers", clientConfig.table());
         assertEquals("localhost", clientConfig.sidecarInstances());
-        assertEquals("2d", clientConfig.effectiveSnapshotTtl());
+        ClientConfig.ClearSnapshotStrategy clearSnapshotStrategy = clientConfig.clearSnapshotStrategy();
+        assertEquals(ClientConfig.ClearSnapshotStrategyType.onCompletionOrTTL, clearSnapshotStrategy.type());
+        assertEquals("2d", clearSnapshotStrategy.ttl());
     }
 }

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/data/CassandraDataLayerTests.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/data/CassandraDataLayerTests.java
@@ -27,7 +27,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class CassandraDataLayerTests
+class CassandraDataLayerTests
 {
     public static final Map<String, String> REQUIRED_CLIENT_CONFIG_OPTIONS = ImmutableMap.of(
     "keyspace", "big-data",

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/data/CassandraDataLayerTests.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/data/CassandraDataLayerTests.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cassandra.spark.data;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class CassandraDataLayerTests
+{
+    public static final Map<String, String> REQUIRED_CLIENT_CONFIG_OPTIONS = ImmutableMap.of(
+    "keyspace", "big-data",
+    "table", "customers",
+    "sidecar_instances", "localhost");
+
+    @Test
+    public void testDefaultSnapshotTTL()
+    {
+        final Map<String, String> options = new HashMap<>(REQUIRED_CLIENT_CONFIG_OPTIONS);
+        ClientConfig clientConfig = ClientConfig.create(options);
+        assertEquals("big-data", clientConfig.keyspace());
+        assertEquals("customers", clientConfig.table());
+        assertEquals("localhost", clientConfig.sidecarInstances());
+        assertEquals("2d", clientConfig.snapshotTtl());
+    }
+}

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/data/CassandraDataLayerTests.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/data/CassandraDataLayerTests.java
@@ -42,6 +42,6 @@ public class CassandraDataLayerTests
         assertEquals("big-data", clientConfig.keyspace());
         assertEquals("customers", clientConfig.table());
         assertEquals("localhost", clientConfig.sidecarInstances());
-        assertEquals("2d", clientConfig.snapshotTtl());
+        assertEquals("2d", clientConfig.effectiveSnapshotTtl());
     }
 }

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/data/CassandraDataLayerTests.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/data/CassandraDataLayerTests.java
@@ -26,6 +26,8 @@ import com.google.common.collect.ImmutableMap;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class CassandraDataLayerTests
 {
@@ -43,7 +45,23 @@ class CassandraDataLayerTests
         assertEquals("customers", clientConfig.table());
         assertEquals("localhost", clientConfig.sidecarInstances());
         ClientConfig.ClearSnapshotStrategy clearSnapshotStrategy = clientConfig.clearSnapshotStrategy();
-        assertEquals(ClientConfig.ClearSnapshotStrategyType.onCompletionOrTTL, clearSnapshotStrategy.type());
+        assertTrue(clearSnapshotStrategy.shouldClearOnCompletion());
         assertEquals("2d", clearSnapshotStrategy.ttl());
+    }
+
+    @Test
+    void testCustomClearSnapshotStrategy()
+    {
+        final Map<String, String> options = new HashMap<>(REQUIRED_CLIENT_CONFIG_OPTIONS);
+        options.put("clearsnapshotstrategy", "tTl 4h");
+        ClientConfig clientConfig = ClientConfig.create(options);
+        assertEquals("big-data", clientConfig.keyspace());
+        assertEquals("customers", clientConfig.table());
+        assertEquals("localhost", clientConfig.sidecarInstances());
+        ClientConfig.ClearSnapshotStrategy clearSnapshotStrategy = clientConfig.clearSnapshotStrategy();
+        assertEquals("TTL 4h", clearSnapshotStrategy.toString());
+        assertTrue(clearSnapshotStrategy.hasTTL());
+        assertFalse(clearSnapshotStrategy.shouldClearOnCompletion());
+        assertEquals("4h", clearSnapshotStrategy.ttl());
     }
 }

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/data/CassandraDataLayerTests.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/data/CassandraDataLayerTests.java
@@ -64,4 +64,17 @@ class CassandraDataLayerTests
         assertFalse(clearSnapshotStrategy.shouldClearOnCompletion());
         assertEquals("4h", clearSnapshotStrategy.ttl());
     }
+
+    @Test
+    void testInvalidClearSnapshotStrategy()
+    {
+        final Map<String, String> options = new HashMap<>(REQUIRED_CLIENT_CONFIG_OPTIONS);
+        options.put("clearsnapshotstrategy", "tTl");
+        ClientConfig clientConfig = ClientConfig.create(options);
+        assertEquals("big-data", clientConfig.keyspace());
+        assertEquals("customers", clientConfig.table());
+        assertEquals("localhost", clientConfig.sidecarInstances());
+        ClientConfig.ClearSnapshotStrategy clearSnapshotStrategy = clientConfig.clearSnapshotStrategy();
+        System.out.println(clearSnapshotStrategy);
+    }
 }

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/data/ClientConfigTests.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/data/ClientConfigTests.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cassandra.spark.data;
+
+import org.junit.jupiter.api.Test;
+
+import static org.apache.cassandra.spark.data.ClientConfig.SNAPSHOT_TTL_PATTERN;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ClientConfigTests
+{
+    @Test
+    void testPositiveSnapshotTTLPatterns()
+    {
+        assertTrue("2h".matches(SNAPSHOT_TTL_PATTERN));
+        assertTrue("200s".matches(SNAPSHOT_TTL_PATTERN));
+        assertTrue("20000ms".matches(SNAPSHOT_TTL_PATTERN));
+        assertTrue("4d".matches(SNAPSHOT_TTL_PATTERN));
+        assertTrue("60m".matches(SNAPSHOT_TTL_PATTERN));
+        assertTrue("2e+9us".matches(SNAPSHOT_TTL_PATTERN));
+        assertTrue("1.5e+9µs".matches(SNAPSHOT_TTL_PATTERN));
+        assertTrue("2e+1.9ns".matches(SNAPSHOT_TTL_PATTERN));
+        assertTrue(".2e+9ns".matches(SNAPSHOT_TTL_PATTERN));
+        assertTrue("2e+.9ns".matches(SNAPSHOT_TTL_PATTERN));
+    }
+
+    @Test
+    void testNegativeSnapshotTTLPatterns()
+    {
+        assertFalse("2 h".matches(SNAPSHOT_TTL_PATTERN));
+        assertFalse("200".matches(SNAPSHOT_TTL_PATTERN));
+        assertFalse("ms".matches(SNAPSHOT_TTL_PATTERN));
+        assertFalse(".89".matches(SNAPSHOT_TTL_PATTERN));
+        assertFalse("39xs".matches(SNAPSHOT_TTL_PATTERN));
+        assertFalse("2+9ms".matches(SNAPSHOT_TTL_PATTERN));
+        assertFalse("2e8µs".matches(SNAPSHOT_TTL_PATTERN));
+        assertFalse("2+9ms".matches(SNAPSHOT_TTL_PATTERN));
+        assertFalse(".e+9ns".matches(SNAPSHOT_TTL_PATTERN));
+        assertFalse("2e+.us".matches(SNAPSHOT_TTL_PATTERN));
+    }
+}

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/data/ClientConfigTests.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/data/ClientConfigTests.java
@@ -70,7 +70,7 @@ class ClientConfigTests
     }
 
     @ParameterizedTest
-    @CsvSource({"delete 10h", "ttl5d", "Ttl 2ms", "TTL", "No Op", "on Completion", "ON COMPLETION 3d",
+    @CsvSource({"delete 10h", "ttl5d", "Ttl 2ms", "TTL", "tTL", "No Op", "on Completion", "ON COMPLETION 3d",
                 "onCompletionOrTTL ", "oN cOmPlEtIoNoRtTL 560m"})
     void testInValidClearSnapshotStrategyParsing(String option)
     {

--- a/cassandra-analytics-integration-tests/src/test/java/org/apache/cassandra/analytics/SparkTestUtils.java
+++ b/cassandra-analytics-integration-tests/src/test/java/org/apache/cassandra/analytics/SparkTestUtils.java
@@ -77,7 +77,7 @@ public final class SparkTestUtils
                   // Shutdown hooks are called after the job ends, and in the case of integration tests
                   // the sidecar is already shut down before this. Since the cluster will be torn
                   // down anyway, the integration job skips clearing snapshots.
-                  .option("clearSnapshot", "noop")
+                  .option("clearSnapshotStrategy", "noop")
                   .option("defaultParallelism", sc.defaultParallelism())
                   .option("numCores", numCores)
                   .option("sizing", "default")

--- a/cassandra-analytics-integration-tests/src/test/java/org/apache/cassandra/analytics/SparkTestUtils.java
+++ b/cassandra-analytics-integration-tests/src/test/java/org/apache/cassandra/analytics/SparkTestUtils.java
@@ -77,7 +77,7 @@ public final class SparkTestUtils
                   // Shutdown hooks are called after the job ends, and in the case of integration tests
                   // the sidecar is already shut down before this. Since the cluster will be torn
                   // down anyway, the integration job skips clearing snapshots.
-                  .option("clearSnapshot", "false")
+                  .option("clearSnapshot", "noop")
                   .option("defaultParallelism", sc.defaultParallelism())
                   .option("numCores", numCores)
                   .option("sizing", "default")

--- a/cassandra-analytics-integration-tests/src/test/java/org/apache/cassandra/analytics/data/ClearSnapshotTest.java
+++ b/cassandra-analytics-integration-tests/src/test/java/org/apache/cassandra/analytics/data/ClearSnapshotTest.java
@@ -56,8 +56,6 @@ class ClearSnapshotTest extends SharedClusterSparkIntegrationTestBase
     = new QualifiedName(TEST_KEYSPACE, "test_ttl_clear_snapshot_strategy");
     static final QualifiedName TABLE_NAME_FOR_NO_OP_CLEAR_SNAPSHOT_STRATEGY
     = new QualifiedName(TEST_KEYSPACE, "test_no_op_clear_snapshot_strategy");
-    static final QualifiedName TABLE_NAME_FOR_CLEAR_SNAPSHOT_STRATEGY_PRECEDENCE
-    = new QualifiedName(TEST_KEYSPACE, "test_clear_snapshot_strategy_precedence");
     static final List<String> DATASET = Arrays.asList("a", "b", "c", "d", "e", "f", "g", "h");
 
     @Test
@@ -65,7 +63,7 @@ class ClearSnapshotTest extends SharedClusterSparkIntegrationTestBase
     {
         DataFrameReader readDf = bulkReaderDataFrame(TABLE_NAME_FOR_TTL_CLEAR_SNAPSHOT_STRATEGY)
                                  .option("snapshotName", "ttlClearSnapshotStrategyTest")
-                                 .option("clearSnapshotStrategy", "TTL [10s]");
+                                 .option("clearSnapshotStrategy", "TTL 10s");
         List<Row> rows = readDf.load().collectAsList();
         assertThat(rows.size()).isEqualTo(8);
 
@@ -103,30 +101,6 @@ class ClearSnapshotTest extends SharedClusterSparkIntegrationTestBase
                                               .get("data_file_directories");
         String dataDir = dataDirs[0];
         List<Path> snapshotPaths = findChildFile(Paths.get(dataDir), "noOpClearSnapshotStrategyTest");
-        assertThat(snapshotPaths).isNotEmpty();
-        Path snapshot = snapshotPaths.get(0);
-        assertThat(snapshot).exists();
-
-        Uninterruptibles.sleepUninterruptibly(30, TimeUnit.SECONDS);
-        assertThat(snapshot).exists();
-    }
-
-    @Test
-    void testClearSnapshotStrategyPrecedenceOverClearSnapshotOption()
-    {
-        DataFrameReader readDf = bulkReaderDataFrame(TABLE_NAME_FOR_NO_OP_CLEAR_SNAPSHOT_STRATEGY)
-                                 .option("snapshotName", "clearSnapshotStrategyPrecedenceTest")
-                                 .option("clearSnapshot", "true")
-                                 .option("clearSnapshotStrategy", "noOp");
-        List<Row> rows = readDf.load().collectAsList();
-        assertThat(rows.size()).isEqualTo(8);
-
-        String[] dataDirs = (String[]) cluster.getFirstRunningInstance()
-                                              .config()
-                                              .getParams()
-                                              .get("data_file_directories");
-        String dataDir = dataDirs[0];
-        List<Path> snapshotPaths = findChildFile(Paths.get(dataDir), "clearSnapshotStrategyPrecedenceTest");
         assertThat(snapshotPaths).isNotEmpty();
         Path snapshot = snapshotPaths.get(0);
         assertThat(snapshot).exists();
@@ -186,8 +160,6 @@ class ClearSnapshotTest extends SharedClusterSparkIntegrationTestBase
         populateTable(TABLE_NAME_FOR_TTL_CLEAR_SNAPSHOT_STRATEGY);
         createTestTable(TABLE_NAME_FOR_NO_OP_CLEAR_SNAPSHOT_STRATEGY, createTableStatement);
         populateTable(TABLE_NAME_FOR_NO_OP_CLEAR_SNAPSHOT_STRATEGY);
-        createTestTable(TABLE_NAME_FOR_CLEAR_SNAPSHOT_STRATEGY_PRECEDENCE, createTableStatement);
-        populateTable(TABLE_NAME_FOR_CLEAR_SNAPSHOT_STRATEGY_PRECEDENCE);
     }
 
     void populateTable(QualifiedName tableName)

--- a/cassandra-analytics-integration-tests/src/test/java/org/apache/cassandra/analytics/data/SnapshotTtlTest.java
+++ b/cassandra-analytics-integration-tests/src/test/java/org/apache/cassandra/analytics/data/SnapshotTtlTest.java
@@ -60,6 +60,7 @@ class SnapshotTtlTest extends SharedClusterSparkIntegrationTestBase
     {
         DataFrameReader readDf = bulkReaderDataFrame(TTL_NAME)
                                  .option("snapshotName", "snapshotTTLTest")
+                                 .option("clearSnapshot", "true")
                                  .option("snapshot_ttl", "1m");
         List<Row> rows = readDf.load().collectAsList();
         assertEquals(8, rows.size());

--- a/cassandra-analytics-integration-tests/src/test/java/org/apache/cassandra/analytics/data/SnapshotTtlTest.java
+++ b/cassandra-analytics-integration-tests/src/test/java/org/apache/cassandra/analytics/data/SnapshotTtlTest.java
@@ -59,7 +59,7 @@ class SnapshotTtlTest extends SharedClusterSparkIntegrationTestBase
     void testWithUserProvidedTTL()
     {
         DataFrameReader readDf = bulkReaderDataFrame(TTL_NAME)
-                                 .option("snapshotName", "snapshotTTLTest")
+                                 .option("snapshotName", "userProvidedSnapshotTTLTest")
                                  .option("clearSnapshot", "true")
                                  .option("snapshot_ttl", "1m");
         List<Row> rows = readDf.load().collectAsList();
@@ -70,7 +70,7 @@ class SnapshotTtlTest extends SharedClusterSparkIntegrationTestBase
                                               .getParams()
                                               .get("data_file_directories");
         String dataDir = dataDirs[0];
-        List<Path> snapshotPaths = findChildFile(Paths.get(dataDir), "snapshotTTLTest");
+        List<Path> snapshotPaths = findChildFile(Paths.get(dataDir), "userProvidedSnapshotTTLTest");
         assertFalse(snapshotPaths.isEmpty());
         Path snapshot = snapshotPaths.get(0);
         assertTrue(Files.exists(snapshot));
@@ -84,7 +84,7 @@ class SnapshotTtlTest extends SharedClusterSparkIntegrationTestBase
     void testClearSnapshotOptionHonored()
     {
         DataFrameReader readDf = bulkReaderDataFrame(TTL_NAME)
-                                 .option("snapshotName", "snapshotTTLTest")
+                                 .option("snapshotName", "clearSnapshotHonorTest")
                                  .option("clearSnapshot", "false")
                                  .option("snapshot_ttl", "1m");
         List<Row> rows = readDf.load().collectAsList();
@@ -95,7 +95,7 @@ class SnapshotTtlTest extends SharedClusterSparkIntegrationTestBase
                                               .getParams()
                                               .get("data_file_directories");
         String dataDir = dataDirs[0];
-        List<Path> snapshotPaths = findChildFile(Paths.get(dataDir), "snapshotTTLTest");
+        List<Path> snapshotPaths = findChildFile(Paths.get(dataDir), "clearSnapshotHonorTest");
         assertFalse(snapshotPaths.isEmpty());
         Path snapshot = snapshotPaths.get(0);
         assertTrue(Files.exists(snapshot));

--- a/cassandra-analytics-integration-tests/src/test/java/org/apache/cassandra/analytics/data/SnapshotTtlTest.java
+++ b/cassandra-analytics-integration-tests/src/test/java/org/apache/cassandra/analytics/data/SnapshotTtlTest.java
@@ -1,0 +1,162 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.analytics.data;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+
+import com.vdurmont.semver4j.Semver;
+import org.apache.cassandra.analytics.SharedClusterSparkIntegrationTestBase;
+import org.apache.cassandra.distributed.UpgradeableCluster;
+import org.apache.cassandra.distributed.api.ConsistencyLevel;
+import org.apache.cassandra.distributed.api.Feature;
+import org.apache.cassandra.distributed.shared.Uninterruptibles;
+import org.apache.cassandra.distributed.shared.Versions;
+import org.apache.cassandra.sidecar.testing.QualifiedName;
+import org.apache.cassandra.testing.TestVersion;
+import org.apache.spark.sql.DataFrameReader;
+import org.apache.spark.sql.Row;
+
+import static org.apache.cassandra.testing.CassandraTestTemplate.waitForHealthyRing;
+import static org.apache.cassandra.testing.TestUtils.DC1_RF3;
+import static org.apache.cassandra.testing.TestUtils.TEST_KEYSPACE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SnapshotTtlTest extends SharedClusterSparkIntegrationTestBase
+{
+    static final QualifiedName TTL_NAME = new QualifiedName(TEST_KEYSPACE, "test_user_provided_ttl");
+    static final List<String> DATASET = Arrays.asList("a", "b", "c", "d", "e", "f", "g", "h");
+
+    @Test
+    void testWithUserProvidedTTL()
+    {
+        DataFrameReader readDf = bulkReaderDataFrame(TTL_NAME)
+                                 .option("snapshotName", "snapshotTTLTest")
+                                 .option("snapshot_ttl", "1m");
+        List<Row> rows = readDf.load().collectAsList();
+        assertEquals(8, rows.size());
+
+        String[] dataDirs = (String[]) cluster.getFirstRunningInstance()
+                                              .config()
+                                              .getParams()
+                                              .get("data_file_directories");
+        String dataDir = dataDirs[0];
+        List<Path> snapshotPaths = findChildFile(Paths.get(dataDir), "snapshotTTLTest");
+        assertFalse(snapshotPaths.isEmpty());
+        Path snapshot = snapshotPaths.get(0);
+        assertTrue(Files.exists(snapshot));
+
+        // Wait to make sure TTLs have expired
+        Uninterruptibles.sleepUninterruptibly(2, TimeUnit.MINUTES);
+        assertFalse(Files.exists(snapshot));
+    }
+
+    @Test
+    void testClearSnapshotOptionHonored()
+    {
+        DataFrameReader readDf = bulkReaderDataFrame(TTL_NAME)
+                                 .option("snapshotName", "snapshotTTLTest")
+                                 .option("clearSnapshot", "false")
+                                 .option("snapshot_ttl", "1m");
+        List<Row> rows = readDf.load().collectAsList();
+        assertEquals(8, rows.size());
+
+        String[] dataDirs = (String[]) cluster.getFirstRunningInstance()
+                                              .config()
+                                              .getParams()
+                                              .get("data_file_directories");
+        String dataDir = dataDirs[0];
+        List<Path> snapshotPaths = findChildFile(Paths.get(dataDir), "snapshotTTLTest");
+        assertFalse(snapshotPaths.isEmpty());
+        Path snapshot = snapshotPaths.get(0);
+        assertTrue(Files.exists(snapshot));
+
+        // Wait to make sure TTLs have expired
+        Uninterruptibles.sleepUninterruptibly(2, TimeUnit.MINUTES);
+        assertTrue(Files.exists(snapshot));
+    }
+
+    private List<Path> findChildFile(Path path, String target)
+    {
+        try (Stream<Path> walkStream = Files.walk(path))
+        {
+            return walkStream.filter(p -> p.getFileName().endsWith(target) || p.toString().contains("/" + target + "/"))
+                             .collect(Collectors.toList());
+        }
+        catch (IOException e)
+        {
+            return Collections.emptyList();
+        }
+    }
+
+    @Override
+    protected UpgradeableCluster provisionCluster(TestVersion testVersion) throws IOException
+    {
+        Versions versions = Versions.find();
+        Versions.Version requestedVersion = versions.getLatest(new Semver(testVersion.version(),
+                                                                          Semver.SemverType.LOOSE));
+        UpgradeableCluster.Builder clusterBuilder =
+        UpgradeableCluster.build(3)
+                          .withDynamicPortAllocation(true)
+                          .withVersion(requestedVersion)
+                          .withDataDirCount(1)
+                          .withDCs(1)
+                          .withConfig(config -> config.with(Feature.NATIVE_PROTOCOL)
+                                                      .with(Feature.GOSSIP)
+                                                      .with(Feature.JMX));
+        UpgradeableCluster cluster = clusterBuilder.createWithoutStarting();
+        cluster.startup();
+
+        waitForHealthyRing(cluster);
+        return cluster;
+    }
+
+    @Override
+    protected void initializeSchemaForTest()
+    {
+        createTestKeyspace(TTL_NAME, DC1_RF3);
+        String createTableStatement = "CREATE TABLE IF NOT EXISTS %s (c1 int, c2 text, PRIMARY KEY(c1));";
+        createTestTable(TTL_NAME, createTableStatement);
+        populateTable();
+    }
+
+    void populateTable()
+    {
+        for (int i = 0; i < DATASET.size(); i++)
+        {
+            String value = DATASET.get(i);
+            String query = String.format("INSERT INTO %s (c1, c2) VALUES (%d, '%s');", TTL_NAME, i, value);
+            cluster.getFirstRunningInstance()
+                   .coordinator()
+                   .execute(query, ConsistencyLevel.ALL);
+        }
+    }
+}

--- a/cassandra-bridge/src/main/java/org/apache/cassandra/spark/utils/MapUtils.java
+++ b/cassandra-bridge/src/main/java/org/apache/cassandra/spark/utils/MapUtils.java
@@ -232,7 +232,7 @@ public final class MapUtils
      * @param key       the key to the map
      * @return boolean
      */
-    public static boolean contains(Map<String, String> options, String key)
+    public static boolean containsKey(Map<String, String> options, String key)
     {
         return options.containsKey(lowerCaseKey(key));
     }

--- a/cassandra-bridge/src/main/java/org/apache/cassandra/spark/utils/MapUtils.java
+++ b/cassandra-bridge/src/main/java/org/apache/cassandra/spark/utils/MapUtils.java
@@ -225,4 +225,15 @@ public final class MapUtils
     {
         return options.getOrDefault(lowerCaseKey(key), defaultValue);
     }
+
+    /**
+     * Method to check if key is present in {@code options} map.
+     * @param options   the map
+     * @param key       the key to the map
+     * @return boolean
+     */
+    public static boolean contains(Map<String, String> options, String key)
+    {
+        return options.containsKey(lowerCaseKey(key));
+    }
 }


### PR DESCRIPTION
We want to allow analytics users to set TTL option for snapshots created through bulk reader. This is to aid in clearing snapshots, especially in case of job failures, when clearSnapshot call is not executed. 