### PR TITLE
CASSANDRA-19827: Add job_timeout_seconds writer option

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 1.0.0
+ * Add job_timeout_seconds writer option (CASSANDRA-19827)
  * Prevent double closing sstable writer (CASSANDRA-19821)
  * Stream sstable eagerly when bulk writing to reclaim local disk space sooner (CASSANDRA-19806)
  * Split the Cassandra type logic out from CassandraBridge into a separate module (CASSANDRA-19793)

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/BulkSparkConf.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/BulkSparkConf.java
@@ -183,7 +183,7 @@ public class BulkSparkConf implements Serializable
         // else fall back to props, and then default if neither specified
         this.useOpenSsl = getBoolean(USE_OPENSSL, true);
         this.ringRetryCount = getInt(RING_RETRY_COUNT, DEFAULT_RING_RETRY_COUNT);
-        this.importCoordinatorTimeoutMultiplier = getDouble(IMPORT_COORDINATOR_TIMEOUT_MULTIPLIER, 2.0);
+        this.importCoordinatorTimeoutMultiplier = getDouble(IMPORT_COORDINATOR_TIMEOUT_MULTIPLIER, 0.5);
         this.ttl = MapUtils.getOrDefault(options, WriterOptions.TTL.name(), null);
         this.timestamp = MapUtils.getOrDefault(options, WriterOptions.TIMESTAMP.name(), null);
         this.quoteIdentifiers = MapUtils.getBoolean(options, WriterOptions.QUOTE_IDENTIFIERS.name(), false, "quote identifiers");

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/CassandraJobInfo.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/CassandraJobInfo.java
@@ -88,13 +88,19 @@ public class CassandraJobInfo implements JobInfo
     }
 
     @Override
+    public long jobTimeoutSeconds()
+    {
+        return conf.getJobTimeoutSeconds();
+    }
+
+    @Override
     public int effectiveSidecarPort()
     {
         return conf.getEffectiveSidecarPort();
     }
 
     @Override
-    public int importCoordinatorTimeoutMultiplier()
+    public double importCoordinatorTimeoutMultiplier()
     {
         return conf.importCoordinatorTimeoutMultiplier;
     }

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/ImportCompletionCoordinator.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/ImportCompletionCoordinator.java
@@ -45,9 +45,9 @@ import org.apache.cassandra.sidecar.client.SidecarInstance;
 import org.apache.cassandra.spark.bulkwriter.blobupload.BlobDataTransferApi;
 import org.apache.cassandra.spark.bulkwriter.blobupload.BlobStreamResult;
 import org.apache.cassandra.spark.bulkwriter.blobupload.CreatedRestoreSlice;
-import org.apache.cassandra.util.ThreadUtil;
 import org.apache.cassandra.spark.data.ReplicationFactor;
 import org.apache.cassandra.spark.transports.storage.extensions.StorageTransportExtension;
+import org.apache.cassandra.util.ThreadUtil;
 
 import static org.apache.cassandra.clients.Sidecar.toSidecarInstance;
 import static org.apache.cassandra.spark.bulkwriter.blobupload.CreatedRestoreSlice.ConsistencyLevelCheckResult.NOT_SATISFIED;
@@ -69,7 +69,7 @@ public final class ImportCompletionCoordinator
     private final CompletableFuture<Void> firstFailure = new CompletableFuture<>();
     private final CompletableFuture<Void> terminal = new CompletableFuture<>();
     private final Map<CompletableFuture<Void>, RequestAndInstance> importFutures = new HashMap<>();
-    private final AtomicBoolean terminalScheduled = new AtomicBoolean(false);
+    private final AtomicBoolean consistencyLevelReached = new AtomicBoolean(false);
     private final AtomicInteger completedSlices = new AtomicInteger(0);
 
     private long waitStartNanos;
@@ -165,6 +165,11 @@ public final class ImportCompletionCoordinator
         }
     }
 
