### PR TITLE
CASSANDRA-19909: Add writer options COORDINATED_WRITE_CONFIG to define coordinated write to multiple Cassandra clusters

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,5 @@
 1.0.0
- * Add writer option COORDINATED_WRITE_CONF to define coordinated write to multiple Cassandra clusters (CASSANDRA-19909)
+ * Add writer option COORDINATED_WRITE_CONFIG to define coordinated write to multiple Cassandra clusters (CASSANDRA-19909)
  * Decouple Cassandra types from Spark types so Cassandra types can be used independently from Spark (CASSANDRA-19815)
  * Make the compression cache configurable to reduce heap pressure for large SSTables (CASSANDRA-19900)
  * Refactor TokenRangeMapping to use proper types instead of Strings (CASSANDRA-19901)

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 1.0.0
+ * Add writer option COORDINATED_WRITE_CONF to define coordinated write to multiple Cassandra clusters (CASSANDRA-19909)
  * Decouple Cassandra types from Spark types so Cassandra types can be used independently from Spark (CASSANDRA-19815)
  * Make the compression cache configurable to reduce heap pressure for large SSTables (CASSANDRA-19900)
  * Refactor TokenRangeMapping to use proper types instead of Strings (CASSANDRA-19901)

--- a/cassandra-analytics-common/src/main/java/org/apache/cassandra/spark/common/model/CassandraInstance.java
+++ b/cassandra-analytics-common/src/main/java/org/apache/cassandra/spark/common/model/CassandraInstance.java
@@ -25,7 +25,7 @@ import org.jetbrains.annotations.Nullable;
 public interface CassandraInstance extends TokenOwner
 {
     /**
-     * @return clusterId of the belong cluster; the return value is nullable
+     * @return ID string that can uniquely identify a cluster; the return value is nullable
      */
     @Nullable String clusterId();
 

--- a/cassandra-analytics-common/src/main/java/org/apache/cassandra/spark/common/model/CassandraInstance.java
+++ b/cassandra-analytics-common/src/main/java/org/apache/cassandra/spark/common/model/CassandraInstance.java
@@ -20,16 +20,26 @@
 package org.apache.cassandra.spark.common.model;
 
 import org.apache.cassandra.spark.data.model.TokenOwner;
+import org.jetbrains.annotations.Nullable;
 
 public interface CassandraInstance extends TokenOwner
 {
+    /**
+     * @return clusterId of the belong cluster; the return value is nullable
+     */
+    @Nullable String clusterId();
+
+    default boolean hasClusterId()
+    {
+        return clusterId() != null;
+    }
+
     String nodeName();
 
     String datacenter();
 
     /**
-     * IP address string of a Cassandra instance.
-     * Mainly used in blocked instance list to identify instances.
+     * IP address string (w/o port) of a Cassandra instance.
      * Prefer to use {@link #ipAddressWithPort} as instance identifier,
      * unless knowing the compared is IP address without port for sure.
      */

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/clients/Sidecar.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/clients/Sidecar.java
@@ -184,7 +184,7 @@ public final class Sidecar
     }
 
     public static List<CompletableFuture<NodeSettings>> allNodeSettings(SidecarClient client,
-                                                                        Set<? extends SidecarInstance> instances)
+                                                                        Set<SidecarInstance> instances)
     {
         return instances.stream()
                         .map(instance -> client

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/BulkSparkConf.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/BulkSparkConf.java
@@ -42,6 +42,8 @@ import org.slf4j.LoggerFactory;
 
 import org.apache.cassandra.sidecar.client.SidecarInstance;
 import org.apache.cassandra.spark.bulkwriter.blobupload.StorageClientConfig;
+import org.apache.cassandra.spark.bulkwriter.coordinatedwrite.CoordinatedWriteConf;
+import org.apache.cassandra.spark.bulkwriter.coordinatedwrite.CoordinatedWriteConf.SimpleClusterConf;
 import org.apache.cassandra.spark.bulkwriter.token.ConsistencyLevel;
 import org.apache.cassandra.spark.bulkwriter.util.SbwKryoRegistrator;
 import org.apache.cassandra.spark.common.SidecarInstanceFactory;
@@ -148,7 +150,9 @@ public class BulkSparkConf implements Serializable
     protected int ringRetryCount;
     // create sidecarInstances from sidecarContactPointsValue and effectiveSidecarPort
     private final String sidecarContactPointsValue; // It takes comma separated values
-    private transient Set<? extends SidecarInstance> sidecarContactPoints; // not serialized
+    private transient Set<SidecarInstance> sidecarContactPoints; // not serialized
+    private final String coordinatedWriteConfJson;
+    private transient CoordinatedWriteConf coordinatedWriteConf; // it is transient; deserialized from coordinatedWriteConfJson in executors
 
     public BulkSparkConf(SparkConf conf, Map<String, String> options)
     {
@@ -223,7 +227,8 @@ public class BulkSparkConf implements Serializable
         }
         this.jobTimeoutSeconds = MapUtils.getLong(options, WriterOptions.JOB_TIMEOUT_SECONDS.name(), -1L);
         this.configuredJobId = MapUtils.getOrDefault(options, WriterOptions.JOB_ID.name(), null);
-
+        this.coordinatedWriteConfJson = MapUtils.getOrDefault(options, WriterOptions.COORDINATED_WRITE_CONF.name(), null);
+        this.coordinatedWriteConf = buildCoordinatedWriteConf(); // must only call the build method at this step, after the related fields have been resolved
         validateEnvironment();
     }
 
@@ -263,7 +268,7 @@ public class BulkSparkConf implements Serializable
         });
     }
 
-    protected Set<? extends SidecarInstance> buildSidecarContactPoints()
+    protected Set<SidecarInstance> buildSidecarContactPoints()
     {
         String[] split = Objects.requireNonNull(sidecarContactPointsValue, "Unable to build sidecar instances from null value")
                                 .split(",");
@@ -273,13 +278,70 @@ public class BulkSparkConf implements Serializable
                      .collect(Collectors.toSet());
     }
 
-    Set<? extends SidecarInstance> sidecarContactPoints()
+    Set<SidecarInstance> sidecarContactPoints()
     {
         if (sidecarContactPoints == null)
         {
             sidecarContactPoints = buildSidecarContactPoints();
         }
         return sidecarContactPoints;
+    }
+
+    public boolean isCoordinatedWriteConfigured()
+    {
+        return coordinatedWriteConf != null;
+    }
+
+    public CoordinatedWriteConf coordinatedWriteConf()
+    {
+        if (coordinatedWriteConf == null)
+        {
+            coordinatedWriteConf = buildCoordinatedWriteConf();
+        }
+
+        return coordinatedWriteConf;
+    }
+
+    @Nullable
+    protected CoordinatedWriteConf buildCoordinatedWriteConf()
+    {
+        if (coordinatedWriteConfJson == null)
+        {
+            return null;
+        }
+
+        if (dataTransportInfo.getTransport() != DataTransport.S3_COMPAT)
+        {
+            throw new IllegalArgumentException("Coordinated write only supports S3_COMPACT mode");
+        }
+
+        if (sidecarContactPointsValue != null)
+        {
+            LOGGER.warn("SIDECAR_CONTACT_POINTS or SIDECAR_INSTANCES are ignored on the presence of COORDINATED_WRITE_CONF");
+        }
+
+        if (localDC != null)
+        {
+            LOGGER.warn("LOCAL_DC is ignored on the presence of COORDINATED_WRITE_CONF");
+        }
+
+        CoordinatedWriteConf result = CoordinatedWriteConf.fromJson(coordinatedWriteConfJson, SimpleClusterConf.class);
+        result.clusters().forEach((clusterId, cluster) -> {
+            if (consistencyLevel.isLocal())
+            {
+                Preconditions.checkState(cluster.localDc() != null,
+                                         "localDc is not configured for cluster: " + clusterId + " for consistency level: " + consistencyLevel);
+            }
+            else
+            {
+                if (cluster.localDc() != null)
+                {
+                    LOGGER.warn("Ignoring the localDc configured for cluster, when consistency level is non-local. cluster={} consistencyLevel={}",
+                                clusterId, consistencyLevel);
+                }
+            }
+        });
+        return result;
     }
 
     protected void validateEnvironment() throws RuntimeException
