### PR TITLE
CASSANDRA-19836: Fix NPE when writing UDT values

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 1.0.0
+ * Fix NPE when writing UDT values (CASSANDRA-19836)
  * Add job_timeout_seconds writer option (CASSANDRA-19827)
  * Prevent double closing sstable writer (CASSANDRA-19821)
  * Stream sstable eagerly when bulk writing to reclaim local disk space sooner (CASSANDRA-19806)

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/CassandraBulkWriterContext.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/CassandraBulkWriterContext.java
@@ -254,6 +254,6 @@ public class CassandraBulkWriterContext implements BulkWriterContext, KryoSerial
                                conf.getTTLOptions(),
                                conf.getTimestampOptions(),
                                lowestCassandraVersion,
-                               jobInfo.qualifiedTableName().quoteIdentifiers());
+                               conf.quoteIdentifiers);
     }
 }

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/RecordWriterTest.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/RecordWriterTest.java
@@ -46,7 +46,6 @@ import org.junit.jupiter.api.io.TempDir;
 import org.apache.cassandra.spark.bulkwriter.token.ConsistencyLevel;
 import org.apache.cassandra.spark.bulkwriter.token.TokenRangeMapping;
 import org.apache.cassandra.spark.common.model.CassandraInstance;
-import org.apache.cassandra.spark.common.schema.ColumnTypes;
 import org.apache.cassandra.spark.data.CqlField;
 import org.apache.cassandra.spark.utils.DigestAlgorithm;
 import org.apache.cassandra.spark.utils.XXHash32DigestAlgorithm;
@@ -57,10 +56,8 @@ import org.mockito.Mockito;
 import scala.Tuple2;
 
 import static org.apache.cassandra.spark.bulkwriter.MockBulkWriterContext.DEFAULT_CASSANDRA_VERSION;
-import static org.apache.cassandra.spark.bulkwriter.SqlToCqlTypeConverter.BOOLEAN;
 import static org.apache.cassandra.spark.bulkwriter.SqlToCqlTypeConverter.DATE;
 import static org.apache.cassandra.spark.bulkwriter.SqlToCqlTypeConverter.INT;
-import static org.apache.cassandra.spark.bulkwriter.SqlToCqlTypeConverter.TEXT;
 import static org.apache.cassandra.spark.bulkwriter.SqlToCqlTypeConverter.VARCHAR;
 import static org.apache.cassandra.spark.bulkwriter.TableSchemaTestCommon.mockCqlType;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -230,34 +227,6 @@ class RecordWriterTest
         writerContext.setSstableDataSizeInMB(1);
         Iterator<Tuple2<DecoratedKey, Object[]>> data = generateData();
         validateSuccessfulWrite(writerContext, data, columnNames);
-    }
-
-    @Test
-    void test() throws InterruptedException
-    {
-        String[] pk = {"pk1", "pk2"};
-        String[] columnNames = {"pk1", "pk2", "c1", "c2"};
-        Pair<StructType, ImmutableMap<String, CqlField.CqlType>> validPair = TableSchemaTestCommon.buildMatchedDataframeAndCqlColumns(
-        columnNames,
-        new DataType[]{DataTypes.StringType, DataTypes.StringType, DataTypes.StringType, DataTypes.BooleanType},
-        new CqlField.CqlType[]{mockCqlType(TEXT), mockCqlType(TEXT), mockCqlType(TEXT), mockCqlType(BOOLEAN)});
-
-        Tokenizer tokenizer = new Tokenizer(Arrays.asList(0, 1), Arrays.asList(pk), Arrays.asList(ColumnTypes.STRING, ColumnTypes.STRING), true);
-
-        MockBulkWriterContext writerContext = new MockBulkWriterContext(tokenRangeMapping,
-                                                                        DEFAULT_CASSANDRA_VERSION,
-                                                                        ConsistencyLevel.CL.LOCAL_QUORUM,
-                                                                        validPair,
-                                                                        pk,
-                                                                        pk,
-                                                                        false);
-        writerContext.setSstableDataSizeInMB(1);
-        Object[] row = new Object[] { "pk1v", "pk2v", "c1v", null };
-        Iterator<Tuple2<DecoratedKey, Object[]>> data = Arrays.asList(Tuple2.apply(new DecoratedKey(BigInteger.ONE, tokenizer.getDecoratedKey(row).getKey()), row)).iterator();
-
-        rw = new RecordWriter(writerContext, columnNames, () -> tc, SortedSSTableWriter::new);
-        WriteResult wr = rw.write(data);
-        System.out.println(wr);
     }
 
     @Test