+    public boolean hasConsistencyLevelReached()
+    {
+        return consistencyLevelReached.get();
+    }
+
     private void waitForCompletionInternal()
     {
         prepareToPoll();
@@ -219,8 +224,6 @@ public final class ImportCompletionCoordinator
         // whenComplete callback will still be invoked when the future is cancelled.
         // In such case, expect CancellationException
         future.whenComplete((v, t) -> {
-            LOGGER.info("Completed slice requests {}/{}", completedSlices.incrementAndGet(), importFutures.keySet().size());
-
             if (t instanceof CancellationException)
             {
                 RequestAndInstance rai = importFutures.get(future);
@@ -228,19 +231,35 @@ public final class ImportCompletionCoordinator
                 return;
             }
 
+            LOGGER.info("Completed slice requests {}/{}", completedSlices.incrementAndGet(), importFutures.keySet().size());
+
             // only enter the block once
             if (satisfiedSlices.get() == totalSlices
-                && terminalScheduled.compareAndSet(false, true))
+                && consistencyLevelReached.compareAndSet(false, true))
             {
-                long timeToAllSatisfiedNanos = System.nanoTime() - waitStartNanos;
-                long timeout = estimateTimeout(timeToAllSatisfiedNanos);
+                long nowNanos = System.nanoTime();
+                long timeToAllSatisfiedNanos = nowNanos - waitStartNanos;
+                long elapsedNanos = nowNanos - startTimeNanos;
+                long timeoutNanos = estimateTimeoutNanos(timeToAllSatisfiedNanos, elapsedNanos,
+                                                         job.importCoordinatorTimeoutMultiplier(),
+                                                         minSliceSize, maxSliceSize,
+                                                         job.jobTimeoutSeconds());
                 LOGGER.info("The specified consistency level of the job has been satisfied. " +
                             "Continuing to waiting on slices completion in order to prevent Cassandra side " +
                             "streaming as much as possible. The estimated additional wait time is {} seconds.",
-                            TimeUnit.NANOSECONDS.toSeconds(timeout));
-                // schedule to complete the terminal
-                scheduler.schedule(() -> terminal.complete(null),
-                                   timeout, TimeUnit.NANOSECONDS);
+                            TimeUnit.NANOSECONDS.toSeconds(timeoutNanos));
+
+                if (timeoutNanos > 0)
+                {
+                    // schedule to complete the terminal
+                    scheduler.schedule(() -> terminal.complete(null),
+                                       timeoutNanos, TimeUnit.NANOSECONDS);
+                }
+                else
+                {
+                    // complete immediately since there is no additional time to wait
+                    terminal.complete(null);
+                }
             }
         });
     }
@@ -258,23 +277,41 @@ public final class ImportCompletionCoordinator
         validateAllRangesAreSatisfied();
     }
 