@@ -351,12 +413,12 @@ public class BulkSparkConf implements Serializable
         return truststorePath;
     }
 
-    protected TTLOption getTTLOptions()
+    public TTLOption getTTLOptions()
     {
         return TTLOption.from(ttl);
     }
 
-    protected TimestampOption getTimestampOptions()
+    public TimestampOption getTimestampOptions()
     {
         return TimestampOption.from(timestamp);
     }

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/BulkSparkConf.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/BulkSparkConf.java
@@ -323,23 +323,7 @@ public class BulkSparkConf implements Serializable
             LOGGER.warn("LOCAL_DC is ignored on the presence of COORDINATED_WRITE_CONF");
         }
 
-        CoordinatedWriteConf result = CoordinatedWriteConf.fromJson(coordinatedWriteConfJson, SimpleClusterConf.class);
-        result.clusters().forEach((clusterId, cluster) -> {
-            if (consistencyLevel.isLocal())
-            {
-                Preconditions.checkState(cluster.localDc() != null,
-                                         "localDc is not configured for cluster: " + clusterId + " for consistency level: " + consistencyLevel);
-            }
-            else
-            {
-                if (cluster.localDc() != null)
-                {
-                    LOGGER.warn("Ignoring the localDc configured for cluster, when consistency level is non-local. cluster={} consistencyLevel={}",
-                                clusterId, consistencyLevel);
-                }
-            }
-        });
-        return result;
+        return CoordinatedWriteConf.create(coordinatedWriteConfJson, consistencyLevel, SimpleClusterConf.class);
     }
 
     protected void validateEnvironment() throws RuntimeException

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/BulkSparkConf.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/BulkSparkConf.java
@@ -227,7 +227,7 @@ public class BulkSparkConf implements Serializable
         }
         this.jobTimeoutSeconds = MapUtils.getLong(options, WriterOptions.JOB_TIMEOUT_SECONDS.name(), -1L);
         this.configuredJobId = MapUtils.getOrDefault(options, WriterOptions.JOB_ID.name(), null);
-        this.coordinatedWriteConfJson = MapUtils.getOrDefault(options, WriterOptions.COORDINATED_WRITE_CONF.name(), null);
+        this.coordinatedWriteConfJson = MapUtils.getOrDefault(options, WriterOptions.COORDINATED_WRITE_CONFIG.name(), null);
         this.coordinatedWriteConf = buildCoordinatedWriteConf(); // must only call the build method at this step, after the related fields have been resolved
         validateEnvironment();
     }
@@ -312,7 +312,7 @@ public class BulkSparkConf implements Serializable
 
         if (dataTransportInfo.getTransport() != DataTransport.S3_COMPAT)
         {
-            throw new IllegalArgumentException("Coordinated write only supports S3_COMPACT mode");
+            throw new IllegalArgumentException("Coordinated write only supports " + DataTransport.S3_COMPAT);
         }
 
         if (sidecarContactPointsValue != null)

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/BulkSparkConf.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/BulkSparkConf.java
@@ -228,7 +228,7 @@ public class BulkSparkConf implements Serializable
         this.jobTimeoutSeconds = MapUtils.getLong(options, WriterOptions.JOB_TIMEOUT_SECONDS.name(), -1L);
         this.configuredJobId = MapUtils.getOrDefault(options, WriterOptions.JOB_ID.name(), null);
         this.coordinatedWriteConfJson = MapUtils.getOrDefault(options, WriterOptions.COORDINATED_WRITE_CONFIG.name(), null);
-        this.coordinatedWriteConf = buildCoordinatedWriteConf(); // must only call the build method at this step, after the related fields have been resolved
+        this.coordinatedWriteConf = buildCoordinatedWriteConf(dataTransportInfo.getTransport());
         validateEnvironment();
     }
 
@@ -296,24 +296,22 @@ public class BulkSparkConf implements Serializable
     {
         if (coordinatedWriteConf == null)
         {
-            coordinatedWriteConf = buildCoordinatedWriteConf();
+            coordinatedWriteConf = buildCoordinatedWriteConf(dataTransportInfo.getTransport());
         }
 
         return coordinatedWriteConf;
     }
 
     @Nullable
