### PR TITLE
CASSANDRA-19411: Bulk reader fails to produce a row when regular column values are null

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 1.0.0
+ * Bulk reader fails to produce a row when regular column values are null (CASSANDRA-19411)
  * Use XXHash32 for digest calculation of SSTables (CASSANDRA-19369)
  * Startup Validation Failures when Checking Sidecar Connectivity (CASSANDRA-19377)
  * No longer need to synchronize on Schema.instance after Cassandra 4.0.12 (CASSANDRA-19351)

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/sparksql/AbstractSparkRowIterator.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/sparksql/AbstractSparkRowIterator.java
@@ -49,8 +49,8 @@ abstract class AbstractSparkRowIterator
 
     protected final List<SchemaFeature> requestedFeatures;
     protected final CqlTable cqlTable;
-    protected final boolean noValueColumns;
     protected final StructType columnFilter;
+    protected final boolean hasProjectedValueColumns;
 
     private Cell cell = null;
     private InternalRow row = null;
@@ -67,7 +67,7 @@ abstract class AbstractSparkRowIterator
         this.stats.openedSparkRowIterator();
         this.openTimeNanos = System.nanoTime();
         this.requestedFeatures = dataLayer.requestedFeatures();
-        this.noValueColumns = it.noValueColumns();
+        this.hasProjectedValueColumns = it.hasProjectedValueColumns();
         this.builder = newBuilder();
     }
 
@@ -132,7 +132,7 @@ abstract class AbstractSparkRowIterator
 
             builder.onCell(cell);
 
