### PR TITLE
[CASSANDRA-19272] Adds integration testing for blocklist handling

### DIFF
--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/BulkSparkConf.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/BulkSparkConf.java
@@ -131,6 +131,7 @@ public class BulkSparkConf implements Serializable
     protected final int userProvidedSidecarPort;
     protected boolean useOpenSsl;
     protected int ringRetryCount;
+    protected final Set<String> blockedInstances;
 
     public BulkSparkConf(SparkConf conf, Map<String, String> options)
     {
@@ -167,7 +168,15 @@ public class BulkSparkConf implements Serializable
         this.ttl = MapUtils.getOrDefault(options, WriterOptions.TTL.name(), null);
         this.timestamp = MapUtils.getOrDefault(options, WriterOptions.TIMESTAMP.name(), null);
         this.quoteIdentifiers = MapUtils.getBoolean(options, WriterOptions.QUOTE_IDENTIFIERS.name(), false, "quote identifiers");
+        this.blockedInstances = buildBlockedInstances(options);
         validateEnvironment();
+    }
+
+    private Set<String> buildBlockedInstances(Map<String, String> options)
+    {
+        String blockedInstances = MapUtils.getOrDefault(options, WriterOptions.BLOCKED_INSTANCES.name(), "");
+        return Arrays.stream(blockedInstances.split(","))
+                     .collect(Collectors.toSet());
     }
 
     protected Set<? extends SidecarInstance> buildSidecarInstances(Map<String, String> options, int sidecarPort)

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/BulkSparkConf.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/BulkSparkConf.java
@@ -174,7 +174,7 @@ public class BulkSparkConf implements Serializable
 
     private Set<String> buildBlockedInstances(Map<String, String> options)
     {
-        String blockedInstances = MapUtils.getOrDefault(options, WriterOptions.BLOCKED_INSTANCES.name(), "");
+        String blockedInstances = MapUtils.getOrDefault(options, WriterOptions.BLOCKED_CASSANDRA_INSTANCES.name(), "");
         return Arrays.stream(blockedInstances.split(","))
                      .collect(Collectors.toSet());
     }

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/CassandraClusterInfo.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/CassandraClusterInfo.java
@@ -578,9 +578,9 @@ public class CassandraClusterInfo implements ClusterInfo, Closeable
         return ns.releaseVersion();
     }
 
-    protected boolean instanceIsBlocked(RingInstance ignored)
+    protected boolean instanceIsBlocked(RingInstance instance)
     {
-        return false;
+        return conf.blockedInstances.contains(instance.getIpAddress());
     }
 
     protected boolean instanceIsNormal(RingEntry ringEntry)

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/WriterOptions.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/WriterOptions.java
@@ -50,5 +50,10 @@ public enum WriterOptions implements WriterOption
      * support mixed case and reserved keyword names for these fields.
      */
     QUOTE_IDENTIFIERS,
+    /**
+     * Option to specify a comma separated list of Cassandra instances that are blocked from receiving any
+     * writes from the analytics library. Note that this contributes to the number of unavailable instances for
+     * the write consistency level validations.
+     */
     BLOCKED_CASSANDRA_INSTANCES,
 }

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/WriterOptions.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/WriterOptions.java
@@ -50,5 +50,5 @@ public enum WriterOptions implements WriterOption
      * support mixed case and reserved keyword names for these fields.
      */
     QUOTE_IDENTIFIERS,
-    BLOCKED_INSTANCES,
+    BLOCKED_CASSANDRA_INSTANCES,
 }

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/WriterOptions.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/WriterOptions.java
@@ -50,4 +50,5 @@ public enum WriterOptions implements WriterOption
      * support mixed case and reserved keyword names for these fields.
      */
     QUOTE_IDENTIFIERS,
+    BLOCKED_INSTANCES,
 }

--- a/cassandra-analytics-integration-framework/src/main/java/org/apache/cassandra/testing/TestUtils.java
+++ b/cassandra-analytics-integration-framework/src/main/java/org/apache/cassandra/testing/TestUtils.java
@@ -46,8 +46,13 @@ public final class TestUtils
     public static final Map<String, Integer> DC1_RF3_DC2_RF3 = ImmutableMap.of("datacenter1", 3,
                                                                                "datacenter2", 3);
 
+    /*
+     * Creates the test table with read-repair disabled for the in-jvm-dtests to allow validation of data
+     * on the nodes following bulk-writes without the chance of false-positives from replication resulting from
+     * read repairs.
+     */
     public static final String CREATE_TEST_TABLE_STATEMENT =
