### PR TITLE
CASSANDRA-19772: Deprecate option SIDECAR_INSTANCES and replace with SIDECAR_CONTACT_POINTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ import org.apache.spark.sql.SparkSession
 
 val sparkSession = SparkSession.builder.getOrCreate()
 val df = sparkSession.read.format("org.apache.cassandra.spark.sparksql.CassandraDataSource")
-                          .option("sidecar_instances", "localhost,localhost2,localhost3")
+                          .option("sidecar_contact_points", "localhost,localhost2,localhost3")
                           .option("keyspace", "sbr_tests")
                           .option("table", "basic_test")
                           .option("DC", "datacenter1")

--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,14 @@ println("Spark version: ${ext.sparkLabel}")
 ext.jdkLabel = System.getenv("JDK_VERSION") ?: "${analyticsJDKLevel}"
 println("Java source/target compatibility level: ${ext.jdkLabel}")
 
+// validate the builder is indeed using the correct JDK_VERSION as specified
+String actualJdkVersion = System.getProperty("java.version")
+if (!actualJdkVersion.startsWith(ext.jdkLabel))
+{
+  def errorMessage = "Invalid jdk version (Found: ${actualJdkVersion}) for jdk-${ext.jdkLabel} build"
+  throw new RuntimeException(errorMessage)
+}
+
 ext.dependencyLocation = (System.getenv("CASSANDRA_DEP_DIR") ?: "${rootDir}/dependencies") + "/"
 
 

--- a/cassandra-analytics-common/src/main/java/org/apache/cassandra/spark/utils/MapUtils.java
+++ b/cassandra-analytics-common/src/main/java/org/apache/cassandra/spark/utils/MapUtils.java
@@ -268,7 +268,7 @@ public final class MapUtils
             deprecatedOptionValue = resolver.apply(deprecated);
         }
 
-        if (options.containsKey(option))
+        if (options.containsKey(option) && deprecatedOptionValue != null)
         {
             LOGGER.info("The option: {} is defined. Favor the value over {}", option, deprecated);
             return resolver.apply(option);

--- a/cassandra-analytics-common/src/main/java/org/apache/cassandra/spark/utils/MapUtils.java
+++ b/cassandra-analytics-common/src/main/java/org/apache/cassandra/spark/utils/MapUtils.java
@@ -268,9 +268,12 @@ public final class MapUtils
             deprecatedOptionValue = resolver.apply(deprecated);
         }
 
-        if (options.containsKey(option) && deprecatedOptionValue != null)
+        if (options.containsKey(option))
         {
-            LOGGER.info("The option: {} is defined. Favor the value over {}", option, deprecated);
+            if (deprecatedOptionValue != null)
+            {
+                LOGGER.info("The option: {} is defined. Favor the value over {}", option, deprecated);
+            }
             return resolver.apply(option);
         }
 

--- a/cassandra-analytics-core-example/src/main/java/org/apache/cassandra/spark/example/DirectWriteAndReadJob.java
+++ b/cassandra-analytics-core-example/src/main/java/org/apache/cassandra/spark/example/DirectWriteAndReadJob.java
@@ -41,7 +41,7 @@ public class DirectWriteAndReadJob extends AbstractCassandraJob
     protected JobConfiguration configureJob(SparkContext sc, SparkConf sparkConf)
     {
         Map<String, String> writeOptions = new HashMap<>();
-        writeOptions.put("sidecar_instances", "localhost,localhost2,localhost3");
+        writeOptions.put("sidecar_contact_points", "localhost,localhost2,localhost3");
         writeOptions.put("keyspace", "spark_test");
         writeOptions.put("table", "test");
         writeOptions.put("local_dc", "datacenter1");
@@ -54,7 +54,7 @@ public class DirectWriteAndReadJob extends AbstractCassandraJob
                                             sparkConf.getInt("spark.executor.instances", 1));
         int numCores = coresPerExecutor * numExecutors;
         Map<String, String> readerOptions = new HashMap<>();