--- a/cassandra-four-zero-types/src/main/java/org/apache/cassandra/spark/data/CqlType.java
+++ b/cassandra-four-zero-types/src/main/java/org/apache/cassandra/spark/data/CqlType.java
@@ -30,6 +30,8 @@ import org.apache.cassandra.db.marshal.AbstractType;
 import org.apache.cassandra.serializers.TypeSerializer;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public abstract class CqlType implements CqlField.CqlType
 {
@@ -106,10 +108,33 @@ public abstract class CqlType implements CqlField.CqlType
         throw CqlField.notImplemented(this);
     }
 
-    // Set inner value for UDTs or Tuples
-    public void setInnerValue(SettableByIndexData<?> udtValue, int position, Object value)
+    /**
+     * Set inner value for UDTs or Tuples
+     * @param udtValue udtValue to update
+     * @param position position in the vdtValue to set
+     * @param value value to set; the value is guaranteed to not be null
+     */
+    protected void setInnerValue(SettableByIndexData<?> udtValue, int position, @NotNull Object value)
     {
         throw CqlField.notImplemented(this);
+    }
+
+    /**
+     * Set nullable inner value at the position for UDTs or Tuples
+     * @param udtValue udtValue to update
+     * @param position position in the vdtValue to set
+     * @param value nullable value to set
+     */
+    public final void setNullableInnerValue(SettableByIndexData<?> udtValue, int position, @Nullable Object value)
+    {
+        if (value == null)
+        {
+            udtValue.setToNull(position);
+        }
+        else
+        {
+            setInnerValue(udtValue, position, value);
+        }
     }
 
     @Override

--- a/cassandra-four-zero-types/src/main/java/org/apache/cassandra/spark/data/CqlType.java
+++ b/cassandra-four-zero-types/src/main/java/org/apache/cassandra/spark/data/CqlType.java
@@ -114,7 +114,7 @@ public abstract class CqlType implements CqlField.CqlType
      * @param position position in the vdtValue to set
      * @param value value to set; the value is guaranteed to not be null
      */
-    protected void setInnerValue(SettableByIndexData<?> udtValue, int position, @NotNull Object value)
+    protected void setInnerValueInternal(SettableByIndexData<?> udtValue, int position, @NotNull Object value)
     {
         throw CqlField.notImplemented(this);
     }
@@ -125,7 +125,7 @@ public abstract class CqlType implements CqlField.CqlType
      * @param position position in the vdtValue to set
      * @param value nullable value to set
      */
-    public final void setNullableInnerValue(SettableByIndexData<?> udtValue, int position, @Nullable Object value)
+    public final void setInnerValue(SettableByIndexData<?> udtValue, int position, @Nullable Object value)
     {
         if (value == null)
         {
@@ -133,7 +133,7 @@ public abstract class CqlType implements CqlField.CqlType
         }
         else
         {
-            setInnerValue(udtValue, position, value);
+            setInnerValueInternal(udtValue, position, value);
         }
     }
 

--- a/cassandra-four-zero-types/src/main/java/org/apache/cassandra/spark/data/complex/CqlFrozen.java
+++ b/cassandra-four-zero-types/src/main/java/org/apache/cassandra/spark/data/complex/CqlFrozen.java
@@ -163,9 +163,9 @@ public class CqlFrozen extends CqlType implements CqlField.CqlFrozen
     }
 
     @Override
-    public void setInnerValue(SettableByIndexData<?> udtValue, int position, Object value)
+    protected void setInnerValue(SettableByIndexData<?> udtValue, int position, Object value)
     {
-        ((CqlType) inner()).setInnerValue(udtValue, position, value);
+        ((CqlType) inner()).setNullableInnerValue(udtValue, position, value);
     }
 
     @Override

--- a/cassandra-four-zero-types/src/main/java/org/apache/cassandra/spark/data/complex/CqlFrozen.java
+++ b/cassandra-four-zero-types/src/main/java/org/apache/cassandra/spark/data/complex/CqlFrozen.java
@@ -163,9 +163,9 @@ public class CqlFrozen extends CqlType implements CqlField.CqlFrozen
     }
 
     @Override
-    protected void setInnerValue(SettableByIndexData<?> udtValue, int position, Object value)
+    protected void setInnerValueInternal(SettableByIndexData<?> udtValue, int position, Object value)
     {
-        ((CqlType) inner()).setNullableInnerValue(udtValue, position, value);
+        ((CqlType) inner()).setInnerValue(udtValue, position, value);
     }
 
     @Override

