### PR TITLE
CASSANALYTICS-20: CassandraDataLayer uses configuration list of IPs instead of the full ring/datacenter

### DIFF
--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/data/CassandraDataLayer.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/data/CassandraDataLayer.java
@@ -220,6 +220,7 @@ public class CassandraDataLayer extends PartitionedDataLayer implements StartupV
         this.rfMap = rfMap;
         this.timeProvider = timeProvider;
         this.maybeQuoteKeyspaceAndTable();
+        this.initSidecarClient();
         this.initInstanceMap();
         this.startupValidate();
     }
@@ -234,7 +235,7 @@ public class CassandraDataLayer extends PartitionedDataLayer implements StartupV
 
         // Load cluster config from options
         clusterConfig = initializeClusterConfig(options);
-        initInstanceMap();
+        initSidecarClient();
 
         // Get cluster info from Cassandra Sidecar
         int effectiveNumberOfCores;
@@ -251,6 +252,7 @@ public class CassandraDataLayer extends PartitionedDataLayer implements StartupV
         {
             throw new RuntimeException(ThrowableUtils.rootCause(exception));
         }
+        initInstanceMap();
         LOGGER.info("Initialized Cassandra Bulk Reader with effectiveNumberOfCores={}", effectiveNumberOfCores);
     }
 
@@ -422,7 +424,23 @@ public class CassandraDataLayer extends PartitionedDataLayer implements StartupV
 
     protected void initInstanceMap()
     {
-        instanceMap = clusterConfig.stream().collect(Collectors.toMap(SidecarInstance::hostname, Function.identity()));
+        if (tokenPartitioner != null)
+        {
+            instanceMap = tokenPartitioner.ring().instances().stream()
+                    .filter(instance -> datacenter == null || datacenter.equals(instance.dataCenter()))
+                    .map(instance -> instance.nodeName()).distinct()
+                    .map(nodeName -> new SidecarInstanceImpl(nodeName, sidecarClientConfig.effectivePort()))
+                    .collect(Collectors.toMap(SidecarInstance::hostname, Function.identity()));
+        }
+        else
+        {
+            instanceMap = Collections.emptyMap();
+        }
+        LOGGER.info("Initialized CassandraDataLayer instanceMap numInstances={}", instanceMap.size());
+    }
+
+    protected void initSidecarClient()
+    {
         try
         {
             SslConfigSecretsProvider secretsProvider = sslConfig != null
@@ -436,7 +454,7 @@ public class CassandraDataLayer extends PartitionedDataLayer implements StartupV
         {
             throw new RuntimeException("Unable to build sidecar client", ioException);
         }
-        LOGGER.info("Initialized CassandraDataLayer instanceMap numInstances={}", instanceMap.size());
+        LOGGER.info("Initialized sidecar client");
     }
 
     @Override
@@ -732,6 +750,7 @@ public class CassandraDataLayer extends PartitionedDataLayer implements StartupV
         this.rfMap = (Map<String, ReplicationFactor>) in.readObject();
         this.timeProvider = new ReaderTimeProvider(in.readInt());
         this.maybeQuoteKeyspaceAndTable();
+        this.initSidecarClient();
         this.initInstanceMap();
         this.startupValidate();
     }
@@ -940,10 +959,10 @@ public class CassandraDataLayer extends PartitionedDataLayer implements StartupV
 
         LOGGER.info("Clearing snapshot at end of Spark job snapshotName={} keyspace={} table={} dc={}",
                     snapshotName, maybeQuotedKeyspace, maybeQuotedTable, datacenter);
-        CountDownLatch latch = new CountDownLatch(clusterConfig.size());
+        CountDownLatch latch = new CountDownLatch(instanceMap.size());
         try
         {
-            for (SidecarInstance instance : clusterConfig)
+            for (SidecarInstance instance : instanceMap.values())
             {
                 sidecar.clearSnapshot(instance, maybeQuotedKeyspace, maybeQuotedTable, snapshotName).whenComplete((resp, throwable) -> {
                     try

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/data/ClientConfig.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/data/ClientConfig.java
@@ -53,6 +53,11 @@ public class ClientConfig
     public static final String SNAPSHOT_NAME_KEY = "snapshotName";
     public static final String DC_KEY = "dc";
     public static final String CREATE_SNAPSHOT_KEY = "createSnapshot";
+    /**
+     * Option to filter distinct instances before creating snapshots. This is only applicable when
+     * using vnodes where the token ring will contain multiple entries per instance.
+     */
+    public static final String CREATE_SNAPSHOT_FILTER_DISTINCT_INSTANCES_KEY = "createSnapshotFilterDistinctInstances";
     public static final String CLEAR_SNAPSHOT_KEY = "clearSnapshot";
     /**
      * Format of clearSnapshotStrategy is {strategy [snapshotTTLvalue]}, clearSnapshotStrategy holds both the strategy
@@ -91,6 +96,7 @@ public class ClientConfig
     protected String datacenter;
     protected boolean createSnapshot;
     protected boolean clearSnapshot;
+    protected boolean createSnapshotFilterDistinctInstances;
     protected ClearSnapshotStrategy clearSnapshotStrategy;
     protected int defaultParallelism;
     protected int numCores;
@@ -115,6 +121,7 @@ public class ClientConfig
         this.snapshotName = MapUtils.getOrDefault(options, SNAPSHOT_NAME_KEY, "sbr_" + UUID.randomUUID().toString().replace("-", ""));
         this.datacenter = options.get(MapUtils.lowerCaseKey(DC_KEY));
         this.createSnapshot = MapUtils.getBoolean(options, CREATE_SNAPSHOT_KEY, true);
+        this.createSnapshotFilterDistinctInstances = MapUtils.getBoolean(options, CREATE_SNAPSHOT_FILTER_DISTINCT_INSTANCES_KEY, true);
         this.clearSnapshot = MapUtils.getBoolean(options, CLEAR_SNAPSHOT_KEY, createSnapshot);
         String clearSnapshotStrategyOption = MapUtils.getOrDefault(options, CLEAR_SNAPSHOT_STRATEGY_KEY, null);
 
@@ -199,6 +206,11 @@ public class ClientConfig
     public boolean clearSnapshot()
     {
         return clearSnapshot;
+    }
+
+    public boolean createSnapshotFilterDistinctInstances()
+    {
+        return createSnapshotFilterDistinctInstances;
     }
 
     public ClearSnapshotStrategy clearSnapshotStrategy()


### PR DESCRIPTION
This includes some changes from #93 , so it's better to merge it only after the other one is merged.

I used `tokenPartitioner.ring().instances()`  instead of making a new request to get ring information since the tokenPartitioner is built just before this. 

An argument can be made that this is not the case for clearing snapshots, since that is happening (much) later. On the other hand if the ring had instances added/removed/replaced in between the new instances would not have the snapshots anyway, and the old instances will be removed.