-    // calculate the timeout based on the 1) time taken to have all slices satisfied, and 2) use import rate
-    private long estimateTimeout(long timeToAllSatisfiedNanos)
+    // Calculate the timeout based on the 1) time taken to have all slices satisfied, 2) use import rate and 3) jobTimeoutSeconds
+    // The effective timeout is the min of the estimate and the jobTimeoutSeconds (when specified)
+    static long estimateTimeoutNanos(long timeToAllSatisfiedNanos,
+                                     long elapsedNanos,
+                                     double importCoordinatorTimeoutMultiplier,
+                                     double minSliceSize,
+                                     double maxSliceSize,
+                                     long jobTimeoutSeconds)
     {
-        long timeout = timeToAllSatisfiedNanos;
+        long timeoutNanos = timeToAllSatisfiedNanos;
         // use the minSliceSize to get the slowest import rate. R = minSliceSize / T
         // use the maxSliceSize to get the highest amount of time needed for import. D = maxSliceSize / R
         // Please do not combine the two statements below for readability purpose
-        double estimatedRateFloor = ((double) minSliceSize) / timeToAllSatisfiedNanos;
-        double timeEstimateBasedOnRate = ((double) maxSliceSize) / estimatedRateFloor;
-        timeout = Math.max((long) timeEstimateBasedOnRate, timeout);
-        timeout = job.importCoordinatorTimeoutMultiplier() * timeout;
-        if (TimeUnit.NANOSECONDS.toHours(timeout) > 1)
+        double estimatedRateFloor = minSliceSize / timeToAllSatisfiedNanos;
+        double timeEstimateBasedOnRate = maxSliceSize / estimatedRateFloor;
+        double estimate = Math.max(timeEstimateBasedOnRate, (double) timeoutNanos);
+        timeoutNanos = (long) Math.ceil(importCoordinatorTimeoutMultiplier * estimate);
+        // consider the jobTimeoutSeconds only if it is specified
+        if (jobTimeoutSeconds != -1)
         {
-            LOGGER.warn("The estimated additional timeout is more than 1 hour. timeout={} seconds",
-                        TimeUnit.NANOSECONDS.toSeconds(timeout));
+            long remainingIdealTimeoutNanos = TimeUnit.SECONDS.toNanos(jobTimeoutSeconds) - elapsedNanos;
+            if (remainingIdealTimeoutNanos <= 0)
+            {
+                // ideal timeout has passed, and we have already achieved the desired consistency level.
+                // Do not wait any longer
+                return 0;
+            }
+            timeoutNanos = Math.min(timeoutNanos, remainingIdealTimeoutNanos);
         }
-        return timeout;
+        if (TimeUnit.NANOSECONDS.toHours(timeoutNanos) > 1)
+        {
+            LOGGER.warn("The additional time to wait is more than 1 hour. timeout={} seconds",
+                        TimeUnit.NANOSECONDS.toSeconds(timeoutNanos));
+        }
+        return timeoutNanos;
     }
 
     private void createSliceInstanceFuture(CreatedRestoreSlice createdRestoreSlice,

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/JobInfo.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/JobInfo.java
@@ -85,6 +85,11 @@ public interface JobInfo extends Serializable
     int jobKeepAliveMinutes();
 
     /**
+     * @return job timeout in seconds; see {@link WriterOptions#JOB_TIMEOUT_SECONDS}
+     */
+    long jobTimeoutSeconds();
+
+    /**
      * @return sidecar service port
      */
     int effectiveSidecarPort();
@@ -92,5 +97,5 @@ public interface JobInfo extends Serializable
     /**
      * @return multiplier to calculate the final timeout for import coordinator
      */
-    int importCoordinatorTimeoutMultiplier();
+    double importCoordinatorTimeoutMultiplier();
 }

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/WriterOptions.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/WriterOptions.java
@@ -117,4 +117,11 @@ public enum WriterOptions implements WriterOption
      * Option to tune the concurrency of the nio http client employed in s3 client
      */
     STORAGE_CLIENT_NIO_HTTP_CLIENT_MAX_CONCURRENCY,
+    /**
+     * Option to specify the timeout in seconds for bulk write jobs. By default, it is disabled.
+     * When JOB_TIMEOUT_SECONDS is specified, a job exceeding the timeout is:
+     * - successful when the desired consistency level is met
+     * - a failure otherwise
+     */
+    JOB_TIMEOUT_SECONDS,
 }

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/blobupload/StorageClient.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/blobupload/StorageClient.java
@@ -43,7 +43,6 @@ import java.util.stream.Collectors;
 
 import org.apache.cassandra.spark.transports.storage.StorageCredentials;
 import org.apache.cassandra.spark.transports.storage.extensions.StorageTransportConfiguration;