--- a/cassandra-four-zero-types/src/main/java/org/apache/cassandra/spark/data/complex/CqlList.java
+++ b/cassandra-four-zero-types/src/main/java/org/apache/cassandra/spark/data/complex/CqlList.java
@@ -116,7 +116,7 @@ public class CqlList extends CqlCollection implements CqlField.CqlList
     }
 
     @Override
-    protected void setInnerValue(SettableByIndexData<?> udtValue, int position, Object value)
+    protected void setInnerValueInternal(SettableByIndexData<?> udtValue, int position, Object value)
     {
         udtValue.setList(position, (List<?>) value);
     }

--- a/cassandra-four-zero-types/src/main/java/org/apache/cassandra/spark/data/complex/CqlList.java
+++ b/cassandra-four-zero-types/src/main/java/org/apache/cassandra/spark/data/complex/CqlList.java
@@ -116,7 +116,7 @@ public class CqlList extends CqlCollection implements CqlField.CqlList
     }
 
     @Override
-    public void setInnerValue(SettableByIndexData<?> udtValue, int position, Object value)
+    protected void setInnerValue(SettableByIndexData<?> udtValue, int position, Object value)
     {
         udtValue.setList(position, (List<?>) value);
     }

--- a/cassandra-four-zero-types/src/main/java/org/apache/cassandra/spark/data/complex/CqlMap.java
+++ b/cassandra-four-zero-types/src/main/java/org/apache/cassandra/spark/data/complex/CqlMap.java
@@ -174,7 +174,7 @@ public class CqlMap extends CqlCollection implements CqlField.CqlMap
     }
 
     @Override
-    public void setInnerValue(SettableByIndexData<?> udtValue, int position, Object value)
+    protected void setInnerValue(SettableByIndexData<?> udtValue, int position, Object value)
     {
         udtValue.setMap(position, (Map<?, ?>) value);
     }

--- a/cassandra-four-zero-types/src/main/java/org/apache/cassandra/spark/data/complex/CqlMap.java
+++ b/cassandra-four-zero-types/src/main/java/org/apache/cassandra/spark/data/complex/CqlMap.java
@@ -174,7 +174,7 @@ public class CqlMap extends CqlCollection implements CqlField.CqlMap
     }
 
     @Override
-    protected void setInnerValue(SettableByIndexData<?> udtValue, int position, Object value)
+    protected void setInnerValueInternal(SettableByIndexData<?> udtValue, int position, Object value)
     {
         udtValue.setMap(position, (Map<?, ?>) value);
     }

--- a/cassandra-four-zero-types/src/main/java/org/apache/cassandra/spark/data/complex/CqlSet.java
+++ b/cassandra-four-zero-types/src/main/java/org/apache/cassandra/spark/data/complex/CqlSet.java
@@ -94,7 +94,7 @@ public class CqlSet extends CqlList implements CqlField.CqlSet
     }
 
     @Override
-    protected void setInnerValue(SettableByIndexData<?> udtValue, int position, Object value)
+    protected void setInnerValueInternal(SettableByIndexData<?> udtValue, int position, Object value)
     {
         udtValue.setSet(position, (Set<?>) value);
     }

--- a/cassandra-four-zero-types/src/main/java/org/apache/cassandra/spark/data/complex/CqlSet.java
+++ b/cassandra-four-zero-types/src/main/java/org/apache/cassandra/spark/data/complex/CqlSet.java
@@ -94,7 +94,7 @@ public class CqlSet extends CqlList implements CqlField.CqlSet
     }
 
     @Override
-    public void setInnerValue(SettableByIndexData<?> udtValue, int position, Object value)
+    protected void setInnerValue(SettableByIndexData<?> udtValue, int position, Object value)
     {
         udtValue.setSet(position, (Set<?>) value);
     }

--- a/cassandra-four-zero-types/src/main/java/org/apache/cassandra/spark/data/complex/CqlTuple.java
+++ b/cassandra-four-zero-types/src/main/java/org/apache/cassandra/spark/data/complex/CqlTuple.java
@@ -203,7 +203,7 @@ public class CqlTuple extends CqlCollection implements CqlField.CqlTuple
     }
 
     @Override
