### PR TITLE
CASSANDRA-19331 - Improve logging for bulk writes and on task failures

### DIFF
--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/CassandraClusterInfo.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/CassandraClusterInfo.java
@@ -392,12 +392,15 @@ public class CassandraClusterInfo implements ClusterInfo, Closeable
         Multimap<RingInstance, Range<BigInteger>> tokenRangesByInstance;
         try
         {
+            long start = System.nanoTime();
             TokenRangeReplicasResponse response = getTokenRangesAndReplicaSets();
+            long elapsedTimeNanos = System.nanoTime() - start;
             replicaMetadata = response.replicaMetadata();
 
             tokenRangesByInstance = getTokenRangesByInstance(response.writeReplicas(), response.replicaMetadata());
-            LOGGER.info("Retrieved token ranges for {} instances from write replica set ",
-                        tokenRangesByInstance.size());
+            LOGGER.info("Retrieved token ranges for {} instances from write replica set in {} nanoseconds",
+                        tokenRangesByInstance.size(),
+                        elapsedTimeNanos);
 
             replacementInstances = response.replicaMetadata()
                                            .values()

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/RecordWriter.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/RecordWriter.java
@@ -298,7 +298,7 @@ public class RecordWriter implements Serializable
         {
             Set<Range<BigInteger>> rangeDelta = symmetricDifference(startMapping.keySet(), endMapping.keySet());
             Set<String> instanceDelta = symmetricDifference(initialInstances, endInstances).stream()
-                                                                                           .map(RingInstance::getIpAddress)
+                                                                                           .map(RingInstance::ipAddress)
                                                                                            .collect(Collectors.toSet());
             String message = String.format("[%s] Token range mappings have changed since the task started " +
                                            "with non-overlapping instances: %s and ranges: %s",

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/RecordWriter.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/RecordWriter.java
@@ -116,8 +116,8 @@ public class RecordWriter implements Serializable
                                  taskTokenRange);
 
         TokenRangeMapping<RingInstance> initialTokenRangeMapping = writerContext.cluster().getTokenRangeMapping(false);
-        LOGGER.info("[{}]: Fetched token range mapping for keyspace:{} with write replicas:{} containing pending " +
-                    "replicas:{}, blocked instances: {}, replacement instances: {}",
+        LOGGER.info("[{}]: Fetched token range mapping for keyspace: {} with write replicas: {} containing pending " +
+                    "replicas: {}, blocked instances: {}, replacement instances: {}",
                     taskContext.partitionId(),
                     writerContext.job().keyspace(),
                     initialTokenRangeMapping.getWriteReplicas().size(),

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/RecordWriter.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/RecordWriter.java
@@ -41,6 +41,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.function.BiFunction;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
@@ -107,12 +108,23 @@ public class RecordWriter implements Serializable
     public List<StreamResult> write(Iterator<Tuple2<DecoratedKey, Object[]>> sourceIterator)
     {
         TaskContext taskContext = taskContextSupplier.get();
+        LOGGER.info("[{}]: Processing bulk writer partition", taskContext.partitionId());
+
         Range<BigInteger> taskTokenRange = getTokenRange(taskContext);
         Preconditions.checkState(!taskTokenRange.isEmpty(),
                                  "Token range for the partition %s is empty",
                                  taskTokenRange);
 
         TokenRangeMapping<RingInstance> initialTokenRangeMapping = writerContext.cluster().getTokenRangeMapping(false);
+        LOGGER.info("[{}]: Fetched token range mapping for keyspace:{} with write replicas:{} containing pending " +
+                    "replicas:{}, blocked instances: {}, replacement instances: {}",
+                    taskContext.partitionId(),
+                    writerContext.job().keyspace(),
+                    initialTokenRangeMapping.getWriteReplicas().size(),
+                    initialTokenRangeMapping.getPendingReplicas().size(),
+                    initialTokenRangeMapping.getBlockedInstances().size(),
+                    initialTokenRangeMapping.getReplacementInstances().size());
+
         Map<Range<BigInteger>, List<RingInstance>> initialTokenRangeInstances =
         taskTokenRangeMapping(initialTokenRangeMapping, taskTokenRange);
         List<StreamResult> results = new ArrayList<>();
@@ -124,7 +136,6 @@ public class RecordWriter implements Serializable
         // for all replicas in this partition
         validateAcceptableTimeSkewOrThrow(new ArrayList<>(instancesFromMapping(initialTokenRangeInstances)));
 
-        LOGGER.info("[{}]: Processing bulk writer partition", taskContext.partitionId());
         scala.collection.Iterator<scala.Tuple2<DecoratedKey, Object[]>> dataIterator =
         new InterruptibleIterator<>(taskContext, asScalaIterator(sourceIterator));
         StreamSession streamSession = null;
@@ -181,13 +192,7 @@ public class RecordWriter implements Serializable
 
             // When instances for the partition's token range have changed within the scope of the task execution,
             // we fail the task for it to be retried
-            if (haveTokenRangeMappingsChanged(initialTokenRangeMapping, taskTokenRange))
-            {
-                String message = String.format("[%s] Token range mappings have changed since the task started", partitionId);
-                LOGGER.error(message);
-                throw new RuntimeException(message);
-            }
-
+            validateTaskTokenRangeMappings(partitionId, initialTokenRangeMapping, taskTokenRange);
             return results;
         }
         catch (Exception exception)
@@ -275,16 +280,42 @@ public class RecordWriter implements Serializable
                      .collect(Collectors.toList());
     }
 
-    private boolean haveTokenRangeMappingsChanged(TokenRangeMapping<RingInstance> startTaskMapping, Range<BigInteger> taskTokenRange)
+    private void validateTaskTokenRangeMappings(int partitionId,
+                                                TokenRangeMapping<RingInstance> startTaskMapping,
+                                                Range<BigInteger> taskTokenRange)
     {
         // Get the uncached, current view of the ring to compare with initial ring
         TokenRangeMapping<RingInstance> endTaskMapping = writerContext.cluster().getTokenRangeMapping(false);
         Map<Range<BigInteger>, List<RingInstance>> startMapping = taskTokenRangeMapping(startTaskMapping, taskTokenRange);
         Map<Range<BigInteger>, List<RingInstance>> endMapping = taskTokenRangeMapping(endTaskMapping, taskTokenRange);
 
+        Set<RingInstance> initialInstances = instancesFromMapping(startMapping);
+        Set<RingInstance> endInstances = instancesFromMapping(endMapping);
         // Token ranges are identical and overall instance list is same
-        return !(startMapping.keySet().equals(endMapping.keySet()) &&
-               instancesFromMapping(startMapping).equals(instancesFromMapping(endMapping)));
+        boolean haveMappingsChanged = !(startMapping.keySet().equals(endMapping.keySet()) &&
+                                        initialInstances.equals(endInstances));
+        if (haveMappingsChanged)
+        {
+            Set<Range<BigInteger>> rangeDelta = symmetricDifference(startMapping.keySet(), endMapping.keySet());
+            Set<String> instanceDelta = symmetricDifference(initialInstances, endInstances).stream()
+                                                                                           .map(RingInstance::getIpAddress)
+                                                                                           .collect(Collectors.toSet());
+            String message = String.format("[%s] Token range mappings have changed since the task started " +
+                                           "with non-overlapping instances: %s and ranges: %s",
+                                           partitionId,
+                                           instanceDelta,
+                                           rangeDelta);
+            LOGGER.error(message);
+            throw new RuntimeException(message);
+        }
+    }
+
+    public static <T> Set<T> symmetricDifference(Set<T> set1, Set<T> set2)
+    {
+        return Stream.concat(
+                     set1.stream().filter(element -> !set2.contains(element)),
+                     set2.stream().filter(element -> !set1.contains(element)))
+                     .collect(Collectors.toSet());
     }
 
     private void validateAcceptableTimeSkewOrThrow(List<RingInstance> replicas)

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/RecordWriterTest.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/RecordWriterTest.java
@@ -57,7 +57,7 @@ import static org.apache.cassandra.spark.bulkwriter.SqlToCqlTypeConverter.INT;
 import static org.apache.cassandra.spark.bulkwriter.SqlToCqlTypeConverter.VARCHAR;
 import static org.apache.cassandra.spark.bulkwriter.TableSchemaTestCommon.mockCqlType;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.endsWith;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -123,7 +123,7 @@ public class RecordWriterTest
         when(m.getTokenRangeMapping(false)).thenCallRealMethod().thenReturn(testMapping);
         Iterator<Tuple2<DecoratedKey, Object[]>> data = generateData(true);
         RuntimeException ex = assertThrows(RuntimeException.class, () -> rw.write(data));
-        assertThat(ex.getMessage(), endsWith("Token range mappings have changed since the task started"));
+        assertThat(ex.getMessage(), containsString("Token range mappings have changed since the task started"));
     }
 
     @Test

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/RecordWriterTest.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/RecordWriterTest.java
@@ -21,6 +21,8 @@ package org.apache.cassandra.spark.bulkwriter;
 
 import java.math.BigInteger;
 import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
@@ -58,6 +60,7 @@ import static org.apache.cassandra.spark.bulkwriter.SqlToCqlTypeConverter.VARCHA
 import static org.apache.cassandra.spark.bulkwriter.TableSchemaTestCommon.mockCqlType;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -102,6 +105,20 @@ public class RecordWriterTest
         tc = new TestTaskContext();
         range = writerContext.job().getTokenPartitioner().getTokenRange(tc.partitionId());
         tokenizer = new Tokenizer(writerContext);
+    }
+
+    @Test
+    void symmetricDifferenceTest()
+    {
+        Set<Integer> s1 = new HashSet<>(Arrays.asList(1, 2, 3));
+        Set<Integer> s2 = new HashSet<>(Arrays.asList(2, 3, 4));
+        Set<Integer> s3 = new HashSet<>(Arrays.asList(5, 6, 7));
+        Set<Integer> s4 = new HashSet<>(Arrays.asList(5, 6, 7));
+        Set<Integer> s5 = new HashSet<>();
+        assertThat(RecordWriter.symmetricDifference(s1, s2), is(new HashSet<>(Arrays.asList(1, 4))));
+        assertThat(RecordWriter.symmetricDifference(s2, s3), is(new HashSet<>(Arrays.asList(2, 3, 4, 5, 6, 7))));
+        assertThat(RecordWriter.symmetricDifference(s3, s4), empty());
+        assertThat(RecordWriter.symmetricDifference(s4, s5), is(s4));
     }
 
     @Test


### PR DESCRIPTION
Small patch that improves logging in the bulk-write path and on spark task failures when token mappings change as a result of cluster resizing.