-            if (!noValueColumns)
+            if (hasProjectedValueColumns)
             {
                 // If schema has value column
                 builder.copyValue(cell);

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/sparksql/FullRowBuilder.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/sparksql/FullRowBuilder.java
@@ -35,18 +35,18 @@ class FullRowBuilder implements RowBuilder
     static final Object[] EMPTY_RESULT = new Object[0];
     final int numColumns;
     final int numCells;
-    final boolean noValueColumns;
+    final boolean hasProjectedValueColumns;
     int extraColumns;
     Object[] result;
     int count;
     private final CqlTable cqlTable;
 
-    FullRowBuilder(CqlTable cqlTable, boolean noValueColumns)
+    FullRowBuilder(CqlTable cqlTable, boolean hasProjectedValueColumns)
     {
         this.cqlTable = cqlTable;
         this.numColumns = cqlTable.numFields();
-        this.numCells = cqlTable.numNonValueColumns() + (noValueColumns ? 0 : 1);
-        this.noValueColumns = noValueColumns;
+        this.hasProjectedValueColumns = hasProjectedValueColumns;
+        this.numCells = cqlTable.numNonValueColumns() + (hasProjectedValueColumns ? 1 : 0);
     }
 
     @Override
@@ -80,7 +80,7 @@ class FullRowBuilder implements RowBuilder
     public void copyKeys(Cell cell)
     {
         // Need to handle special case where schema is only partition or clustering keys - i.e. no value columns
-        int length = noValueColumns ? cell.values.length : cell.values.length - 1;
+        int length = !hasProjectedValueColumns ? cell.values.length : cell.values.length - 1;
         System.arraycopy(cell.values, 0, result, 0, length);
         count += length;
     }
@@ -108,7 +108,7 @@ class FullRowBuilder implements RowBuilder
     @Override
     public boolean hasRegularValueColumn()
     {
-        return !noValueColumns;
+        return hasProjectedValueColumns;
     }
 
     @Override

--- a/cassandra-analytics-core/src/main/spark2/org/apache/cassandra/spark/sparksql/SparkRowIterator.java
+++ b/cassandra-analytics-core/src/main/spark2/org/apache/cassandra/spark/sparksql/SparkRowIterator.java
@@ -56,7 +56,7 @@ public class SparkRowIterator extends AbstractSparkRowIterator implements InputP
     @NotNull
     RowBuilder newBuilder()
     {
-        RowBuilder builder = new FullRowBuilder(cqlTable, noValueColumns);
+        RowBuilder builder = new FullRowBuilder(cqlTable, hasProjectedValueColumns);
         for (SchemaFeature feature : requestedFeatures)
         {
             builder = feature.decorate(builder);

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/Tester.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/Tester.java
@@ -365,8 +365,7 @@ public final class Tester
                                                     .collect(Collectors.toMap(Function.identity(),
                                                                               ignore -> new MutableLong()));
             Map<String, TestSchema.TestRow> rows = new HashMap<>(numRandomRows);
-            IntStream.range(0, numSSTables).forEach(ssTable -> schema.writeSSTable(directory, bridge, partitioner, upsert, writer ->
-            {
+            IntStream.range(0, numSSTables).forEach(ssTable -> schema.writeSSTable(directory, bridge, partitioner, upsert, writer -> {
                 IntStream.range(0, numRandomRows).forEach(row -> {
                     TestSchema.TestRow testRow;
                     do

--- a/cassandra-bridge/src/main/java/org/apache/cassandra/spark/reader/EmptyStreamScanner.java
+++ b/cassandra-bridge/src/main/java/org/apache/cassandra/spark/reader/EmptyStreamScanner.java
@@ -41,6 +41,12 @@ public class EmptyStreamScanner implements StreamScanner<Rid>
     }
 
     @Override
+    public boolean hasMoreColumns()
+    {
+        return false;
+    }
+
+    @Override
     public void close()
     {
     }

--- a/cassandra-bridge/src/main/java/org/apache/cassandra/spark/reader/StreamScanner.java
+++ b/cassandra-bridge/src/main/java/org/apache/cassandra/spark/reader/StreamScanner.java
@@ -77,4 +77,9 @@ public interface StreamScanner<Type> extends Closeable
      * @throws IOException
      */
     void advanceToNextColumn() throws IOException;
+
+    /**
+     * @return {@code true} if the scanner has more columns to consume, {@code false} otherwise
+     */
+    boolean hasMoreColumns();
 }

--- a/cassandra-bridge/src/main/java/org/apache/cassandra/spark/reader/common/IndexIterator.java
+++ b/cassandra-bridge/src/main/java/org/apache/cassandra/spark/reader/common/IndexIterator.java
@@ -137,6 +137,12 @@ public class IndexIterator<ReaderType extends IIndexReader> implements StreamSca
         return finished.get() == readers.size();
     }
 
+    @Override
+    public boolean hasMoreColumns()
+    {
+        return true;
+    }
+
     public void advanceToNextColumn()
     {
         if (closed.get())

--- a/cassandra-four-zero/src/main/java/org/apache/cassandra/spark/reader/AbstractStreamScanner.java
+++ b/cassandra-four-zero/src/main/java/org/apache/cassandra/spark/reader/AbstractStreamScanner.java
@@ -125,6 +125,12 @@ public abstract class AbstractStreamScanner implements StreamScanner<Rid>, Close
         columnData.consume();
     }
 
+    @Override
+    public boolean hasMoreColumns()
+    {
+        return columns != null && columns.hasNext();
+    }
+
     // CHECKSTYLE IGNORE: Long method
     @Override
     public boolean hasNext() throws IOException


### PR DESCRIPTION
Bulk Reader won't emit a row when the regular column values are all `null`. For example, a schema `PK` = `a`, `b` ; `CK` = `c`, `d` ; and columns = `e`, `f`.

|  a  |  b  |  c  |  d  |  e   |  f   |
| --- | --- | --- | --- | ---- | ---- |
| pk1 | pk2 | ck1 | ck2 | null | null |

When queried from Analytics bulk reader, it won't produce a row.

This issue also occurs when the projected regular column values are all `null`, where other non-projected columns might have some values.

Patch by Francisco Guerrero; Reviewed by TBD for CASSANDRA-19411