-    protected void setInnerValue(SettableByIndexData<?> udtValue, int position, Object value)
+    protected void setInnerValueInternal(SettableByIndexData<?> udtValue, int position, Object value)
     {
         udtValue.setTupleValue(position, toTupleValue(CassandraVersion.FOURZERO, this, value));
     }

--- a/cassandra-four-zero-types/src/main/java/org/apache/cassandra/spark/data/complex/CqlTuple.java
+++ b/cassandra-four-zero-types/src/main/java/org/apache/cassandra/spark/data/complex/CqlTuple.java
@@ -203,7 +203,7 @@ public class CqlTuple extends CqlCollection implements CqlField.CqlTuple
     }
 
     @Override
-    public void setInnerValue(SettableByIndexData<?> udtValue, int position, Object value)
+    protected void setInnerValue(SettableByIndexData<?> udtValue, int position, Object value)
     {
         udtValue.setTupleValue(position, toTupleValue(CassandraVersion.FOURZERO, this, value));
     }
@@ -237,7 +237,7 @@ public class CqlTuple extends CqlCollection implements CqlField.CqlTuple
         Object[] array = (Object[]) value;
         for (int position = 0; position < array.length; position++)
         {
-            CqlUdt.setInnerValue(version, tupleValue, (CqlType) tuple.type(position), position, array[position]);
+            CqlUdt.setNullableInnerValue(version, tupleValue, (CqlType) tuple.type(position), position, array[position]);
         }
         return tupleValue;
     }

--- a/cassandra-four-zero-types/src/main/java/org/apache/cassandra/spark/data/complex/CqlUdt.java
+++ b/cassandra-four-zero-types/src/main/java/org/apache/cassandra/spark/data/complex/CqlUdt.java
@@ -135,7 +135,7 @@ public class CqlUdt extends CqlType implements CqlField.CqlUdt
     }
 
     @Override
-    protected void setInnerValue(SettableByIndexData<?> udtValue, int position, Object value)
+    protected void setInnerValueInternal(SettableByIndexData<?> udtValue, int position, Object value)
     {
         udtValue.setUDTValue(position, (UDTValue) value);
     }
@@ -524,7 +524,7 @@ public class CqlUdt extends CqlType implements CqlField.CqlUdt
                                              int position,
                                              @Nullable Object value)
     {
-        type.setNullableInnerValue(udtValue, position, value == null ? null : type.convertForCqlWriter(value, version));
+        type.setInnerValue(udtValue, position, value == null ? null : type.convertForCqlWriter(value, version));
     }
 
     public static UserType toUserType(CqlUdt udt)

--- a/cassandra-four-zero-types/src/main/java/org/apache/cassandra/spark/data/types/BigInt.java
+++ b/cassandra-four-zero-types/src/main/java/org/apache/cassandra/spark/data/types/BigInt.java
@@ -41,7 +41,7 @@ public class BigInt extends LongBased
     }
 
     @Override
-    protected void setInnerValue(SettableByIndexData<?> udtValue, int position, Object value)
+    protected void setInnerValueInternal(SettableByIndexData<?> udtValue, int position, Object value)
     {
         udtValue.setLong(position, (long) value);
     }

--- a/cassandra-four-zero-types/src/main/java/org/apache/cassandra/spark/data/types/BigInt.java
+++ b/cassandra-four-zero-types/src/main/java/org/apache/cassandra/spark/data/types/BigInt.java
@@ -41,7 +41,7 @@ public class BigInt extends LongBased
     }
 
     @Override
-    public void setInnerValue(SettableByIndexData<?> udtValue, int position, Object value)
+    protected void setInnerValue(SettableByIndexData<?> udtValue, int position, Object value)
     {
         udtValue.setLong(position, (long) value);
     }

--- a/cassandra-four-zero-types/src/main/java/org/apache/cassandra/spark/data/types/Blob.java
+++ b/cassandra-four-zero-types/src/main/java/org/apache/cassandra/spark/data/types/Blob.java
@@ -63,7 +63,7 @@ public class Blob extends BinaryBased
     }
 
     @Override
-    public void setInnerValue(SettableByIndexData<?> udtValue, int position, Object value)
+    protected void setInnerValue(SettableByIndexData<?> udtValue, int position, Object value)
     {
         udtValue.setBytes(position, (ByteBuffer) value);
     }

--- a/cassandra-four-zero-types/src/main/java/org/apache/cassandra/spark/data/types/Blob.java
+++ b/cassandra-four-zero-types/src/main/java/org/apache/cassandra/spark/data/types/Blob.java
@@ -63,7 +63,7 @@ public class Blob extends BinaryBased
     }
 
     @Override