-        readerOptions.put("sidecar_instances", "localhost,localhost2,localhost3");
+        readerOptions.put("sidecar_contact_points", "localhost,localhost2,localhost3");
         readerOptions.put("keyspace", "spark_test");
         readerOptions.put("table", "test");
         readerOptions.put("DC", "datacenter1");

--- a/cassandra-analytics-core-example/src/main/java/org/apache/cassandra/spark/example/LocalS3WriteAndReadJob.java
+++ b/cassandra-analytics-core-example/src/main/java/org/apache/cassandra/spark/example/LocalS3WriteAndReadJob.java
@@ -66,7 +66,7 @@ public class LocalS3WriteAndReadJob extends AbstractCassandraJob
     protected JobConfiguration configureJob(SparkContext sc, SparkConf sparkConf)
     {
         Map<String, String> writeOptions = new HashMap<>();
-        writeOptions.put("sidecar_instances", sidecarInstances);
+        writeOptions.put("sidecar_contact_points", sidecarInstances);
         writeOptions.put("keyspace", "spark_test");
         writeOptions.put("table", "test");
         writeOptions.put("local_dc", dataCenter);
@@ -92,7 +92,7 @@ public class LocalS3WriteAndReadJob extends AbstractCassandraJob
                                             sparkConf.getInt("spark.executor.instances", 1));
         int numCores = coresPerExecutor * numExecutors;
         Map<String, String> readerOptions = new HashMap<>();
-        readerOptions.put("sidecar_instances", "localhost,localhost2,localhost3");
+        readerOptions.put("sidecar_contact_points", "localhost,localhost2,localhost3");
         readerOptions.put("keyspace", "spark_test");
         readerOptions.put("table", "test");
         readerOptions.put("DC", "datacenter1");

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/BulkSparkConf.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/BulkSparkConf.java
@@ -41,7 +41,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.cassandra.sidecar.client.SidecarInstance;
-import org.apache.cassandra.sidecar.client.SidecarInstanceImpl;
 import org.apache.cassandra.spark.bulkwriter.blobupload.StorageClientConfig;
 import org.apache.cassandra.spark.bulkwriter.token.ConsistencyLevel;
 import org.apache.cassandra.spark.bulkwriter.util.SbwKryoRegistrator;
@@ -158,7 +157,7 @@ public class BulkSparkConf implements Serializable
         this.userProvidedSidecarPort = sidecarPortFromOptions.isPresent() ? sidecarPortFromOptions.get() : getOptionalInt(SIDECAR_PORT).orElse(-1);
         this.effectiveSidecarPort = this.userProvidedSidecarPort == -1 ? DEFAULT_SIDECAR_PORT : this.userProvidedSidecarPort;
         this.sidecarContactPointsValue = resolveSidecarContactPoints(options);
-        this.sidecarContactPoints = sidecarInstances();
+        this.sidecarContactPoints = sidecarContactPoints();
         this.keyspace = MapUtils.getOrThrow(options, WriterOptions.KEYSPACE.name());
         this.table = MapUtils.getOrThrow(options, WriterOptions.TABLE.name());
         this.skipExtendedVerify = MapUtils.getBoolean(options, WriterOptions.SKIP_EXTENDED_VERIFY.name(), true,
@@ -265,7 +264,7 @@ public class BulkSparkConf implements Serializable
         });
     }
 
-    protected Set<? extends SidecarInstance> buildSidecarInstances()
+    protected Set<? extends SidecarInstance> buildSidecarContactPoints()
     {
         String[] split = Objects.requireNonNull(sidecarContactPointsValue, "Unable to build sidecar instances from null value")
                                 .split(",");
@@ -275,11 +274,11 @@ public class BulkSparkConf implements Serializable
                      .collect(Collectors.toSet());
     }
 
