### PR TITLE
CASSANDRA-19351 No longer need to synchronize on Schema.instance afte…

### DIFF
--- a/cassandra-four-zero/src/main/java/org/apache/cassandra/bridge/CassandraBridgeImplementation.java
+++ b/cassandra-four-zero/src/main/java/org/apache/cassandra/bridge/CassandraBridgeImplementation.java
@@ -570,9 +570,7 @@ public class CassandraBridgeImplementation extends CassandraBridge
             builder.withType(statement);
         }
 
-        // TODO: Remove me once CQLSSTableWriter.Builder synchronize on schema (see CASSANDRA-TBD)
-        //       build update schema, we need to synchornize
-        try (CQLSSTableWriter ssTable = CassandraSchema.apply(s -> builder.build()))
+        try (CQLSSTableWriter ssTable = builder.build())
         {
             writer.accept(values -> {
                 try

--- a/cassandra-four-zero/src/main/java/org/apache/cassandra/bridge/SSTableWriterImplementation.java
+++ b/cassandra-four-zero/src/main/java/org/apache/cassandra/bridge/SSTableWriterImplementation.java
@@ -54,9 +54,7 @@ public class SSTableWriterImplementation implements SSTableWriter
                                                             insertStatement,
                                                             bufferSizeMB,
                                                             cassPartitioner);
-        // TODO: Remove me once CQLSSTableWriter.Builder synchronize on schema (see CASSANDRA-TBD)
-        //       build update schema, we need to synchronize
-        writer = CassandraSchema.apply(s -> builder.build());
+        writer = builder.build();
     }
 
     @Override


### PR DESCRIPTION
…r Cassandra 4.0.12

We no longer need to synchronize on the `Schema.instance` in Analytics after the release of Cassandra 4.0.12, that includes a synchronization fix in https://issues.apache.org/jira/browse/CASSANDRA-18317.

This commit cleans up TODOs pending on that code being released.

Patch by Francisco Guerrero; Reviewed by TBD for CASSANDRA-19351