-    protected void setInnerValue(SettableByIndexData<?> udtValue, int position, Object value)
+    protected void setInnerValueInternal(SettableByIndexData<?> udtValue, int position, Object value)
     {
         udtValue.setBytes(position, (ByteBuffer) value);
     }

--- a/cassandra-four-zero-types/src/main/java/org/apache/cassandra/spark/data/types/Boolean.java
+++ b/cassandra-four-zero-types/src/main/java/org/apache/cassandra/spark/data/types/Boolean.java
@@ -84,7 +84,7 @@ public class Boolean extends NativeType
     }
 
     @Override
-    protected void setInnerValue(SettableByIndexData<?> udtValue, int position, Object value)
+    protected void setInnerValueInternal(SettableByIndexData<?> udtValue, int position, Object value)
     {
         udtValue.setBool(position, (boolean) value);
     }

--- a/cassandra-four-zero-types/src/main/java/org/apache/cassandra/spark/data/types/Boolean.java
+++ b/cassandra-four-zero-types/src/main/java/org/apache/cassandra/spark/data/types/Boolean.java
@@ -84,7 +84,7 @@ public class Boolean extends NativeType
     }
 
     @Override
-    public void setInnerValue(SettableByIndexData<?> udtValue, int position, Object value)
+    protected void setInnerValue(SettableByIndexData<?> udtValue, int position, Object value)
     {
         udtValue.setBool(position, (boolean) value);
     }

--- a/cassandra-four-zero-types/src/main/java/org/apache/cassandra/spark/data/types/Date.java
+++ b/cassandra-four-zero-types/src/main/java/org/apache/cassandra/spark/data/types/Date.java
@@ -105,7 +105,7 @@ public class Date extends NativeType
     }
 
     @Override
-    protected void setInnerValue(SettableByIndexData<?> udtValue, int position, Object value)
+    protected void setInnerValueInternal(SettableByIndexData<?> udtValue, int position, Object value)
     {
         udtValue.setDate(position, (LocalDate) value);
     }

--- a/cassandra-four-zero-types/src/main/java/org/apache/cassandra/spark/data/types/Date.java
+++ b/cassandra-four-zero-types/src/main/java/org/apache/cassandra/spark/data/types/Date.java
@@ -105,7 +105,7 @@ public class Date extends NativeType
     }
 
     @Override
-    public void setInnerValue(SettableByIndexData<?> udtValue, int position, Object value)
+    protected void setInnerValue(SettableByIndexData<?> udtValue, int position, Object value)
     {
         udtValue.setDate(position, (LocalDate) value);
     }

--- a/cassandra-four-zero-types/src/main/java/org/apache/cassandra/spark/data/types/Decimal.java
+++ b/cassandra-four-zero-types/src/main/java/org/apache/cassandra/spark/data/types/Decimal.java
@@ -100,7 +100,7 @@ public class Decimal extends NativeType
     }
 
     @Override
-    public void setInnerValue(SettableByIndexData<?> udtValue, int position, Object value)
+    protected void setInnerValue(SettableByIndexData<?> udtValue, int position, Object value)
     {
         udtValue.setDecimal(position, (BigDecimal) value);
     }

--- a/cassandra-four-zero-types/src/main/java/org/apache/cassandra/spark/data/types/Decimal.java
+++ b/cassandra-four-zero-types/src/main/java/org/apache/cassandra/spark/data/types/Decimal.java
@@ -100,7 +100,7 @@ public class Decimal extends NativeType
     }
 
     @Override
-    protected void setInnerValue(SettableByIndexData<?> udtValue, int position, Object value)
+    protected void setInnerValueInternal(SettableByIndexData<?> udtValue, int position, Object value)
     {
         udtValue.setDecimal(position, (BigDecimal) value);
     }

--- a/cassandra-four-zero-types/src/main/java/org/apache/cassandra/spark/data/types/Double.java
+++ b/cassandra-four-zero-types/src/main/java/org/apache/cassandra/spark/data/types/Double.java
@@ -78,7 +78,7 @@ public class Double extends NativeType
     }
 
     @Override
-    protected void setInnerValue(SettableByIndexData<?> udtValue, int position, Object value)
+    protected void setInnerValueInternal(SettableByIndexData<?> udtValue, int position, Object value)
     {
         udtValue.setDouble(position, (double) value);
     }