-import org.apache.cassandra.spark.utils.ByteBufferUtils;
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
@@ -216,7 +215,8 @@ public class StorageClient implements AutoCloseable
             {
                 int loopPartNumber = partNumber;
                 ByteBuffer buffer = chunks.next();
-                AsyncRequestBody body = AsyncRequestBody.fromBytes(ByteBufferUtils.getArray(buffer));
+                // get a copy of the remaining ByteBuffer; for the last chunk, the cloned ByteBuffer is resized accordingly.
+                AsyncRequestBody body = AsyncRequestBody.fromRemainingByteBuffer(buffer);
                 UploadPartRequest uploadPartRequest = UploadPartRequest.builder()
                                                                        .overrideConfiguration(credentialsOverride(credentials))
                                                                        .bucket(storageTransportConfiguration.getWriteBucket())

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/ImportCompletionCoordinatorTest.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/ImportCompletionCoordinatorTest.java
@@ -241,11 +241,11 @@ class ImportCompletionCoordinatorTest
     }
 
     @Test
-    void testAwaitShouldBlockUntilClSatisfiedWhenIdealTimeoutIsLow()
+    void testAwaitShouldBlockUntilClSatisfiedWhenTimeoutIsLow()
     {
-        // it should produce a really large estimate; the coordinator ignores it anyway due to small ideal timeout
+        // it should produce a really large estimate; the coordinator ignores it anyway due to small  timeout
         when(mockJobInfo.importCoordinatorTimeoutMultiplier()).thenReturn(1000.0);
-        when(mockJobInfo.jobTimeoutSeconds()).thenReturn(1L); // low ideal timeout lead to immediate termination as soon as CL is satisfied
+        when(mockJobInfo.jobTimeoutSeconds()).thenReturn(1L); // low  timeout lead to immediate termination as soon as CL is satisfied
         List<BlobStreamResult> resultList = buildBlobStreamResultWithNoProgressImports(/* Stuck slice per replica set */ 1, /* importTimeMillis */ 100L);
         ImportCompletionCoordinator coordinator = ImportCompletionCoordinator.of(System.nanoTime(), mockWriterContext, dataTransferApi,
                                                                                  writerValidator, resultList, mockExtension, onCancelJob);
@@ -255,19 +255,19 @@ class ImportCompletionCoordinatorTest
                      "All objects should be applied and reported for exactly once");
         assertEquals(allTestObjectKeys(), new HashSet<>(appliedObjectKeys.getAllValues()));
         Map<CompletableFuture<Void>, RequestAndInstance> importFutures = coordinator.importFutures();
-        // all the other imports should be cancelled, given ideal timeout has exceeded
+        // all the other imports should be cancelled, given  timeout has exceeded
         int cancelledImports = importFutures.keySet().stream().mapToInt(f -> f.isCancelled() ? 1 : 0).sum();
         assertEquals(TOTAL_INSTANCES, cancelledImports,
                      "Each replica set should have a slice gets cancelled due to making no progress");
     }
 
     @Test
-    void testAwaitShouldBlockUntilIdealTimeoutExceeds()
+    void testAwaitShouldBlockUntilTimeoutExceeds()
     {
-        // it should produce a really large estimate; the coordinator ignores it anyway due to small ideal timeout
+        // it should produce a really large estimate; the coordinator ignores it anyway due to small  timeout
         when(mockJobInfo.importCoordinatorTimeoutMultiplier()).thenReturn(1000.0);
-        long idealTimeout = 5L;
-        when(mockJobInfo.jobTimeoutSeconds()).thenReturn(idealTimeout); // await at most 10 seconds
+        long timeout = 5L;
+        when(mockJobInfo.jobTimeoutSeconds()).thenReturn(timeout);
         List<BlobStreamResult> resultList = buildBlobStreamResultWithNoProgressImports(/* Stuck slice per replica set */ 1, /* importTimeMillis */ 100L);
         long startNanos = System.nanoTime();
         ImportCompletionCoordinator coordinator = ImportCompletionCoordinator.of(startNanos, mockWriterContext, dataTransferApi,
@@ -277,12 +277,12 @@ class ImportCompletionCoordinatorTest
                      "All objects should be applied and reported for exactly once");
         assertEquals(allTestObjectKeys(), new HashSet<>(appliedObjectKeys.getAllValues()));
         Map<CompletableFuture<Void>, RequestAndInstance> importFutures = coordinator.importFutures();
-        // all the other imports should be cancelled, given ideal timeout has exceeded
+        // all the other imports should be cancelled, given  timeout has exceeded
         int cancelledImports = importFutures.keySet().stream().mapToInt(f -> f.isCancelled() ? 1 : 0).sum();
         assertEquals(TOTAL_INSTANCES, cancelledImports,
                      "Each replica set should have a slice gets cancelled due to making no progress");
-        assertTrue(System.nanoTime() - startNanos > TimeUnit.SECONDS.toNanos(idealTimeout),
-                   "ImportCompletionCoordinator should wait for at least " + idealTimeout + " seconds");
+        assertTrue(System.nanoTime() - startNanos > TimeUnit.SECONDS.toNanos(timeout),
+                   "ImportCompletionCoordinator should wait for at least " + timeout + " seconds");
     }
 
     @Test