-    Set<? extends SidecarInstance> sidecarInstances()
+    Set<? extends SidecarInstance> sidecarContactPoints()
     {
         if (sidecarContactPoints == null)
         {
-            sidecarContactPoints = buildSidecarInstances();
+            sidecarContactPoints = buildSidecarContactPoints();
         }
         return sidecarContactPoints;
     }

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/BulkSparkConf.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/BulkSparkConf.java
@@ -33,7 +33,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import com.google.common.base.Preconditions;

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/CassandraContext.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/CassandraContext.java
@@ -88,7 +88,7 @@ public class CassandraContext implements StartupValidatable, Closeable
 
     protected Set<? extends SidecarInstance> createClusterConfig()
     {
-        return conf.sidecarInstances();
+        return conf.sidecarContactPoints();
     }
 
     public SidecarClient getSidecarClient()

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/WriterOptions.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/WriterOptions.java
@@ -26,7 +26,11 @@ import org.apache.cassandra.spark.transports.storage.extensions.StorageTransport
  */
 public enum WriterOptions implements WriterOption
 {
+    @Deprecated // Prefer the equivalent, SIDECAR_CONTACT_POINTS
     SIDECAR_INSTANCES,
+    // The option specifies the initial contact points of sidecar servers to discover the cluster topology
+    // Note that the addresses can include port; when port is present, it takes precedence over SIDECAR_PORT
+    SIDECAR_CONTACT_POINTS,
     KEYSPACE,
     TABLE,
     BULK_WRITER_CL,
@@ -45,7 +49,7 @@ public enum WriterOptions implements WriterOption
     TRUSTSTORE_PATH,
     TRUSTSTORE_BASE64_ENCODED,
     SIDECAR_PORT,
-    @Deprecated // the size unit `MB` is incorrect, use `SSTABLE_DATA_SIZE_IN_MIB` instead
+    @Deprecated // Prefer the equivalent, `SSTABLE_DATA_SIZE_IN_MIB`. The size unit `MB` is incorrect and internally treated as MiB.
     SSTABLE_DATA_SIZE_IN_MB,
     SSTABLE_DATA_SIZE_IN_MIB,
     TTL,

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/common/SidecarInstanceFactory.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/common/SidecarInstanceFactory.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cassandra.spark.common;
+
+import com.google.common.base.Preconditions;
+import org.apache.commons.lang3.StringUtils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.cassandra.sidecar.client.SidecarInstanceImpl;
+
+public class SidecarInstanceFactory
+{
+    private static final Logger LOGGER = LoggerFactory.getLogger(SidecarInstanceFactory.class);
+
+    public static SidecarInstanceImpl createFromString(String input, int defaultPort)
+    {
+        Preconditions.checkArgument(StringUtils.isNotEmpty(input), "Unable to create sidecar instance from empty input");
+
+        String hostname = input;
+        int port = defaultPort;
+        // has port in the string. The former matches ipv6 and the latter matches ipv4 and hostnames
+        // ipv6 with port example: [2024:a::1]:8080
+        if (input.contains("]:") || (!input.startsWith("[") && input.contains(":")))
+        {
+            int index = input.lastIndexOf(':');
+            hostname = input.substring(0, index); // includes ']' if it is ipv6
+            String portStr = input.substring(index + 1);
+            port = Integer.parseInt(portStr);
+        }
+
+        LOGGER.info("Create sidecar instance. hostname={} port={}", hostname, port);
+        return new SidecarInstanceImpl(hostname, port);
+    }
+}

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/common/SidecarInstanceFactory.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/common/SidecarInstanceFactory.java
@@ -29,8 +29,19 @@ import org.apache.cassandra.sidecar.client.SidecarInstanceImpl;
 
 public class SidecarInstanceFactory
 {
+    private SidecarInstanceFactory()
+    {
+        throw new UnsupportedOperationException("Utility class");
+    }
+
     private static final Logger LOGGER = LoggerFactory.getLogger(SidecarInstanceFactory.class);
 
+    /**
+     * Create SidecarInstance object by parsing the input string, which is IP address or hostname and optionally includes port
+     * @param input hostname string that can optionally includes the port. If port is present, the defaultPort param is ignored.
+     * @param defaultPort port value used when the input string contains no port
+     * @return SidecarInstanceImpl
+     */
     public static SidecarInstanceImpl createFromString(String input, int defaultPort)
     {
         Preconditions.checkArgument(StringUtils.isNotEmpty(input), "Unable to create sidecar instance from empty input");

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/data/CassandraDataLayer.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/data/CassandraDataLayer.java
@@ -76,7 +76,6 @@ import org.apache.cassandra.sidecar.client.SidecarInstance;
 import org.apache.cassandra.sidecar.client.SidecarInstanceImpl;
 import org.apache.cassandra.sidecar.client.SimpleSidecarInstancesProvider;
 import org.apache.cassandra.sidecar.client.exception.RetriesExhaustedException;
-import org.apache.cassandra.spark.bulkwriter.BulkSparkConf;
 import org.apache.cassandra.spark.common.SidecarInstanceFactory;
 import org.apache.cassandra.spark.config.SchemaFeature;
 import org.apache.cassandra.spark.config.SchemaFeatureSet;

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/data/ClientConfig.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/data/ClientConfig.java
@@ -45,7 +45,7 @@ public class ClientConfig
 
     // TODO: the key value string is not consistent with WriterOptions and keys in BulkSparkConf
     @Deprecated // Prefer the equivalent, SIDECAR_CONTACT_POINTS
-    public static final String SIDECAR_INSTANCES = "sidecar_instances";
+    public static final String SIDECAR_INSTANCES = "sidecar_contact_points";
     // The option specifies the initial contact points of sidecar servers to discover the cluster topology
     public static final String SIDECAR_CONTACT_POINTS = "sidecar_contact_points";
     public static final String KEYSPACE_KEY = "keyspace";

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/data/CassandraDataLayerTests.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/data/CassandraDataLayerTests.java
@@ -45,7 +45,7 @@ class CassandraDataLayerTests
         ClientConfig clientConfig = ClientConfig.create(options);
         assertEquals("big-data", clientConfig.keyspace());
         assertEquals("customers", clientConfig.table());
-        assertEquals("localhost", clientConfig.sidecarInstances());
+        assertEquals("localhost", clientConfig.sidecarContactPoints());
         ClientConfig.ClearSnapshotStrategy clearSnapshotStrategy = clientConfig.clearSnapshotStrategy();
         assertTrue(clearSnapshotStrategy.shouldClearOnCompletion());
         assertEquals("2d", clearSnapshotStrategy.ttl());

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/data/CassandraDataLayerTests.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/data/CassandraDataLayerTests.java
@@ -36,7 +36,7 @@ class CassandraDataLayerTests
     public static final Map<String, String> REQUIRED_CLIENT_CONFIG_OPTIONS = ImmutableMap.of(
     "keyspace", "big-data",
     "table", "customers",
-    "sidecar_instances", "localhost");
+    "sidecar_contact_points", "localhost");
 
     @Test
     void testDefaultClearSnapshotStrategy()

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/data/CassandraDataSourceHelperCacheTest.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/data/CassandraDataSourceHelperCacheTest.java
@@ -48,7 +48,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class CassandraDataSourceHelperCacheTest
 {
     public static final Map<String, String> REQUIRED_CLIENT_CONFIG_OPTIONS =
-            ImmutableMap.of("sidecar_instances", "127.0.0.1",
+            ImmutableMap.of("sidecar_contact_points", "127.0.0.1",
                             "keyspace", "big-data",
                             "table", "customers");
 

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/data/ClientConfigTests.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/data/ClientConfigTests.java
@@ -36,7 +36,7 @@ class ClientConfigTests
     public static final Map<String, String> REQUIRED_CLIENT_CONFIG_OPTIONS = ImmutableMap.of(
     "keyspace", "big-data",
     "table", "customers",
-    "sidecar_instances", "localhost");
+    "sidecar_contact_points", "localhost");
 
     @ParameterizedTest
     @ValueSource(strings = {"2h", "200s", "4d", "60m", "  60m", "50s ", " 32d "})

--- a/cassandra-analytics-core/src/test/spark3/org/apache/cassandra/spark/common/SidecarInstanceFactoryTest.java
+++ b/cassandra-analytics-core/src/test/spark3/org/apache/cassandra/spark/common/SidecarInstanceFactoryTest.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cassandra.spark.common;
+
+import org.junit.jupiter.api.Test;
+
+import org.apache.cassandra.sidecar.client.SidecarInstance;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class SidecarInstanceFactoryTest
+{
+    @Test
+    void testCreateSidecarInstance()
+    {
+        assertThatThrownBy(() -> SidecarInstanceFactory.createFromString("", 9999))
+        .isExactlyInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Unable to create sidecar instance from empty input");
+
+        assertSidecarInstance(SidecarInstanceFactory.createFromString("localhost", 9999),
+                              "localhost", 9999);
+        assertSidecarInstance(SidecarInstanceFactory.createFromString("[2024:a::1]", 9999),
+                              "[2024:a::1]", 9999);
+        assertSidecarInstance(SidecarInstanceFactory.createFromString("localhost:8888", 9999),
+                              "localhost", 8888);
+        assertSidecarInstance(SidecarInstanceFactory.createFromString("127.0.0.1:8888", 9999),
+                              "127.0.0.1", 8888);
+        assertSidecarInstance(SidecarInstanceFactory.createFromString("[2024:a::1]:8888", 9999),
+                              "[2024:a::1]", 8888);
+    }
+
+    private void assertSidecarInstance(SidecarInstance sidecarInstance, String expectedHostname, int expectedPort)
+    {
+        assertThat(sidecarInstance.hostname()).isEqualTo(expectedHostname);
+        assertThat(sidecarInstance.port()).isEqualTo(expectedPort);
+    }
+}

--- a/cassandra-analytics-integration-tests/src/test/java/org/apache/cassandra/analytics/SparkTestUtils.java
+++ b/cassandra-analytics-integration-tests/src/test/java/org/apache/cassandra/analytics/SparkTestUtils.java
@@ -116,7 +116,7 @@ public class SparkTestUtils
         int numCores = coresPerExecutor * numExecutors;
 
         return sql.read().format("org.apache.cassandra.spark.sparksql.CassandraDataSource")
-                  .option("sidecar_instances", sidecarInstancesOption(cluster, dnsResolver))
+                  .option("sidecar_contact_points", sidecarInstancesOption(cluster, dnsResolver))
                   .option("keyspace", tableName.keyspace()) // unquoted
                   .option("table", tableName.table()) // unquoted
                   .option("DC", "datacenter1")
@@ -147,7 +147,7 @@ public class SparkTestUtils
     {
         return df.write()
                  .format("org.apache.cassandra.spark.sparksql.CassandraDataSink")
-                 .option("sidecar_instances", sidecarInstancesOption(cluster, dnsResolver))
+                 .option("sidecar_contact_points", sidecarInstancesOption(cluster, dnsResolver))
                  .option("keyspace", tableName.keyspace())
                  .option("table", tableName.table())
                  .option("local_dc", "datacenter1")


### PR DESCRIPTION
This patch introduces a new option SIDECAR_CONTACT_POINTS for both bulk writer and reader. The option name better describes the purpose, which is to specify the initial contact points to discover the cluster topology. The existing option SIDECAR_INSTANCES are used for the same purpose and it is now deprecated. In addition, it allows including the port value in the addresses when defining SIDECAR_CONTACT_POINTS

Patch by Yifan Cai; Reviewed by Francisco Guerrero for CASSANDRA-19772