--- a/cassandra-four-zero-types/src/main/java/org/apache/cassandra/spark/data/types/Double.java
+++ b/cassandra-four-zero-types/src/main/java/org/apache/cassandra/spark/data/types/Double.java
@@ -78,7 +78,7 @@ public class Double extends NativeType
     }
 
     @Override
-    public void setInnerValue(SettableByIndexData<?> udtValue, int position, Object value)
+    protected void setInnerValue(SettableByIndexData<?> udtValue, int position, Object value)
     {
         udtValue.setDouble(position, (double) value);
     }

--- a/cassandra-four-zero-types/src/main/java/org/apache/cassandra/spark/data/types/Empty.java
+++ b/cassandra-four-zero-types/src/main/java/org/apache/cassandra/spark/data/types/Empty.java
@@ -89,7 +89,7 @@ public class Empty extends NativeType
     }
 
     @Override
-    public void setInnerValue(SettableByIndexData<?> udtValue, int position, Object value)
+    protected void setInnerValue(SettableByIndexData<?> udtValue, int position, Object value)
     {
         udtValue.setToNull(position);
     }

--- a/cassandra-four-zero-types/src/main/java/org/apache/cassandra/spark/data/types/Empty.java
+++ b/cassandra-four-zero-types/src/main/java/org/apache/cassandra/spark/data/types/Empty.java
@@ -89,7 +89,7 @@ public class Empty extends NativeType
     }
 
     @Override
-    protected void setInnerValue(SettableByIndexData<?> udtValue, int position, Object value)
+    protected void setInnerValueInternal(SettableByIndexData<?> udtValue, int position, Object value)
     {
         udtValue.setToNull(position);
     }

--- a/cassandra-four-zero-types/src/main/java/org/apache/cassandra/spark/data/types/Float.java
+++ b/cassandra-four-zero-types/src/main/java/org/apache/cassandra/spark/data/types/Float.java
@@ -78,7 +78,7 @@ public class Float extends NativeType
     }
 
     @Override
-    public void setInnerValue(SettableByIndexData<?> udtValue, int position, Object value)
+    protected void setInnerValue(SettableByIndexData<?> udtValue, int position, Object value)
     {
         udtValue.setFloat(position, (float) value);
     }

--- a/cassandra-four-zero-types/src/main/java/org/apache/cassandra/spark/data/types/Float.java
+++ b/cassandra-four-zero-types/src/main/java/org/apache/cassandra/spark/data/types/Float.java
@@ -78,7 +78,7 @@ public class Float extends NativeType
     }
 
     @Override
-    protected void setInnerValue(SettableByIndexData<?> udtValue, int position, Object value)
+    protected void setInnerValueInternal(SettableByIndexData<?> udtValue, int position, Object value)
     {
         udtValue.setFloat(position, (float) value);
     }

--- a/cassandra-four-zero-types/src/main/java/org/apache/cassandra/spark/data/types/Inet.java
+++ b/cassandra-four-zero-types/src/main/java/org/apache/cassandra/spark/data/types/Inet.java
@@ -73,7 +73,7 @@ public class Inet extends BinaryBased
     }
 
     @Override
-    protected void setInnerValue(SettableByIndexData<?> udtValue, int position, Object value)
+    protected void setInnerValueInternal(SettableByIndexData<?> udtValue, int position, Object value)
     {
         udtValue.setInet(position, (InetAddress) value);
     }

--- a/cassandra-four-zero-types/src/main/java/org/apache/cassandra/spark/data/types/Inet.java
+++ b/cassandra-four-zero-types/src/main/java/org/apache/cassandra/spark/data/types/Inet.java
@@ -73,7 +73,7 @@ public class Inet extends BinaryBased
     }
 
     @Override
-    public void setInnerValue(SettableByIndexData<?> udtValue, int position, Object value)
+    protected void setInnerValue(SettableByIndexData<?> udtValue, int position, Object value)
     {
         udtValue.setInet(position, (InetAddress) value);
     }

--- a/cassandra-four-zero-types/src/main/java/org/apache/cassandra/spark/data/types/Int.java
+++ b/cassandra-four-zero-types/src/main/java/org/apache/cassandra/spark/data/types/Int.java
@@ -78,7 +78,7 @@ public class Int extends NativeType
     }
 
     @Override
-    protected void setInnerValue(SettableByIndexData<?> udtValue, int position, Object value)
+    protected void setInnerValueInternal(SettableByIndexData<?> udtValue, int position, Object value)
     {
         udtValue.setInt(position, (int) value);
     }