@@ -329,21 +329,21 @@ class ImportCompletionCoordinatorTest
         double importCoordinatorTimeoutMultiplier = 1;
         double minSliceSize = 100;
         double maxSliceSize = 200;
-        long jobIdealTimeoutSeconds = 0;
+        long jobTimeoutSeconds = 0;
 
 
         long estimatedTimeout = estimateTimeoutNanos(timeToAllSatisfiedNanos, elapsedNanos,
                                                      importCoordinatorTimeoutMultiplier,
                                                      minSliceSize, maxSliceSize,
-                                                     jobIdealTimeoutSeconds);
+                                                     jobTimeoutSeconds);
         assertEquals(0, estimatedTimeout,
-                     "jobIdealTimeoutSeconds is 0. It should not wait for any additional time");
+                     "jobTimeoutSeconds is 0. It should not wait for any additional time");
 
-        jobIdealTimeoutSeconds = Integer.MAX_VALUE;
+        jobTimeoutSeconds = Integer.MAX_VALUE;
         estimatedTimeout = estimateTimeoutNanos(timeToAllSatisfiedNanos, elapsedNanos,
                                                 importCoordinatorTimeoutMultiplier,
                                                 minSliceSize, maxSliceSize,
-                                                jobIdealTimeoutSeconds);
+                                                jobTimeoutSeconds);
         assertEquals(TimeUnit.SECONDS.toNanos(6), estimatedTimeout,
                      "It takes 3 seconds to achieve CL; Based on the size estimate, it should take 200 / 100 * 3 seconds in addition");
 
@@ -351,7 +351,7 @@ class ImportCompletionCoordinatorTest
         estimatedTimeout = estimateTimeoutNanos(timeToAllSatisfiedNanos, elapsedNanos,
                                                 importCoordinatorTimeoutMultiplier,
                                                 minSliceSize, maxSliceSize,
-                                                jobIdealTimeoutSeconds);
+                                                jobTimeoutSeconds);
         assertEquals(0, estimatedTimeout,
                      "When timeout multiplier is 0, there is no additional wait time");
 
@@ -359,7 +359,7 @@ class ImportCompletionCoordinatorTest
         estimatedTimeout = estimateTimeoutNanos(timeToAllSatisfiedNanos, elapsedNanos,
                                                 importCoordinatorTimeoutMultiplier,
                                                 minSliceSize, maxSliceSize,
-                                                jobIdealTimeoutSeconds);
+                                                jobTimeoutSeconds);
         assertEquals(TimeUnit.SECONDS.toNanos(3), estimatedTimeout,
                      "The estimate is 200 / 100 * 3 * 0.5 == 3");
     }

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/MockBulkWriterContext.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/MockBulkWriterContext.java
@@ -283,15 +283,21 @@ public class MockBulkWriterContext implements BulkWriterContext, ClusterInfo, Jo
     }
 
     @Override
+    public long jobTimeoutSeconds()
+    {
+        return -1;
+    }
+
+    @Override
     public int effectiveSidecarPort()
     {
         return 9043;
     }
 
     @Override