-    "CREATE TABLE IF NOT EXISTS %s (id int, course text, marks int, PRIMARY KEY (id));";
+    "CREATE TABLE IF NOT EXISTS %s (id int, course text, marks int, PRIMARY KEY (id)) WITH read_repair='NONE';";
 
     private TestUtils()
     {

--- a/cassandra-analytics-integration-tests/src/test/java/org/apache/cassandra/analytics/BlockedInstancesTest.java
+++ b/cassandra-analytics-integration-tests/src/test/java/org/apache/cassandra/analytics/BlockedInstancesTest.java
@@ -1,0 +1,167 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.analytics;
+
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import org.apache.cassandra.distributed.UpgradeableCluster;
+import org.apache.cassandra.distributed.api.Feature;
+import org.apache.cassandra.distributed.api.IInstance;
+import org.apache.cassandra.sidecar.testing.QualifiedName;
+import org.apache.cassandra.spark.bulkwriter.WriterOptions;
+import org.apache.cassandra.testing.TestVersion;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+
+import static com.datastax.driver.core.ConsistencyLevel.ALL;
+import static com.datastax.driver.core.ConsistencyLevel.ONE;
+import static com.datastax.driver.core.ConsistencyLevel.QUORUM;
+import static org.apache.cassandra.testing.TestUtils.CREATE_TEST_TABLE_STATEMENT;
+import static org.apache.cassandra.testing.TestUtils.DC1_RF3;
+import static org.apache.cassandra.testing.TestUtils.ROW_COUNT;
+import static org.apache.cassandra.testing.TestUtils.TEST_KEYSPACE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+public class BlockedInstancesTest extends ResiliencyTestBase
+{
+    Dataset<Row> df;
+    Map<IInstance, Set<String>> expectedInstanceData;
+
+    @Test
+    void testSingleBlockedNodeSucceeds(TestInfo testInfo)
+    {
+        TestConsistencyLevel cl = TestConsistencyLevel.of(QUORUM, QUORUM);
+        QualifiedName table = new QualifiedName(TEST_KEYSPACE, testInfo.getTestMethod().get().getName().toLowerCase());
+        bulkWriterDataFrameWriter(df, table).option(WriterOptions.BULK_WRITER_CL.name(), cl.writeCL.name())
+                                            .option("blocked_instances", "127.0.0.2")
+                                            .save();
+        expectedInstanceData.entrySet()
+                            .stream()
+                            .filter(e -> e.getKey().broadcastAddress().getAddress().getHostAddress().equals("127.0.0.2"))
+                            .forEach(e -> e.setValue(Collections.emptySet()));
+        validateNodeSpecificData(table, expectedInstanceData);
+        validateData(table, cl.readCL, ROW_COUNT);
+
+    }
+
+    @Test
+    void testSingleBlockedNodeWithWriteFailure(TestInfo testInfo)
+    {
+        TestConsistencyLevel cl = TestConsistencyLevel.of(ONE, ALL);
+        QualifiedName table = new QualifiedName(TEST_KEYSPACE, testInfo.getTestMethod().get().getName().toLowerCase());
+        Throwable thrown = catchThrowable(() ->
+                                          bulkWriterDataFrameWriter(df, table).option(WriterOptions.BULK_WRITER_CL.name(), cl.writeCL.name())
+                                                                              .option("blocked_instances", "127.0.0.2")
+                                                                              .save());
+        validateFailedJob(table, cl, thrown);
+    }
+
+    @Test
+    void testMultipleBlockedNodesWithWriteFailure(TestInfo testInfo)
+    {
+        TestConsistencyLevel cl = TestConsistencyLevel.of(QUORUM, QUORUM);
+        QualifiedName table = new QualifiedName(TEST_KEYSPACE, testInfo.getTestMethod().get().getName().toLowerCase());
+        Throwable thrown = catchThrowable(() ->
+                                          bulkWriterDataFrameWriter(df, table).option(WriterOptions.BULK_WRITER_CL.name(), cl.writeCL.name())
+                                                                              .option("blocked_instances", "127.0.0.2,127.0.0.3")
+                                                                              .save());
+        validateFailedJob(table, cl, thrown);
+    }
+
+    private void validateFailedJob(QualifiedName table, TestConsistencyLevel cl, Throwable thrown)
+    {
+        assertThat(thrown).isInstanceOf(RuntimeException.class)
+                          .hasMessageContaining("java.lang.RuntimeException: Bulk Write to Cassandra has failed");
+
+        Throwable cause = thrown;
+        while (cause != null && !StringUtils.contains(cause.getMessage(), "Failed to load"))
+        {
+            cause = cause.getCause();
+        }
+
+        assertThat(cause).isNotNull()
+                         .hasMessageFindingMatch(String.format("Failed to load (\\d+) ranges with %s for " +
+                                                 "job ([a-zA-Z0-9-]+) in phase Environment Validation.", cl.writeCL));
+
+        expectedInstanceData.entrySet()
+                            .stream()
+                            .forEach(e -> e.setValue(Collections.emptySet()));
+        validateNodeSpecificData(table, expectedInstanceData);
+        validateData(table, cl.readCL, 0);
+
+    }
+
+
+    protected ClusterBuilderConfiguration testClusterConfiguration()
+    {
+        return clusterConfig().nodesPerDc(3)
+                              .requestFeature(Feature.NETWORK);
+    }
+
+    @Override
+    protected void beforeTestStart()
+    {
+        SparkSession spark = getOrCreateSparkSession();
+        // Generate some artificial data for the test
+        df = DataGenerationUtils.generateCourseData(spark, ROW_COUNT);
+        // Generate the expected data for the new instances
+        expectedInstanceData = generateExpectedInstanceData(cluster, Collections.emptyList(), ROW_COUNT);
+    }
+
+    @Override
+    protected UpgradeableCluster provisionCluster(TestVersion testVersion) throws IOException
+    {
+        ClusterBuilderConfiguration configuration = testClusterConfiguration();
+        return clusterBuilder(configuration, testVersion);
+    }
+
+    @Override
+    protected void initializeSchemaForTest()
+    {
+        createTestKeyspace(TEST_KEYSPACE, DC1_RF3);
+
+        try
+        {
+            Class<?> testClass = Class.forName("org.apache.cassandra.analytics.BlockedInstancesTest");
+            Method[] methods = testClass.getDeclaredMethods();
+
+            for (Method method : methods)
+            {
+                if (method.isAnnotationPresent(Test.class))
+                {
+                    createTestTable(new QualifiedName(TEST_KEYSPACE, method.getName().toLowerCase()), CREATE_TEST_TABLE_STATEMENT);
+                }
+            }
+        }
+        catch (ClassNotFoundException e)
+        {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
### Changes
- Adds spark config with default empty list for `blocked_instances`
- Adds tests for blocked instances