--- a/cassandra-four-zero-types/src/main/java/org/apache/cassandra/spark/data/types/Int.java
+++ b/cassandra-four-zero-types/src/main/java/org/apache/cassandra/spark/data/types/Int.java
@@ -78,7 +78,7 @@ public class Int extends NativeType
     }
 
     @Override
-    public void setInnerValue(SettableByIndexData<?> udtValue, int position, Object value)
+    protected void setInnerValue(SettableByIndexData<?> udtValue, int position, Object value)
     {
         udtValue.setInt(position, (int) value);
     }

--- a/cassandra-four-zero-types/src/main/java/org/apache/cassandra/spark/data/types/SmallInt.java
+++ b/cassandra-four-zero-types/src/main/java/org/apache/cassandra/spark/data/types/SmallInt.java
@@ -78,7 +78,7 @@ public class SmallInt extends NativeType
     }
 
     @Override
-    protected void setInnerValue(SettableByIndexData<?> udtValue, int position, Object value)
+    protected void setInnerValueInternal(SettableByIndexData<?> udtValue, int position, Object value)
     {
         udtValue.setShort(position, (short) value);
     }

--- a/cassandra-four-zero-types/src/main/java/org/apache/cassandra/spark/data/types/SmallInt.java
+++ b/cassandra-four-zero-types/src/main/java/org/apache/cassandra/spark/data/types/SmallInt.java
@@ -78,7 +78,7 @@ public class SmallInt extends NativeType
     }
 
     @Override
-    public void setInnerValue(SettableByIndexData<?> udtValue, int position, Object value)
+    protected void setInnerValue(SettableByIndexData<?> udtValue, int position, Object value)
     {
         udtValue.setShort(position, (short) value);
     }

--- a/cassandra-four-zero-types/src/main/java/org/apache/cassandra/spark/data/types/StringBased.java
+++ b/cassandra-four-zero-types/src/main/java/org/apache/cassandra/spark/data/types/StringBased.java
@@ -93,7 +93,7 @@ public abstract class StringBased extends NativeType
     }
 
     @Override
-    protected void setInnerValue(SettableByIndexData<?> udtValue, int position, Object value)
+    protected void setInnerValueInternal(SettableByIndexData<?> udtValue, int position, Object value)
     {
         udtValue.setString(position, (String) value);
     }

--- a/cassandra-four-zero-types/src/main/java/org/apache/cassandra/spark/data/types/StringBased.java
+++ b/cassandra-four-zero-types/src/main/java/org/apache/cassandra/spark/data/types/StringBased.java
@@ -93,7 +93,7 @@ public abstract class StringBased extends NativeType
     }
 
     @Override
-    public void setInnerValue(SettableByIndexData<?> udtValue, int position, Object value)
+    protected void setInnerValue(SettableByIndexData<?> udtValue, int position, Object value)
     {
         udtValue.setString(position, (String) value);
     }

--- a/cassandra-four-zero-types/src/main/java/org/apache/cassandra/spark/data/types/Time.java
+++ b/cassandra-four-zero-types/src/main/java/org/apache/cassandra/spark/data/types/Time.java
@@ -41,7 +41,7 @@ public class Time extends LongBased
     }
 
     @Override
-    protected void setInnerValue(SettableByIndexData<?> udtValue, int position, Object value)
+    protected void setInnerValueInternal(SettableByIndexData<?> udtValue, int position, Object value)
     {
         udtValue.setTime(position, (long) value);
     }

--- a/cassandra-four-zero-types/src/main/java/org/apache/cassandra/spark/data/types/Time.java
+++ b/cassandra-four-zero-types/src/main/java/org/apache/cassandra/spark/data/types/Time.java
@@ -41,7 +41,7 @@ public class Time extends LongBased
     }
 
     @Override
-    public void setInnerValue(SettableByIndexData<?> udtValue, int position, Object value)
+    protected void setInnerValue(SettableByIndexData<?> udtValue, int position, Object value)
     {
         udtValue.setTime(position, (long) value);
     }

--- a/cassandra-four-zero-types/src/main/java/org/apache/cassandra/spark/data/types/Timestamp.java
+++ b/cassandra-four-zero-types/src/main/java/org/apache/cassandra/spark/data/types/Timestamp.java
@@ -87,7 +87,7 @@ public class Timestamp extends NativeType
     }
 
     @Override