-    public int importCoordinatorTimeoutMultiplier()
+    public double importCoordinatorTimeoutMultiplier()
     {
-        return 2;
+        return 2.0;
     }
 
     public void setSkipCleanOnFailures(boolean skipClean)

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/SimpleTaskSchedulerTest.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/SimpleTaskSchedulerTest.java
@@ -29,34 +29,34 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class HeartbeatReporterTest
+public class SimpleTaskSchedulerTest
 {
-    private HeartbeatReporter heartbeatReporter = new HeartbeatReporter();
+    private SimpleTaskScheduler simpleTaskScheduler = new SimpleTaskScheduler();
     private String heartbeatName = "test-heartbeat";
 
     @AfterEach
     public void teardown()
     {
-        heartbeatReporter.unschedule(heartbeatName);
+        simpleTaskScheduler.unschedule(heartbeatName);
     }
 
     @Test
-    public void testScheduleHeartbeat()
+    public void testSchedulePeriodicHeartbeat()
     {
         CountDownLatch latch = new CountDownLatch(10);
         long start = System.nanoTime();
-        heartbeatReporter.schedule(heartbeatName, 10, latch::countDown);
+        simpleTaskScheduler.schedulePeriodic(heartbeatName, 10, latch::countDown);
         Uninterruptibles.awaitUninterruptibly(latch);
         assertEquals(0, latch.getCount());
         assertTrue(System.nanoTime() > start + TimeUnit.MILLISECONDS.toNanos(10 * 10));
     }
 
     @Test
-    public void testScheduleSuppressThrows()
+    public void testSchedulePeriodicSuppressThrows()
     {
         CountDownLatch latch = new CountDownLatch(10);
         long start = System.nanoTime();
-        heartbeatReporter.schedule(heartbeatName, 10, () -> {
+        simpleTaskScheduler.schedulePeriodic(heartbeatName, 10, () -> {
             latch.countDown();
             throw new RuntimeException("It fails");
         });

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/SimpleTaskSchedulerTest.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/SimpleTaskSchedulerTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.cassandra.spark.bulkwriter;
 
+import java.time.Duration;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -32,20 +33,20 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class SimpleTaskSchedulerTest
 {
     private SimpleTaskScheduler simpleTaskScheduler = new SimpleTaskScheduler();
-    private String heartbeatName = "test-heartbeat";
+    private String taskName = "test-task";
 
     @AfterEach
     public void teardown()
     {
-        simpleTaskScheduler.unschedule(heartbeatName);
+        simpleTaskScheduler.unschedule(taskName);
     }
 
     @Test
-    public void testSchedulePeriodicHeartbeat()
+    public void testSchedulePeriodic()
     {
         CountDownLatch latch = new CountDownLatch(10);
         long start = System.nanoTime();
-        simpleTaskScheduler.schedulePeriodic(heartbeatName, 10, latch::countDown);
+        simpleTaskScheduler.schedulePeriodic(taskName, Duration.ofMillis(10), latch::countDown);
         Uninterruptibles.awaitUninterruptibly(latch);
         assertEquals(0, latch.getCount());
         assertTrue(System.nanoTime() > start + TimeUnit.MILLISECONDS.toNanos(10 * 10));
@@ -56,7 +57,7 @@ public class SimpleTaskSchedulerTest
     {
         CountDownLatch latch = new CountDownLatch(10);
         long start = System.nanoTime();
-        simpleTaskScheduler.schedulePeriodic(heartbeatName, 10, () -> {
+        simpleTaskScheduler.schedulePeriodic(taskName, Duration.ofMillis(10), () -> {
             latch.countDown();
             throw new RuntimeException("It fails");
         });


### PR DESCRIPTION
Option to specify the timeout in seconds for bulk write jobs. By default, it is disabled.
When JOB_TIMEOUT_SECONDS is specified, a job exceeding the timeout is:
- successful when the desired consistency level is met
- a failure otherwise