-    protected CoordinatedWriteConf buildCoordinatedWriteConf()
+    protected CoordinatedWriteConf buildCoordinatedWriteConf(DataTransport dataTransport)
     {
         if (coordinatedWriteConfJson == null)
         {
             return null;
         }
 
-        if (dataTransportInfo.getTransport() != DataTransport.S3_COMPAT)
-        {
-            throw new IllegalArgumentException("Coordinated write only supports " + DataTransport.S3_COMPAT);
-        }
+        Preconditions.checkArgument(dataTransport == DataTransport.S3_COMPAT,
+                                    "Coordinated write only supports " + DataTransport.S3_COMPAT);
 
         if (sidecarContactPointsValue != null)
         {

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/CassandraContext.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/CassandraContext.java
@@ -40,7 +40,7 @@ public class CassandraContext implements StartupValidatable, Closeable
 {
     private static final Logger LOGGER = LoggerFactory.getLogger(CassandraContext.class);
     @NotNull
-    protected Set<? extends SidecarInstance> clusterConfig;
+    protected Set<SidecarInstance> clusterConfig;
     private final BulkSparkConf conf;
     private final transient SidecarClient sidecarClient;
 
@@ -57,7 +57,7 @@ public class CassandraContext implements StartupValidatable, Closeable
         return new CassandraContext(conf);
     }
 
-    public Set<? extends SidecarInstance> getCluster()
+    public Set<SidecarInstance> getCluster()
     {
         return clusterConfig;
     }
@@ -86,7 +86,7 @@ public class CassandraContext implements StartupValidatable, Closeable
         return Sidecar.from(new SimpleSidecarInstancesProvider(new ArrayList<>(clusterConfig)), conf);
     }
 
-    protected Set<? extends SidecarInstance> createClusterConfig()
+    protected Set<SidecarInstance> createClusterConfig()
     {
         return conf.sidecarContactPoints();
     }

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/CassandraJobInfo.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/CassandraJobInfo.java
@@ -21,9 +21,11 @@ package org.apache.cassandra.spark.bulkwriter;
 
 import java.util.UUID;
 
+import org.apache.cassandra.spark.bulkwriter.coordinatedwrite.CoordinatedWriteConf;
 import org.apache.cassandra.spark.bulkwriter.token.ConsistencyLevel;
 import org.apache.cassandra.spark.data.QualifiedTableName;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class CassandraJobInfo implements JobInfo
 {
@@ -103,6 +105,13 @@ public class CassandraJobInfo implements JobInfo
     public double importCoordinatorTimeoutMultiplier()
     {
         return conf.importCoordinatorTimeoutMultiplier;
+    }
+
+    @Nullable
+    @Override
+    public CoordinatedWriteConf coordinatedWriteConf()
+    {
+        return conf.coordinatedWriteConf();
     }
 
     @Override

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/ClusterInfo.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/ClusterInfo.java
@@ -27,6 +27,7 @@ import o.a.c.sidecar.client.shaded.common.response.TimeSkewResponse;
 import org.apache.cassandra.spark.bulkwriter.token.TokenRangeMapping;
 import org.apache.cassandra.spark.data.partitioner.Partitioner;
 import org.apache.cassandra.spark.validation.StartupValidatable;
+import org.jetbrains.annotations.Nullable;
 
 public interface ClusterInfo extends StartupValidatable, Serializable
 {
@@ -47,9 +48,28 @@ public interface ClusterInfo extends StartupValidatable, Serializable
 
     TimeSkewResponse getTimeSkew(List<RingInstance> replicas);
 
+    /**
+     * Return the keyspace schema string of the enclosing keyspace for bulk write in the cluster
+     * @param cached whether using the cached schema information
+     * @return keyspace schema string
+     */
     String getKeyspaceSchema(boolean cached);
 
     CassandraContext getCassandraContext();
+
+    /**
+     * ID string that can uniquely identify a cluster
+     * <p>
+     * Implementor note: the method is optional. When writing to a single cluster, there is no requirement of assigning an ID for bulk write to proceed.
+     * When in the coordinated write mode, i.e. writing to multiple clusters, the method must be implemented and return unique string for clusters.
+     *
+     * @return cluster id string, null if absent
+     */
+    @Nullable
+    default String clusterId()
+    {
+        return null;
+    }
 
     default void close()
     {

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/JobInfo.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/JobInfo.java
@@ -22,6 +22,7 @@ package org.apache.cassandra.spark.bulkwriter;
 import java.io.Serializable;
 import java.util.UUID;
 
+import org.apache.cassandra.spark.bulkwriter.coordinatedwrite.CoordinatedWriteConf;
 import org.apache.cassandra.spark.bulkwriter.token.ConsistencyLevel;
 import org.apache.cassandra.spark.data.QualifiedTableName;
 import org.jetbrains.annotations.NotNull;
@@ -100,4 +101,10 @@ public interface JobInfo extends Serializable
      * @return multiplier to calculate the final timeout for import coordinator
      */
     double importCoordinatorTimeoutMultiplier();
+
+    /**
+     * @return CoordinatedWriteConf if configured, null otherwise
+     */
+    @Nullable
+    CoordinatedWriteConf coordinatedWriteConf();
 }

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/RingInstance.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/RingInstance.java
@@ -122,9 +122,9 @@ public class RingInstance implements CassandraInstance, Serializable
     }
 
     /**
-     * Custom equality that compares the token, fully qualified domain name, the port, and the datacenter
+     * Custom equality that compares the token, fully qualified domain name, the port, the datacenter and the clusterId
      *
-     * Note that node state and status are not part of the calculation.
+     * Note that node state, status,  are not part of the calculation.
      *
      * @param other the other instance
      * @return true if both instances are equal, false otherwise
@@ -145,6 +145,7 @@ public class RingInstance implements CassandraInstance, Serializable
         return Objects.equals(clusterId, that.clusterId)
                && Objects.equals(ringEntry.token(), that.ringEntry.token())
                && Objects.equals(ringEntry.fqdn(), that.ringEntry.fqdn())
+               && Objects.equals(ringEntry.rack(), that.ringEntry.rack())
                && Objects.equals(ringEntry.address(), that.ringEntry.address())
                && ringEntry.port() == that.ringEntry.port()
                && Objects.equals(ringEntry.datacenter(), that.ringEntry.datacenter());
@@ -160,7 +161,7 @@ public class RingInstance implements CassandraInstance, Serializable
     @Override
     public int hashCode()
     {
-        return Objects.hash(clusterId, ringEntry.token(), ringEntry.fqdn(), ringEntry.port(), ringEntry.datacenter(), ringEntry.address());
+        return Objects.hash(clusterId, ringEntry.token(), ringEntry.fqdn(), ringEntry.rack(), ringEntry.port(), ringEntry.datacenter(), ringEntry.address());
     }
 
     @Override
@@ -169,7 +170,7 @@ public class RingInstance implements CassandraInstance, Serializable
         return ringEntry.toString();
     }
 
-    public RingEntry ringInstance()
+    public RingEntry ringEntry()
     {
         return ringEntry;
     }

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/WriterOptions.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/WriterOptions.java
@@ -36,7 +36,7 @@ public enum WriterOptions implements WriterOption
      * See org.apache.cassandra.spark.bulkwriter.coordinatedwrite.CoordinatedWriteConf.
      * When the option is present, SIDECAR_CONTACT_POINTS, SIDECAR_INSTANCES and LOCAL_DC are ignored if they are present.
      */
-    COORDINATED_WRITE_CONF,
+    COORDINATED_WRITE_CONFIG,
     KEYSPACE,
     TABLE,
     BULK_WRITER_CL,

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/WriterOptions.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/WriterOptions.java
@@ -31,6 +31,12 @@ public enum WriterOptions implements WriterOption
     // The option specifies the initial contact points of sidecar servers to discover the cluster topology
     // Note that the addresses can include port; when port is present, it takes precedence over SIDECAR_PORT
     SIDECAR_CONTACT_POINTS,
+    /**
+     * The option specifies the configuration (in JSON) for coordinated write.
+     * See org.apache.cassandra.spark.bulkwriter.coordinatedwrite.CoordinatedWriteConf.
+     * When the option is present, SIDECAR_CONTACT_POINTS, SIDECAR_INSTANCES and LOCAL_DC are ignored if they are present.
+     */
+    COORDINATED_WRITE_CONF,
     KEYSPACE,
     TABLE,
     BULK_WRITER_CL,

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/coordinatedwrite/CoordinatedWriteConf.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/coordinatedwrite/CoordinatedWriteConf.java
@@ -69,7 +69,7 @@ public class CoordinatedWriteConf
         {
             return new CoordinatedWriteConf(OBJECT_MAPPER.readValue(json, javaType));
         }
-        catch (JsonProcessingException e)
+        catch (Exception e)
         {
             throw new IllegalArgumentException("Unable to parse json string into CoordinatedWriteConf of " + clusterConfType.getSimpleName() +
                                                " due to " + e.getMessage(), e);

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/coordinatedwrite/CoordinatedWriteConf.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/coordinatedwrite/CoordinatedWriteConf.java
@@ -51,7 +51,7 @@ public class CoordinatedWriteConf
 {
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     // The runtime type of ClusterConfProvider is erased; use clustersOf method to read the desired type back
-    private final Map<String, ClusterConfProvider> clusters;
+    private final Map<String, ClusterConf> clusters;
 
     /**
      * Parse JSON string and create a CoordinatedWriteConf object with the specified ClusterConfProvider format
@@ -61,7 +61,7 @@ public class CoordinatedWriteConf
      * @return CoordinatedWriteConf object
      * @param <T> subtype of ClusterConfProvider
      */
-    public static <T extends CoordinatedWriteConf.ClusterConfProvider>
+    public static <T extends ClusterConf>
     CoordinatedWriteConf fromJson(String json, Class<T> clusterConfType)
     {
         JavaType javaType = TypeFactory.defaultInstance().constructMapType(Map.class, String.class, clusterConfType);
@@ -76,23 +76,23 @@ public class CoordinatedWriteConf
         }
     }
 
-    public CoordinatedWriteConf(Map<String, ? extends ClusterConfProvider> clusters)
+    public CoordinatedWriteConf(Map<String, ? extends ClusterConf> clusters)
     {
         this.clusters = Collections.unmodifiableMap(clusters);
     }
 
-    public Map<String, ClusterConfProvider> clusters()
+    public Map<String, ClusterConf> clusters()
     {
         return clusters;
     }
 
     @Nullable
-    public ClusterConfProvider cluster(String clusterId)
+    public ClusterConf cluster(String clusterId)
     {
         return clusters.get(clusterId);
     }
 
-    public <T extends ClusterConfProvider> Map<String, T> clustersOf(Class<T> clusterConfType)
+    public <T extends ClusterConf> Map<String, T> clustersOf(Class<T> clusterConfType)
     {
         // verify that map type can cast; there are only limited number of values and check is cheap
         clusters.values().forEach(v -> Preconditions.checkState(clusterConfType.isInstance(v),
@@ -105,7 +105,7 @@ public class CoordinatedWriteConf
         return OBJECT_MAPPER.writeValueAsString(clusters);
     }
 
-    public interface ClusterConfProvider
+    public interface ClusterConf
     {
         Set<SidecarInstance> sidecarContactPoints();
 
@@ -131,7 +131,7 @@ public class CoordinatedWriteConf
 
     @JsonIgnoreProperties(ignoreUnknown = true)
     @JsonInclude(JsonInclude.Include.NON_NULL)
-    public static class SimpleClusterConf implements ClusterConfProvider
+    public static class SimpleClusterConf implements ClusterConf
     {
         private final List<String> sidecarContactPointsValue;
         private final Set<SidecarInstance> sidecarContactPoints;

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/coordinatedwrite/CoordinatedWriteConf.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/coordinatedwrite/CoordinatedWriteConf.java
@@ -1,0 +1,177 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cassandra.spark.bulkwriter.coordinatedwrite;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import com.google.common.base.Preconditions;
+import org.apache.commons.lang3.StringUtils;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.type.TypeFactory;
+import org.apache.cassandra.sidecar.client.SidecarInstance;
+import org.apache.cassandra.spark.bulkwriter.token.ConsistencyLevel;
+import org.apache.cassandra.spark.common.SidecarInstanceFactory;
+import org.jetbrains.annotations.Nullable;
+
+import static java.util.stream.Collectors.collectingAndThen;
+import static java.util.stream.Collectors.toSet;
+
+/**
+ * Data class containing the configurations required for coordinated write.
+ * The serialization format is JSON string. The class takes care of serialization and deserialization.
+ */
+public class CoordinatedWriteConf
+{
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    // The runtime type of ClusterConfProvider is erased; use clustersOf method to read the desired type back
+    private final Map<String, ClusterConfProvider> clusters;
+
+    /**
+     * Parse JSON string and create a CoordinatedWriteConf object with the specified ClusterConfProvider format
+     *
+     * @param json JSON string
+     * @param clusterConfType concrete type of ClusterConfProvider that can be used for JSON serialization and deserialization
+     * @return CoordinatedWriteConf object
+     * @param <T> subtype of ClusterConfProvider
+     */
+    public static <T extends CoordinatedWriteConf.ClusterConfProvider>
+    CoordinatedWriteConf fromJson(String json, Class<T> clusterConfType)
+    {
+        JavaType javaType = TypeFactory.defaultInstance().constructMapType(Map.class, String.class, clusterConfType);
+        try
+        {
+            return new CoordinatedWriteConf(OBJECT_MAPPER.readValue(json, javaType));
+        }
+        catch (JsonProcessingException e)
+        {
+            throw new IllegalArgumentException("Unable to parse json string into CoordinatedWriteConf of " + clusterConfType.getSimpleName() +
+                                               " due to " + e.getMessage(), e);
+        }
+    }
+
+    public CoordinatedWriteConf(Map<String, ? extends ClusterConfProvider> clusters)
+    {
+        this.clusters = Collections.unmodifiableMap(clusters);
+    }
+
+    public Map<String, ClusterConfProvider> clusters()
+    {
+        return clusters;
+    }
+
+    @Nullable
+    public ClusterConfProvider cluster(String clusterId)
+    {
+        return clusters.get(clusterId);
+    }
+
+    public <T extends ClusterConfProvider> Map<String, T> clustersOf(Class<T> clusterConfType)
+    {
+        // verify that map type can cast; there are only limited number of values and check is cheap
+        clusters.values().forEach(v -> Preconditions.checkState(clusterConfType.isInstance(v),
+                                                                "ClusterConfProvider value is not instance of " + clusterConfType));
+        return (Map<String, T>) clusters;
+    }
+
+    public String toJson() throws JsonProcessingException
+    {
+        return OBJECT_MAPPER.writeValueAsString(clusters);
+    }
+
+    public interface ClusterConfProvider
+    {
+        Set<SidecarInstance> sidecarContactPoints();
+
+        @Nullable
+        String localDc();
+
+        @Nullable
+        default String resolveLocalDc(ConsistencyLevel.CL cl)
+        {
+            String localDc = localDc();
+            boolean hasLocalDc = !StringUtils.isEmpty(localDc());
+            if (!cl.isLocal() && hasLocalDc)
+            {
+                return null;
+            }
+            if (cl.isLocal() && !hasLocalDc)
+            {
+                throw new IllegalStateException("No localDc is specified for local consistency level: " + cl);
+            }
+            return localDc;
+        }
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class SimpleClusterConf implements ClusterConfProvider
+    {
+        private final List<String> sidecarContactPointsValue;
+        private final Set<SidecarInstance> sidecarContactPoints;
+        private final @Nullable String localDc;
+
+        @JsonCreator
+        public SimpleClusterConf(@JsonProperty("sidecarContactPoints") List<String> sidecarContactPointsValue,
+                                 @JsonProperty("localDc") String localDc)
+        {
+            this.sidecarContactPointsValue = sidecarContactPointsValue;
+            this.sidecarContactPoints = buildSidecarContactPoints(sidecarContactPointsValue);
+            this.localDc = localDc;
+        }
+
+        @JsonProperty("sidecarContactPoints")
+        public List<String> sidecarContactPointsValue()
+        {
+            return sidecarContactPointsValue;
+        }
+
+        @Nullable
+        @Override
+        @JsonProperty("localDc")
+        public String localDc()
+        {
+            return localDc;
+        }
+
+        @Override
+        public Set<SidecarInstance> sidecarContactPoints()
+        {
+            return sidecarContactPoints;
+        }
+
+        private Set<SidecarInstance> buildSidecarContactPoints(List<String> sidecarContactPoints)
+        {
+            return sidecarContactPoints.stream()
+                                       .filter(StringUtils::isNotEmpty)
+                                       .map(SidecarInstanceFactory::createFromString)
+                                       .collect(collectingAndThen(toSet(), Collections::unmodifiableSet));
+        }
+    }
+}

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/common/SidecarInstanceFactory.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/common/SidecarInstanceFactory.java
@@ -58,7 +58,19 @@ public class SidecarInstanceFactory
             port = Integer.parseInt(portStr);
         }
 
+        Preconditions.checkState(port != -1, "Unable to resolve port from %s", input);
+
         LOGGER.info("Create sidecar instance. hostname={} port={}", hostname, port);
         return new SidecarInstanceImpl(hostname, port);
+    }
+
+    /**
+     * Similar to {@link SidecarInstanceFactory#createFromString(String, int)}, but it requires that the input string must include port
+     * @param hostnameWithPort hostname with port
+     * @return SidecarInstanceImpl
+     */
+    public static SidecarInstanceImpl createFromString(String hostnameWithPort)
+    {
+        return createFromString(hostnameWithPort, -1);
     }
 }

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/data/CassandraDataLayer.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/data/CassandraDataLayer.java
@@ -124,7 +124,7 @@ public class CassandraDataLayer extends PartitionedDataLayer implements StartupV
     // create clusterConfig from sidecarInstances and sidecarPort, see initializeClusterConfig
     protected String sidecarInstances;
     protected int sidecarPort;
-    protected transient Set<? extends SidecarInstance> clusterConfig;
+    protected transient Set<SidecarInstance> clusterConfig;
     protected TokenPartitioner tokenPartitioner;
     protected Map<String, AvailabilityHint> availabilityHints;
     protected Sidecar.ClientConfig sidecarClientConfig;
@@ -907,13 +907,13 @@ public class CassandraDataLayer extends PartitionedDataLayer implements StartupV
         }
     }
 
-    protected Set<? extends SidecarInstance> initializeClusterConfig(ClientConfig options)
+    protected Set<SidecarInstance> initializeClusterConfig(ClientConfig options)
     {
         return initializeClusterConfig(options.sidecarContactPoints, options.sidecarPort());
     }
 
     // not intended to be overridden
-    private Set<? extends SidecarInstance> initializeClusterConfig(String sidecarInstances, int sidecarPort)
+    private Set<SidecarInstance> initializeClusterConfig(String sidecarInstances, int sidecarPort)
     {
         return Arrays.stream(sidecarInstances.split(","))
                      .filter(StringUtils::isNotEmpty)
@@ -921,7 +921,7 @@ public class CassandraDataLayer extends PartitionedDataLayer implements StartupV
                      .collect(Collectors.toSet());
     }
 
-    protected String getEffectiveCassandraVersionForRead(Set<? extends SidecarInstance> clusterConfig,
+    protected String getEffectiveCassandraVersionForRead(Set<SidecarInstance> clusterConfig,
                                                          NodeSettings nodeSettings)
     {
         return nodeSettings.releaseVersion();
@@ -932,7 +932,7 @@ public class CassandraDataLayer extends PartitionedDataLayer implements StartupV
         LOGGER.info("Dial home. clientConfig={}", options);
     }
 
-    protected void clearSnapshot(Set<? extends SidecarInstance> clusterConfig, @NotNull ClientConfig options)
+    protected void clearSnapshot(Set<SidecarInstance> clusterConfig, @NotNull ClientConfig options)
     {
         if (maybeQuotedKeyspace == null || maybeQuotedTable == null)
         {
@@ -982,7 +982,7 @@ public class CassandraDataLayer extends PartitionedDataLayer implements StartupV
      * @param options           the {@link ClientConfig} options
      * @return the {@link Sizing} object based on the {@code sizing} option provided by the user
      */
-    protected Sizing getSizing(Set<? extends SidecarInstance> clusterConfig,
+    protected Sizing getSizing(Set<SidecarInstance> clusterConfig,
                                ReplicationFactor replicationFactor,
                                ClientConfig options)
     {

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/BulkSparkConfTest.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/BulkSparkConfTest.java
@@ -325,14 +325,14 @@ class BulkSparkConfTest
         .describedAs("When COORDINATED_WRITE_CONF is present, it should return true")
         .isTrue();
         assertThat(conf.coordinatedWriteConf().clusters()).containsOnlyKeys("cluster1", "cluster2");
-        CoordinatedWriteConf.ClusterConfProvider cluster1 = conf.coordinatedWriteConf().cluster("cluster1");
+        CoordinatedWriteConf.ClusterConf cluster1 = conf.coordinatedWriteConf().cluster("cluster1");
         assertThat(cluster1).isNotNull();
         assertThat(cluster1.sidecarContactPoints())
         .containsExactlyInAnyOrder(new SidecarInstanceImpl("instance-1", 9999),
                                    new SidecarInstanceImpl("instance-2", 9999),
                                    new SidecarInstanceImpl("instance-3", 9999));
         assertThat(cluster1.localDc()).isEqualTo("dc1");
-        CoordinatedWriteConf.ClusterConfProvider cluster2 = conf.coordinatedWriteConf().cluster("cluster2");
+        CoordinatedWriteConf.ClusterConf cluster2 = conf.coordinatedWriteConf().cluster("cluster2");
         assertThat(cluster2).isNotNull();
         assertThat(cluster2.sidecarContactPoints())
         .containsExactlyInAnyOrder(new SidecarInstanceImpl("instance-4", 8888),

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/BulkSparkConfTest.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/BulkSparkConfTest.java
@@ -284,10 +284,10 @@ class BulkSparkConfTest
         String coordinatedWriteConfJsonNoLocalDc = "{\"cluster1\":" +
                                                    "{\"sidecarContactPoints\":[\"instance-1:9999\",\"instance-2:9999\",\"instance-3:9999\"]}}";
 
-        options.put(WriterOptions.COORDINATED_WRITE_CONF.name(), coordinatedWriteConfJsonNoLocalDc);
+        options.put(WriterOptions.COORDINATED_WRITE_CONFIG.name(), coordinatedWriteConfJsonNoLocalDc);
         assertThatThrownBy(() -> new BulkSparkConf(sparkConf, options))
         .isExactlyInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Coordinated write only supports S3_COMPACT mode");
+        .hasMessage("Coordinated write only supports S3_COMPAT");
 
         options.put(WriterOptions.DATA_TRANSPORT.name(), DataTransport.S3_COMPAT.name());
         options.put(WriterOptions.BULK_WRITER_CL.name(), "LOCAL_QUORUM");
@@ -295,7 +295,7 @@ class BulkSparkConfTest
         .isExactlyInstanceOf(IllegalStateException.class)
         .hasMessage("localDc is not configured for cluster: cluster1 for consistency level: LOCAL_QUORUM");
 
-        options.put(WriterOptions.COORDINATED_WRITE_CONF.name(), "invalid json");
+        options.put(WriterOptions.COORDINATED_WRITE_CONFIG.name(), "invalid json");
         assertThatThrownBy(() -> new BulkSparkConf(sparkConf, options))
         .isExactlyInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("Unable to parse json string into CoordinatedWriteConf of SimpleClusterConf due to Unrecognized token 'invalid'");
@@ -305,7 +305,7 @@ class BulkSparkConfTest
     void testCoordinatedWriteConf()
     {
         Map<String, String> options = copyDefaultOptions();
-        options.remove(WriterOptions.COORDINATED_WRITE_CONF.name());
+        options.remove(WriterOptions.COORDINATED_WRITE_CONFIG.name());
         BulkSparkConf conf = new BulkSparkConf(sparkConf, options);
         assertThat(conf.isCoordinatedWriteConfigured())
         .describedAs("When COORDINATED_WRITE_CONF is absent, isCoordinatedWriteConfigured should return false")
@@ -319,7 +319,7 @@ class BulkSparkConfTest
                                           "\"localDc\":\"dc1\"}}";
         options.put(WriterOptions.DATA_TRANSPORT.name(), DataTransport.S3_COMPAT.name());
         options.put(WriterOptions.BULK_WRITER_CL.name(), "LOCAL_QUORUM");
-        options.put(WriterOptions.COORDINATED_WRITE_CONF.name(), coordinatedWriteConfJson);
+        options.put(WriterOptions.COORDINATED_WRITE_CONFIG.name(), coordinatedWriteConfJson);
         conf = new BulkSparkConf(sparkConf, options);
         assertThat(conf.isCoordinatedWriteConfigured())
         .describedAs("When COORDINATED_WRITE_CONF is present, it should return true")

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/BulkWriteValidatorTest.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/BulkWriteValidatorTest.java
@@ -62,9 +62,7 @@ class BulkWriteValidatorTest
         for (RingInstance instance : topology.getTokenRanges().keySet())
         {
             // Mark nodes 0, 1, 2 as DOWN
-            int nodeId = Integer.parseInt(instance.ipAddress()
-                                                  .replace("localhost", "")
-                                                  .replace(":9042", ""));
+            int nodeId = Integer.parseInt(instance.ipAddress().replace("localhost", ""));
             instanceAvailabilityMap.put(instance, (nodeId <= 2) ? WriteAvailability.UNAVAILABLE_DOWN : WriteAvailability.AVAILABLE);
         }
         when(mockClusterInfo.clusterWriteAvailability()).thenReturn(instanceAvailabilityMap);

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/ImportCompletionCoordinatorTest.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/ImportCompletionCoordinatorTest.java
@@ -494,6 +494,7 @@ class ImportCompletionCoordinatorTest
         int instanceInRing = i % totalInstances + 1;
         return new RingInstance(new RingEntry.Builder()
                                 .datacenter("DC1")
+                                .rack("Rack")
                                 .address("127.0.0." + instanceInRing)
                                 .token(String.valueOf(i * 100_000))
                                 .fqdn("DC1-i" + instanceInRing)

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/MockBulkWriterContext.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/MockBulkWriterContext.java
@@ -46,6 +46,7 @@ import o.a.c.sidecar.client.shaded.common.response.TimeSkewResponse;
 import org.apache.cassandra.bridge.CassandraBridge;
 import org.apache.cassandra.bridge.CassandraBridgeFactory;
 import org.apache.cassandra.bridge.CassandraVersion;
+import org.apache.cassandra.spark.bulkwriter.coordinatedwrite.CoordinatedWriteConf;
 import org.apache.cassandra.spark.bulkwriter.token.ConsistencyLevel;
 import org.apache.cassandra.spark.bulkwriter.token.ReplicaAwareFailureHandler;
 import org.apache.cassandra.spark.bulkwriter.token.TokenRangeMapping;
@@ -63,6 +64,7 @@ import org.apache.cassandra.spark.validation.StartupValidator;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructType;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import static org.apache.cassandra.spark.bulkwriter.SqlToCqlTypeConverter.DATE;
 import static org.apache.cassandra.spark.bulkwriter.SqlToCqlTypeConverter.INT;
@@ -211,6 +213,12 @@ public class MockBulkWriterContext implements BulkWriterContext, ClusterInfo, Jo
     }
 
     @Override
+    public String clusterId()
+    {
+        return "test-cluster";
+    }
+
+    @Override
     public void refreshClusterInfo()
     {
         refreshClusterInfoCallCount++;
@@ -301,6 +309,13 @@ public class MockBulkWriterContext implements BulkWriterContext, ClusterInfo, Jo
     public double importCoordinatorTimeoutMultiplier()
     {
         return 2.0;
+    }
+
+    @Nullable
+    @Override
+    public CoordinatedWriteConf coordinatedWriteConf()
+    {
+        return null;
     }
 
     public void setSkipCleanOnFailures(boolean skipClean)

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/RingInstanceSerializationTest.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/RingInstanceSerializationTest.java
@@ -69,7 +69,7 @@ public class RingInstanceSerializationTest
                                                        7000,
                                                        dataCenter);
 
-        RingInstance ring = new RingInstance(metadata);
+        RingInstance ring = new RingInstance(metadata, "test-cluster");
 
         byte[] bytes = serialize(ring);
         RingInstance deserialized = deserialize(bytes, RingInstance.class);

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/RingInstanceTest.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/RingInstanceTest.java
@@ -31,7 +31,6 @@ import java.util.List;
 import java.util.Map;
 
 import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Range;

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/RingInstanceTest.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/RingInstanceTest.java
@@ -43,6 +43,7 @@ import org.apache.cassandra.spark.bulkwriter.token.ReplicaAwareFailureHandler;
 import org.apache.cassandra.spark.bulkwriter.token.TokenRangeMapping;
 import org.apache.cassandra.spark.data.ReplicationFactor;
 import org.apache.cassandra.spark.data.partitioner.Partitioner;
+import org.jetbrains.annotations.NotNull;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -125,60 +126,49 @@ public class RingInstanceTest
     @Test
     public void testEquals()
     {
-        RingInstance instance1 = TokenRangeMappingUtils.getInstances(0, ImmutableMap.of("DATACENTER1", 1), 1).get(0);
-        RingInstance instance2 = TokenRangeMappingUtils.getInstances(0, ImmutableMap.of("DATACENTER1", 1), 1).get(0);
+        RingInstance instance1 = mockRingInstance();
+        RingInstance instance2 = mockRingInstance();
         assertEquals(instance1, instance2);
     }
 
     @Test
     public void testHashCode()
     {
-        RingInstance instance1 = TokenRangeMappingUtils.getInstances(0, ImmutableMap.of("DATACENTER1", 1), 1).get(0);
-        RingInstance instance2 = TokenRangeMappingUtils.getInstances(0, ImmutableMap.of("DATACENTER1", 1), 1).get(0);
+        RingInstance instance1 = mockRingInstance();
+        RingInstance instance2 = mockRingInstance();
         assertEquals(instance1.hashCode(), instance2.hashCode());
     }
 
     @Test
-    public void testEqualsAndHashcodeIgnoreHost()
+    public void testEqualsAndHashcodeIgnoreNonCriticalFields()
     {
-        RingInstance realInstance = new RingInstance(new RingEntry.Builder()
-                                                     .datacenter("DATACENTER1")
-                                                     .address("127.0.0.1")
-                                                     .port(7000)
-                                                     .rack("Rack")
-                                                     .status("UP")
-                                                     .state("NORMAL")
-                                                     .load("0")
-                                                     .token("0")
-                                                     .fqdn("fqdn")
-                                                     .hostId("")
-                                                     .owns("")
-                                                     .build());
-
-        RingInstance questionInstance = new RingInstance(new RingEntry.Builder()
-                                                         .datacenter("DATACENTER1")
-                                                         .address("127.0.0.1")
-                                                         .port(7000)
-                                                         .rack("Rack")
-                                                         .status("UP")
-                                                         .state("NORMAL")
-                                                         .load("0")
-                                                         .token("0")
-                                                         .fqdn("fqdn")
-                                                         .hostId("")
-                                                         .owns("")
-                                                         .build());
-        assertEquals(realInstance, questionInstance);
-        assertEquals(realInstance.hashCode(), questionInstance.hashCode());
+        RingEntry.Builder builder = mockRingEntryBuilder();
+        // the fields chained in the builder below are not considered for equality check
+        RingInstance instance1 = new RingInstance(builder
+                                                  .status("1")
+                                                  .state("1")
+                                                  .load("1")
+                                                  .hostId("1")
+                                                  .owns("1")
+                                                  .build());
+        RingInstance instance2 = new RingInstance(builder
+                                                  .status("2")
+                                                  .state("2")
+                                                  .load("2")
+                                                  .hostId("2")
+                                                  .owns("2")
+                                                  .build());
+        assertEquals(instance1, instance2);
+        assertEquals(instance1.hashCode(), instance2.hashCode());
     }
 
     @Test
     public void testEqualsAndHashcodeConsidersClusterId()
     {
-        RingInstance instance = TokenRangeMappingUtils.getInstances(0, ImmutableMap.of("DATACENTER1", 1), 1).get(0);
-        RingInstance c1i1 = new RingInstance(instance.ringInstance(), "cluster1");
-        RingInstance c1i2 = new RingInstance(instance.ringInstance(), "cluster1");
-        RingInstance c2i1 = new RingInstance(instance.ringInstance(), "cluster2");
+        RingEntry ringEntry = mockRingEntry();
+        RingInstance c1i1 = new RingInstance(ringEntry, "cluster1");
+        RingInstance c1i2 = new RingInstance(ringEntry, "cluster1");
+        RingInstance c2i1 = new RingInstance(ringEntry, "cluster2");
 
         assertEquals(c1i1, c1i2);
         assertEquals(c1i1.hashCode(), c1i2.hashCode());
@@ -190,10 +180,11 @@ public class RingInstanceTest
     @Test
     public void testHasClusterId()
     {
-        RingInstance instance = TokenRangeMappingUtils.getInstances(0, ImmutableMap.of("DATACENTER1", 1), 1).get(0);
+        RingEntry ringEntry = mockRingEntry();
+        RingInstance instance = new RingInstance(ringEntry);
         assertFalse(instance.hasClusterId());
 
-        RingInstance instanceWithClusterId = new RingInstance(instance.ringInstance(), "cluster1");
+        RingInstance instanceWithClusterId = new RingInstance(ringEntry, "cluster1");
         assertTrue(instanceWithClusterId.hasClusterId());
         assertEquals("cluster1", instanceWithClusterId.clusterId());
     }
@@ -201,8 +192,9 @@ public class RingInstanceTest
     @Test
     public void multiMapWorksWithRingInstances()
     {
-        RingInstance instance1 = TokenRangeMappingUtils.getInstances(0, ImmutableMap.of("DATACENTER1", 1), 1).get(0);
-        RingInstance instance2 = TokenRangeMappingUtils.getInstances(0, ImmutableMap.of("DATACENTER1", 1), 1).get(0);
+        RingEntry ringEntry = mockRingEntry();
+        RingInstance instance1 = new RingInstance(ringEntry);
+        RingInstance instance2 = new RingInstance(ringEntry);
         byte[] buffer;
 
         try
@@ -253,5 +245,34 @@ public class RingInstanceTest
                                                        tokens[0].add(BigInteger.valueOf(2L))), instance2, "Failure 2");
 
         assertTrue(replicationFactor3.getFailedRanges(tokenRange, CL.LOCAL_QUORUM, DATACENTER_1).isEmpty());
+    }
+
+    @NotNull
+    private static RingEntry mockRingEntry()
+    {
+        return mockRingEntryBuilder().build();
+    }
+
+    @NotNull
+    private static RingEntry.Builder mockRingEntryBuilder()
+    {
+        return new RingEntry.Builder()
+               .datacenter("DATACENTER1")
+               .address("127.0.0.1")
+               .port(0)
+               .rack("Rack")
+               .status("UP")
+               .state("NORMAL")
+               .load("0")
+               .token("0")
+               .fqdn("DATACENTER1-i1")
+               .hostId("")
+               .owns("");
+    }
+
+    @NotNull
+    private static RingInstance mockRingInstance()
+    {
+        return new RingInstance(mockRingEntry());
     }
 }

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/TokenRangeMappingUtils.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/TokenRangeMappingUtils.java
@@ -61,7 +61,7 @@ public final class TokenRangeMappingUtils
     {
         List<RingInstance> instances = getInstances(initialToken, rfByDC, instancesPerDC);
         RingInstance instance = instances.remove(0);
-        RingEntry entry = instance.ringInstance();
+        RingEntry entry = instance.ringEntry();
         RingEntry newEntry = new RingEntry.Builder()
                              .datacenter(entry.datacenter())
                              .port(entry.port())
@@ -97,7 +97,7 @@ public final class TokenRangeMappingUtils
         if (shouldUpdateToken)
         {
             RingInstance instance = instances.remove(0);
-            RingEntry entry = instance.ringInstance();
+            RingEntry entry = instance.ringEntry();
             RingEntry newEntry = new RingEntry.Builder()
                                  .datacenter(entry.datacenter())
                                  .port(entry.port())

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/TokenRangeMappingUtils.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/TokenRangeMappingUtils.java
@@ -218,9 +218,11 @@ public final class TokenRangeMappingUtils
             replicasPerDc.put("ignored", replicas);
             ReplicaInfo ri = new ReplicaInfo(String.valueOf(startToken), String.valueOf(endToken), replicasPerDc);
             replicaInfoList.add(ri);
-            String address = "localhost" + i + ":9042";
+            String address = "localhost" + i;
+            int port = 9042;
+            String addressWithPort = address + ":" + port;
             ReplicaMetadata rm = new ReplicaMetadata("NORMAL", "UP", address, address, 9042, "ignored");
-            replicaMetadata.put(address, rm);
+            replicaMetadata.put(addressWithPort, rm);
             startToken = endToken;
         }
         return new TokenRangeReplicasResponse(replicaInfoList, replicaInfoList, replicaMetadata);

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/coordinatedwrite/CoordinatedWriteConfTest.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/coordinatedwrite/CoordinatedWriteConfTest.java
@@ -28,7 +28,6 @@ import java.util.Set;
 import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.exc.ValueInstantiationException;
 import org.apache.cassandra.sidecar.client.SidecarInstance;
 import org.apache.cassandra.sidecar.client.SidecarInstanceImpl;
 import org.apache.cassandra.spark.bulkwriter.coordinatedwrite.CoordinatedWriteConf.ClusterConfProvider;

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/coordinatedwrite/CoordinatedWriteConfTest.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/coordinatedwrite/CoordinatedWriteConfTest.java
@@ -85,9 +85,8 @@ class CoordinatedWriteConfTest
                       "{\"sidecarContactPoints\":[\"instance-1\",\"instance-2\",\"instance-3\"]," +
                       "\"localDc\":\"dc1\"}}";
         assertThatThrownBy(() -> CoordinatedWriteConf.fromJson(json, SimpleClusterConf.class))
-        .isExactlyInstanceOf(RuntimeException.class)
+        .isExactlyInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("Unable to parse json string into CoordinatedWriteConf of SimpleClusterConf")
-        .hasCauseExactlyInstanceOf(ValueInstantiationException.class)
         .hasRootCauseExactlyInstanceOf(IllegalStateException.class)
         .hasRootCauseMessage("Unable to resolve port from instance-1");
     }

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/coordinatedwrite/CoordinatedWriteConfTest.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/coordinatedwrite/CoordinatedWriteConfTest.java
@@ -95,10 +95,8 @@ class CoordinatedWriteConfTest
     {
         String json = "{\"cluster1\":{\"sidecarContactPoints\":[\"instance-1:8888\"]}}";
         assertThatThrownBy(() -> CoordinatedWriteConf.create(json, CL.LOCAL_QUORUM, SimpleClusterConf.class))
-        .isExactlyInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("Unable to parse json string into CoordinatedWriteConf of SimpleClusterConf")
-        .hasRootCauseExactlyInstanceOf(IllegalStateException.class)
-        .hasRootCauseMessage("localDc is not configured for cluster: cluster1 for consistency level: LOCAL_QUORUM");
+        .isExactlyInstanceOf(IllegalStateException.class)
+        .hasMessage("localDc is not configured for cluster: cluster1 for consistency level: LOCAL_QUORUM");
     }
 
     @Test

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/coordinatedwrite/CoordinatedWriteConfTest.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/coordinatedwrite/CoordinatedWriteConfTest.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cassandra.spark.bulkwriter.coordinatedwrite;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.exc.ValueInstantiationException;
+import org.apache.cassandra.sidecar.client.SidecarInstance;
+import org.apache.cassandra.sidecar.client.SidecarInstanceImpl;
+import org.apache.cassandra.spark.bulkwriter.coordinatedwrite.CoordinatedWriteConf.ClusterConfProvider;
+import org.apache.cassandra.spark.bulkwriter.coordinatedwrite.CoordinatedWriteConf.SimpleClusterConf;
+import org.apache.cassandra.spark.bulkwriter.token.ConsistencyLevel.CL;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class CoordinatedWriteConfTest
+{
+    @Test
+    void testSerDeser() throws JsonProcessingException
+    {
+        Map<String, SimpleClusterConf> clusters = new HashMap<>();
+        clusters.put("cluster1", new SimpleClusterConf(Arrays.asList("instance-1:9999", "instance-2:9999", "instance-3:9999"), "dc1"));
+        clusters.put("cluster2", new SimpleClusterConf(Arrays.asList("instance-4:8888", "instance-5:8888", "instance-6:8888"), "dc1"));
+        CoordinatedWriteConf conf = new CoordinatedWriteConf(clusters);
+        String json = conf.toJson();
+        assertThat(json)
+        .isEqualTo("{\"cluster1\":" +
+                   "{\"sidecarContactPoints\":[\"instance-1:9999\",\"instance-2:9999\",\"instance-3:9999\"]," +
+                   "\"localDc\":\"dc1\"}," +
+                   "\"cluster2\":" +
+                   "{\"sidecarContactPoints\":[\"instance-4:8888\",\"instance-5:8888\",\"instance-6:8888\"]," +
+                   "\"localDc\":\"dc1\"}}");
+        CoordinatedWriteConf deser = CoordinatedWriteConf.fromJson(json, SimpleClusterConf.class);
+        assertThat(deser.clusters()).containsKeys("cluster1", "cluster2");
+        assertThat(deser.clustersOf(SimpleClusterConf.class).get("cluster1").sidecarContactPointsValue())
+        .isEqualTo(Arrays.asList("instance-1:9999", "instance-2:9999", "instance-3:9999"));
+        assertThat(deser.clustersOf(SimpleClusterConf.class).get("cluster2").sidecarContactPointsValue())
+        .isEqualTo(Arrays.asList("instance-4:8888", "instance-5:8888", "instance-6:8888"));
+        assertThat(deser.clusters().get("cluster1").localDc()).isEqualTo("dc1");
+        assertThat(deser.clusters().get("cluster2").localDc()).isEqualTo("dc1");
+        Set<SidecarInstance> contactPoints = deser.clusters().get("cluster1").sidecarContactPoints();
+        assertThat(contactPoints)
+        .hasSize(3);
+        // assertj contains method does not compile with SidecarInstanceImpl due to type erasure
+        assertThat(contactPoints.contains(new SidecarInstanceImpl("instance-1", 9999))).isTrue();
+        assertThat(contactPoints.contains(new SidecarInstanceImpl("instance-2", 9999))).isTrue();
+        assertThat(contactPoints.contains(new SidecarInstanceImpl("instance-3", 9999))).isTrue();
+        contactPoints = deser.clusters().get("cluster2").sidecarContactPoints();
+        assertThat(contactPoints)
+        .hasSize(3);
+        assertThat(contactPoints.contains(new SidecarInstanceImpl("instance-4", 8888))).isTrue();
+        assertThat(contactPoints.contains(new SidecarInstanceImpl("instance-5", 8888))).isTrue();
+        assertThat(contactPoints.contains(new SidecarInstanceImpl("instance-6", 8888))).isTrue();
+    }
+
+    @Test
+    void testDeserFailsWhenInstanceHasNoPort()
+    {
+        String json = "{\"cluster1\":" +
+                      "{\"sidecarContactPoints\":[\"instance-1\",\"instance-2\",\"instance-3\"]," +
+                      "\"localDc\":\"dc1\"}}";
+        assertThatThrownBy(() -> CoordinatedWriteConf.fromJson(json, SimpleClusterConf.class))
+        .isExactlyInstanceOf(RuntimeException.class)
+        .hasMessageContaining("Unable to parse json string into CoordinatedWriteConf of SimpleClusterConf")
+        .hasCauseExactlyInstanceOf(ValueInstantiationException.class)
+        .hasRootCauseExactlyInstanceOf(IllegalStateException.class)
+        .hasRootCauseMessage("Unable to resolve port from instance-1");
+    }
+
+    @Test
+    void testResolveLocalDc()
+    {
+        ClusterConfProvider clusterWithLocalDc = new SimpleClusterConf(Collections.singletonList("instance-1:9999"), "dc1");
+        assertThat(clusterWithLocalDc.resolveLocalDc(CL.EACH_QUORUM))
+        .describedAs("Resolving localDc with Non-local CL should return null")
+        .isNull();
+        assertThat(clusterWithLocalDc.resolveLocalDc(CL.LOCAL_QUORUM))
+        .describedAs("Resolving localDc with local CL should return the actual localDc")
+        .isEqualTo("dc1");
+        ClusterConfProvider clusterWithoutLocalDc = new SimpleClusterConf(Collections.singletonList("instance-1:9999"), null);
+        assertThat(clusterWithoutLocalDc.resolveLocalDc(CL.EACH_QUORUM)).isNull();
+        assertThatThrownBy(() -> clusterWithoutLocalDc.resolveLocalDc(CL.LOCAL_QUORUM))
+        .isExactlyInstanceOf(IllegalStateException.class)
+        .hasMessage("No localDc is specified for local consistency level: " + CL.LOCAL_QUORUM);
+    }
+}

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/coordinatedwrite/CoordinatedWriteConfTest.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/coordinatedwrite/CoordinatedWriteConfTest.java
@@ -30,7 +30,7 @@ import org.junit.jupiter.api.Test;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import org.apache.cassandra.sidecar.client.SidecarInstance;
 import org.apache.cassandra.sidecar.client.SidecarInstanceImpl;
-import org.apache.cassandra.spark.bulkwriter.coordinatedwrite.CoordinatedWriteConf.ClusterConfProvider;
+import org.apache.cassandra.spark.bulkwriter.coordinatedwrite.CoordinatedWriteConf.ClusterConf;
 import org.apache.cassandra.spark.bulkwriter.coordinatedwrite.CoordinatedWriteConf.SimpleClusterConf;
 import org.apache.cassandra.spark.bulkwriter.token.ConsistencyLevel.CL;
 
@@ -93,14 +93,14 @@ class CoordinatedWriteConfTest
     @Test
     void testResolveLocalDc()
     {
-        ClusterConfProvider clusterWithLocalDc = new SimpleClusterConf(Collections.singletonList("instance-1:9999"), "dc1");
+        ClusterConf clusterWithLocalDc = new SimpleClusterConf(Collections.singletonList("instance-1:9999"), "dc1");
         assertThat(clusterWithLocalDc.resolveLocalDc(CL.EACH_QUORUM))
         .describedAs("Resolving localDc with Non-local CL should return null")
         .isNull();
         assertThat(clusterWithLocalDc.resolveLocalDc(CL.LOCAL_QUORUM))
         .describedAs("Resolving localDc with local CL should return the actual localDc")
         .isEqualTo("dc1");
-        ClusterConfProvider clusterWithoutLocalDc = new SimpleClusterConf(Collections.singletonList("instance-1:9999"), null);
+        ClusterConf clusterWithoutLocalDc = new SimpleClusterConf(Collections.singletonList("instance-1:9999"), null);
         assertThat(clusterWithoutLocalDc.resolveLocalDc(CL.EACH_QUORUM)).isNull();
         assertThatThrownBy(() -> clusterWithoutLocalDc.resolveLocalDc(CL.LOCAL_QUORUM))
         .isExactlyInstanceOf(IllegalStateException.class)


### PR DESCRIPTION
The option specifies the configuration (in JSON) for coordinated write. See org.apache.cassandra.spark.bulkwriter.coordinatedwrite.CoordinatedWriteConf. When the option is present, SIDECAR_CONTACT_POINTS, SIDECAR_INSTANCES and LOCAL_DC are ignored if they are present.

Patch by Yifan Cai; Reviewed by TBD for CASSANDRA-19909