-    public void setInnerValue(SettableByIndexData<?> udtValue, int position, Object value)
+    protected void setInnerValue(SettableByIndexData<?> udtValue, int position, Object value)
     {
         udtValue.setTimestamp(position, (java.util.Date) value);
     }

--- a/cassandra-four-zero-types/src/main/java/org/apache/cassandra/spark/data/types/Timestamp.java
+++ b/cassandra-four-zero-types/src/main/java/org/apache/cassandra/spark/data/types/Timestamp.java
@@ -87,7 +87,7 @@ public class Timestamp extends NativeType
     }
 
     @Override
-    protected void setInnerValue(SettableByIndexData<?> udtValue, int position, Object value)
+    protected void setInnerValueInternal(SettableByIndexData<?> udtValue, int position, Object value)
     {
         udtValue.setTimestamp(position, (java.util.Date) value);
     }

--- a/cassandra-four-zero-types/src/main/java/org/apache/cassandra/spark/data/types/TinyInt.java
+++ b/cassandra-four-zero-types/src/main/java/org/apache/cassandra/spark/data/types/TinyInt.java
@@ -78,7 +78,7 @@ public class TinyInt extends NativeType
     }
 
     @Override
-    protected void setInnerValue(SettableByIndexData<?> udtValue, int position, Object value)
+    protected void setInnerValueInternal(SettableByIndexData<?> udtValue, int position, Object value)
     {
         udtValue.setByte(position, (byte) value);
     }

--- a/cassandra-four-zero-types/src/main/java/org/apache/cassandra/spark/data/types/TinyInt.java
+++ b/cassandra-four-zero-types/src/main/java/org/apache/cassandra/spark/data/types/TinyInt.java
@@ -78,7 +78,7 @@ public class TinyInt extends NativeType
     }
 
     @Override
-    public void setInnerValue(SettableByIndexData<?> udtValue, int position, Object value)
+    protected void setInnerValue(SettableByIndexData<?> udtValue, int position, Object value)
     {
         udtValue.setByte(position, (byte) value);
     }

--- a/cassandra-four-zero-types/src/main/java/org/apache/cassandra/spark/data/types/UUID.java
+++ b/cassandra-four-zero-types/src/main/java/org/apache/cassandra/spark/data/types/UUID.java
@@ -60,7 +60,7 @@ public class UUID extends StringBased
     }
 
     @Override
-    public void setInnerValue(SettableByIndexData<?> udtValue, int position, Object value)
+    protected void setInnerValue(SettableByIndexData<?> udtValue, int position, Object value)
     {
         udtValue.setUUID(position, (java.util.UUID) value);
     }

--- a/cassandra-four-zero-types/src/main/java/org/apache/cassandra/spark/data/types/UUID.java
+++ b/cassandra-four-zero-types/src/main/java/org/apache/cassandra/spark/data/types/UUID.java
@@ -60,7 +60,7 @@ public class UUID extends StringBased
     }
 
     @Override
-    protected void setInnerValue(SettableByIndexData<?> udtValue, int position, Object value)
+    protected void setInnerValueInternal(SettableByIndexData<?> udtValue, int position, Object value)
     {
         udtValue.setUUID(position, (java.util.UUID) value);
     }

--- a/cassandra-four-zero-types/src/main/java/org/apache/cassandra/spark/data/types/VarInt.java
+++ b/cassandra-four-zero-types/src/main/java/org/apache/cassandra/spark/data/types/VarInt.java
@@ -93,7 +93,7 @@ public class VarInt extends Decimal
     }
 
     @Override
-    protected void setInnerValue(SettableByIndexData<?> udtValue, int position, Object value)
+    protected void setInnerValueInternal(SettableByIndexData<?> udtValue, int position, Object value)
     {
         udtValue.setVarint(position, (BigInteger) value);
     }

--- a/cassandra-four-zero-types/src/main/java/org/apache/cassandra/spark/data/types/VarInt.java
+++ b/cassandra-four-zero-types/src/main/java/org/apache/cassandra/spark/data/types/VarInt.java
@@ -93,7 +93,7 @@ public class VarInt extends Decimal
     }
 
     @Override
-    public void setInnerValue(SettableByIndexData<?> udtValue, int position, Object value)
+    protected void setInnerValue(SettableByIndexData<?> udtValue, int position, Object value)
     {
         udtValue.setVarint(position, (BigInteger) value);
     }


### PR DESCRIPTION
When UDT field values are set to null, the bulk writer throws NPE

Patch by Yifan Cai; Reviewed by TBD for CASSANDRA-19836