### PR TITLE
CASSANALYTICS-51 Support Tuples and Tuples with UDTs

### DIFF
--- a/cassandra-analytics-common/src/main/java/org/apache/cassandra/spark/data/CqlTable.java
+++ b/cassandra-analytics-common/src/main/java/org/apache/cassandra/spark/data/CqlTable.java
@@ -275,6 +275,37 @@ public class CqlTable implements Serializable
         return columnsWithUdts.contains(fieldName);
     }
 
+    /**
+     * If a field is of type Tuple, or Tuple inside a frozen type, this function finds CqlTuple associated with that field
+     * @param fieldName name of the field
+     * @return CqlTuple associated with the requested field, returns null otherwise
+     */
+    public CqlField.CqlTuple findTuple(String fieldName)
+    {
+        CqlField field = fieldsMap.get(fieldName);
+        if (field == null)
+        {
+            return null;
+        }
+
+        CqlField.CqlType current = field.type();
+        while (true)
+        {
+            if (current instanceof CqlField.CqlTuple)
+            {
+                return (CqlField.CqlTuple) current;
+            }
+
+            if (current instanceof CqlField.CqlFrozen)
+            {
+                CqlField.CqlFrozen frozen = (CqlField.CqlFrozen) current;
+                current = frozen.inner();
+                continue;
+            }
+            return null;
+        }
+    }
+
     @Override
     public int hashCode()
     {

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/RecordWriter.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/RecordWriter.java
@@ -372,19 +372,33 @@ public class RecordWriter
     private Map<String, Object> getBindValuesForColumns(Map<String, Object> map, String[] columnNames, Object[] values)
     {
         Preconditions.checkArgument(values.length == columnNames.length,
-                                    "Number of values does not match the number of columns " + values.length + ", " + columnNames.length);
+                "Number of values does not match the number of columns " + values.length + ", " + columnNames.length);
 
         for (int i = 0; i < columnNames.length; i++)
         {
-            if (cqlTable.containsUdt(columnNames[i]))
+            String columnName = columnNames[i];
+            Object columnValue = values[i];
+
+            // convert all BridgeUDTValue types in the column to UDTValue
+            if (cqlTable.containsUdt(columnName))
             {
-                map.put(columnNames[i], maybeConvertUdt(values[i]));
+                columnValue = maybeConvertUdt(columnValue);
             }
-            else
+
+            // Find CqlTuple associated with the field and convert value to TupleValue
+            // Note: Tuples do not need recursive conversions
+            //       Tuple with UDT come here as Object[...UDTValue...]
+            //       Tuple with Tuple come here as Object[...Object[]...]
+            //       UDT with Tuple come here as UDTValue[...Object[]...]
+            CqlField.CqlTuple cqlTuple = cqlTable.findTuple(columnName);
+            if (cqlTuple != null && columnValue != null)
             {
-                map.put(columnNames[i], values[i]);
+                columnValue = cqlTuple.convertForCqlWriter(columnValue, writerContext.bridge().getVersion(), false);
             }
+
+            map.put(columnName, columnValue);
         }
+
         return map;
     }
 
@@ -405,6 +419,19 @@ public class RecordWriter
             }
 
             return resultList;
+        }
+
+        // Tuples come here as Object[]
+        if (value instanceof Object[])
+        {
+            Object[] valueArray = (Object[]) value;
+            Object[] resultArray = new Object[valueArray.length];
+            for (int i = 0; i < valueArray.length; i++)
+            {
+                resultArray[i] = maybeConvertUdt(valueArray[i]);
+            }
+
+            return resultArray;
         }
 
         if (value instanceof Set && !((Set<?>) value).isEmpty())

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/SqlToCqlTypeConverter.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/SqlToCqlTypeConverter.java
@@ -172,6 +172,12 @@ public final class SqlToCqlTypeConverter implements Serializable
             case SET:
                 return new SetConverter<>((CqlField.CqlCollection) cqlType);
             case TUPLE:
+                if (cqlType.internalType() == CqlField.CqlType.InternalType.Tuple)
+                {
+                    assert cqlType instanceof CqlField.CqlTuple;
+                    return new TupleConverter((CqlField.CqlTuple) cqlType);
+                }
+                LOGGER.warn("Unable to match type={}. Defaulting to NoOp Converter", cqlName);
                 return NO_OP_CONVERTER;
             default:
                 if (cqlType.internalType() == CqlField.CqlType.InternalType.Udt)
@@ -876,6 +882,51 @@ public final class SqlToCqlTypeConverter implements Serializable
                 Object val = row.get(row.fieldIndex(fieldName));
                 result.put(fieldName, converter.convert(val));
             }
+            return result;
+        }
+    }
+
+    public static class TupleConverter extends NullableConverter<Object[]>
+    {
+        private final List<Converter<?>> converters;
+
+        TupleConverter(CqlField.CqlTuple cqlTuple)
+        {
+            // Each field of Tuple can be of different type
+            // hence, prepare list of converters
+            this.converters = new ArrayList<>();
+            for (CqlField.CqlType type : cqlTuple.types())
+            {
+                converters.add(getConverter(type));
+            }
+        }
+
+        @Override
+        public Object[] convertInternal(Object object)
+        {
+            if (object instanceof GenericRowWithSchema)
+            {
+                return makeTuple((GenericRowWithSchema) object);
+            }
+            throw new RuntimeException("Unsupported conversion for UDT from " + object.getClass().getTypeName());
+        }
+
+        @Override
+        public String toString()
+        {
+            return "Tuple";
+        }
+
+        private Object[] makeTuple(GenericRowWithSchema row)
+        {
+            Object[] result = new Object[row.size()];
+            for (int i = 0; i < row.schema().fieldNames().length; i++)
+            {
+                Converter<?> converter = converters.get(i);
+                Object val = row.get(i);
+                result[i] = converter.convert(val);
+            }
+            // Object array with converted values
             return result;
         }
     }

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/EndToEndTests.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/EndToEndTests.java
@@ -41,6 +41,7 @@ import com.google.common.collect.Maps;
 import com.google.common.util.concurrent.Uninterruptibles;
 import org.apache.commons.lang3.mutable.MutableLong;
 import org.apache.commons.lang3.tuple.Pair;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -1215,6 +1216,7 @@ public class EndToEndTests
             );
     }
 
+    @Tag("heavy")
     @ParameterizedTest
     @MethodSource("org.apache.cassandra.bridge.VersionRunner#bridges")
     public void testUdtInnerMap(CassandraBridge bridge)

--- a/cassandra-analytics-integration-tests/src/test/java/org/apache/cassandra/analytics/BulkWriteTupleTest.java
+++ b/cassandra-analytics-integration-tests/src/test/java/org/apache/cassandra/analytics/BulkWriteTupleTest.java
@@ -29,7 +29,7 @@ import org.apache.spark.sql.Row;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 
-import static org.apache.cassandra.testing.TestUtils.DC1_RF1;
+import static org.apache.cassandra.testing.TestUtils.DC1_RF3;
 import static org.apache.cassandra.testing.TestUtils.ROW_COUNT;
 import static org.apache.cassandra.testing.TestUtils.TEST_KEYSPACE;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -165,7 +165,7 @@ class BulkWriteTupleTest extends SharedClusterSparkIntegrationTestBase
     {
         coordinator = cluster.getFirstRunningInstance().coordinator();
 
-        createTestKeyspace(TUPLE_SOURCE_TABLE, DC1_RF1);
+        createTestKeyspace(TUPLE_SOURCE_TABLE, DC1_RF3);
         cluster.schemaChangeIgnoringStoppedInstances(UDT_WITH_COLLECTIONS_TYPE_CREATE);
 
         cluster.schemaChangeIgnoringStoppedInstances(String.format(TUPLE_TABLE_CREATE, TUPLE_SOURCE_TABLE.keyspace(), TUPLE_SOURCE_TABLE.table()));

--- a/cassandra-analytics-integration-tests/src/test/java/org/apache/cassandra/analytics/BulkWriteTupleTest.java
+++ b/cassandra-analytics-integration-tests/src/test/java/org/apache/cassandra/analytics/BulkWriteTupleTest.java
@@ -1,0 +1,181 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cassandra.analytics;
+
+import com.datastax.driver.core.TupleValue;
+import org.apache.cassandra.distributed.api.ConsistencyLevel;
+import org.apache.cassandra.distributed.api.ICoordinator;
+import org.apache.cassandra.sidecar.testing.QualifiedName;
+import org.apache.cassandra.testing.ClusterBuilderConfiguration;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+
+import static org.apache.cassandra.testing.TestUtils.DC1_RF1;
+import static org.apache.cassandra.testing.TestUtils.ROW_COUNT;
+import static org.apache.cassandra.testing.TestUtils.TEST_KEYSPACE;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class BulkWriteTupleTest extends SharedClusterSparkIntegrationTestBase
+{
+    public static final QualifiedName TUPLE_SOURCE_TABLE = new QualifiedName(TEST_KEYSPACE, "tuple_src");
+    public static final QualifiedName TUPLE_DEST_TABLE = new QualifiedName(TEST_KEYSPACE, "tuple_dest");
+    public static final String TUPLE_TABLE_CREATE = "CREATE TABLE %s.%s (\n"
+                                                    + "            id BIGINT PRIMARY KEY,\n"
+                                                    + "            udttuple frozen<tuple<int, text>>)";
+
+    // UDT with collections in it (list, set, map and tuple) in it
+    public static final String UDT_WITH_COLLECTIONS_TYPE_NAME = "udt_with_collections";
+    public static final String UDT_WITH_COLLECTIONS_TYPE_CREATE = "CREATE TYPE " + TEST_KEYSPACE + "." + UDT_WITH_COLLECTIONS_TYPE_NAME +
+            " (f1 list<text>, f2 set<text>, f3 map<int, text>, f4 tuple<int, text>);";
+
+    public static final QualifiedName TUPLE_WITH_UDT_WITH_TUPLE_SOURCE_TABLE = new QualifiedName(TEST_KEYSPACE, "tuple_with_udt_with_tuple_src");
+    public static final QualifiedName TUPLE_WITH_UDT_WITH_TUPLE_DEST_TABLE = new QualifiedName(TEST_KEYSPACE, "tuple_with_udt_with_tuple_dest");
+    // Table with a tuple, which contains a UDT which in-turn contains collections including nested tuple
+    public static final String TUPLE_WITH_UDT_TABLE_CREATE = "CREATE TABLE %s.%s (id BIGINT PRIMARY KEY,\n"
+            + "            tuplewithudt frozen<tuple<int, udt_with_collections>>)";
+
+    private ICoordinator coordinator;
+
+    @Test
+    void testSimpleTuples()
+    {
+        int numRowsInserted = populateSimpleTuples();
+        Dataset<Row> sourceData = bulkReaderDataFrame(TUPLE_SOURCE_TABLE).load();
+        assertThat(sourceData.count()).isEqualTo(numRowsInserted);
+
+        bulkWriterDataFrameWriter(sourceData, TUPLE_DEST_TABLE).save();
+        validateWritesWithDriverResultSet(sourceData.collectAsList(),
+                queryAllDataWithDriver(TUPLE_DEST_TABLE),
+                BulkWriteTupleTest::tupleRowFormatter);
+    }
+
+    private int populateSimpleTuples()
+    {
+        String insertIntoTuples = "INSERT INTO %s (id, udttuple) VALUES (%d, (%d, 'value %d'))";
+        int i = 0;
+        for (; i < 1; i++)
+        {
+            coordinator.executeWithResult(String.format(insertIntoTuples, TUPLE_SOURCE_TABLE, i, i, i),
+                    ConsistencyLevel.ALL);
+        }
+
+        // test null cases
+        coordinator.executeWithResult(String.format("insert into %s (id) values (%d)",
+                TUPLE_SOURCE_TABLE, i++), ConsistencyLevel.ALL);
+        coordinator.executeWithResult(String.format("insert into %s (id, udttuple) values (%d, null)",
+                TUPLE_SOURCE_TABLE, i++), ConsistencyLevel.ALL);
+
+        return i;
+    }
+
+    @Test
+    void testTupleWithUdtWithTuple()
+    {
+        int numRowsInserted = populateTupleWithUdtWithTuple();
+
+        // Create a spark frame with the data inserted during the setup
+        Dataset<Row> sourceData = bulkReaderDataFrame(TUPLE_WITH_UDT_WITH_TUPLE_SOURCE_TABLE).load();
+        assertThat(sourceData.count()).isEqualTo(numRowsInserted);
+
+        // Insert the dataset containing list of UDTs, and UDT itself has collections in it
+        bulkWriterDataFrameWriter(sourceData, TUPLE_WITH_UDT_WITH_TUPLE_DEST_TABLE).save();
+        validateWritesWithDriverResultSet(sourceData.collectAsList(),
+                queryAllDataWithDriver(TUPLE_WITH_UDT_WITH_TUPLE_DEST_TABLE),
+                BulkWriteTupleTest::tupleRowFormatter);
+    }
+
+    private int populateTupleWithUdtWithTuple()
+    {
+        // table(id, tuple<float, udt_with_collections(list<>, set<>, map<>, tuple<>)>)
+        // insert list of UDTs, and each UDT has a list, set and map
+        String insertIntoTupleOfUdts = "INSERT INTO %s (id, tuplewithudt) VALUES (%d, " +
+                "(%d, {f1:['list value %d'], f2:{'set value %d'}, f3:{%d : 'map value %d'}, f4:(%d, 'tuple value %d')}))";
+
+        int i = 0;
+        for (; i < ROW_COUNT; i++)
+        {
+            coordinator.executeWithResult(String.format(insertIntoTupleOfUdts,
+                    TUPLE_WITH_UDT_WITH_TUPLE_SOURCE_TABLE, i, i, i, i, i, i, i, i), ConsistencyLevel.ALL);
+        }
+
+        // test null cases
+        coordinator.executeWithResult(String.format("insert into %s (id) values (%d)",
+                TUPLE_WITH_UDT_WITH_TUPLE_SOURCE_TABLE, i++), ConsistencyLevel.ALL);
+        coordinator.executeWithResult(String.format("insert into %s (id, tuplewithudt) values (%d, null)",
+                TUPLE_WITH_UDT_WITH_TUPLE_SOURCE_TABLE, i++), ConsistencyLevel.ALL);
+        coordinator.executeWithResult(String.format("insert into %s (id, tuplewithudt) values (%d, " +
+                        "(null, {f1:null, f2:null, f3:null, f4:null}))",
+                TUPLE_WITH_UDT_WITH_TUPLE_SOURCE_TABLE, i++), ConsistencyLevel.ALL);
+
+        return i;
+    }
+
+    @NotNull
+    public static String tupleRowFormatter(com.datastax.driver.core.Row row)
+    {
+        String resultRow = row.getLong(0) + ":";
+        TupleValue tupleValue = row.getTupleValue(1);
+        if (tupleValue == null)
+        {
+            return resultRow + "null";
+        }
+
+        return (resultRow + tupleValue)
+               // empty collections have different formatting between driver and spark
+               .replace("{}", "null")
+               .replace("[]", "null")
+               // driver writes lists as [] and sets as {},
+               // whereas spark entries have the same type Seq for both lists and sets
+               .replace('[', '{')
+               .replace(']', '}')
+               // Driver writes tuples inside (), whereas
+               // Spark considers tuples as type GenericSchemaRow and uses {}
+               .replace('(', '{')
+               .replace(')', '}');
+    }
+
+    @Override
+    protected ClusterBuilderConfiguration testClusterConfiguration()
+    {
+        return super.testClusterConfiguration()
+                    .nodesPerDc(3);
+    }
+
+    @Override
+    protected void initializeSchemaForTest()
+    {
+        coordinator = cluster.getFirstRunningInstance().coordinator();
+
+        createTestKeyspace(TUPLE_SOURCE_TABLE, DC1_RF1);
+        cluster.schemaChangeIgnoringStoppedInstances(UDT_WITH_COLLECTIONS_TYPE_CREATE);
+
+        cluster.schemaChangeIgnoringStoppedInstances(String.format(TUPLE_TABLE_CREATE, TUPLE_SOURCE_TABLE.keyspace(), TUPLE_SOURCE_TABLE.table()));
+        cluster.schemaChangeIgnoringStoppedInstances(String.format(TUPLE_TABLE_CREATE, TUPLE_DEST_TABLE.keyspace(), TUPLE_DEST_TABLE.table()));
+
+        cluster.schemaChangeIgnoringStoppedInstances(String.format(TUPLE_WITH_UDT_TABLE_CREATE,
+                TUPLE_WITH_UDT_WITH_TUPLE_SOURCE_TABLE.keyspace(),
+                TUPLE_WITH_UDT_WITH_TUPLE_SOURCE_TABLE.table()));
+        cluster.schemaChangeIgnoringStoppedInstances(String.format(TUPLE_WITH_UDT_TABLE_CREATE,
+                TUPLE_WITH_UDT_WITH_TUPLE_DEST_TABLE.keyspace(),
+                TUPLE_WITH_UDT_WITH_TUPLE_DEST_TABLE.table()));
+    }
+}

--- a/cassandra-analytics-integration-tests/src/test/java/org/apache/cassandra/analytics/BulkWriteUdtTest.java
+++ b/cassandra-analytics-integration-tests/src/test/java/org/apache/cassandra/analytics/BulkWriteUdtTest.java
@@ -64,7 +64,7 @@ class BulkWriteUdtTest extends SharedClusterSparkIntegrationTestBase
     // UDT with list, set and map in it
     public static final String UDT_WITH_COLLECTIONS_TYPE_NAME = "udt_with_collections";
     public static final String UDT_WITH_COLLECTIONS_TYPE_CREATE = "CREATE TYPE " + TEST_KEYSPACE + "." + UDT_WITH_COLLECTIONS_TYPE_NAME +
-            " (f1 list<text>, f2 set<int>, f3 map<int, text>);";
+            " (f1 list<text>, f2 set<text>, f3 map<int, text>, f4 tuple<int, text>);";
 
     // table with list of UDTs, and UDT itself has collections in it
     public static final QualifiedName LIST_OF_UDT_SOURCE_TABLE = new QualifiedName(TEST_KEYSPACE, "list_of_udt_src");
@@ -168,12 +168,15 @@ class BulkWriteUdtTest extends SharedClusterSparkIntegrationTestBase
     {
         // table(id, list<udt(list<>, set<>, map<>)>)
         // insert list of UDTs, and each UDT has a list, set and map
-        String insertIntoListOfUdts = "INSERT INTO %s (id, udtlist) VALUES (%d, [{f1:['value %d'], f2:{%d}, f3:{%d : 'value %d'}}])";
+        String insertIntoListOfUdts = "INSERT INTO %s (id, udtlist) VALUES (%d, " +
+                                      "[{f1:['list value %d'], f2:{'set value %d'}, f3:{%d : 'map value %d'}, " +
+                                      "f4:(%d, 'tuple value %d')}])";
 
         int i = 0;
         for (; i < ROW_COUNT; i++)
         {
-            coordinator.execute(String.format(insertIntoListOfUdts, LIST_OF_UDT_SOURCE_TABLE, i, i, i, i, i), ConsistencyLevel.ALL);
+            coordinator.execute(String.format(insertIntoListOfUdts, LIST_OF_UDT_SOURCE_TABLE, i, i, i, i, i, i, i),
+                                ConsistencyLevel.ALL);
         }
 
         // test null cases
@@ -207,13 +210,14 @@ class BulkWriteUdtTest extends SharedClusterSparkIntegrationTestBase
         // table(id, set<udt(list<>, set<>, map<>)>)
         // insert set of UDTs, and UDT has a list, set and map inside it
         String insertIntoSetOfUdts = "INSERT INTO %s (id, udtset) VALUES (%d, " +
-                "{{f1:['value %d'], f2:{%d}, f3:{%d : 'value %d'}}})";
+                                     "{{f1:['list value %d'], f2:{'set value %d'}, f3:{%d : 'map value %d'}, " +
+                                     "f4:(%d, 'tuple value %d')}})";
 
         int i = 0;
         for (; i < ROW_COUNT; i++)
         {
-            cluster.schemaChangeIgnoringStoppedInstances(String.format(insertIntoSetOfUdts, SET_OF_UDT_SOURCE_TABLE,
-                    i, i, i, i, i));
+            coordinator.execute(String.format(insertIntoSetOfUdts, SET_OF_UDT_SOURCE_TABLE, i, i, i, i, i, i, i),
+                                ConsistencyLevel.ALL);
         }
 
         // test null cases
@@ -247,13 +251,14 @@ class BulkWriteUdtTest extends SharedClusterSparkIntegrationTestBase
         // table(id, map<udt(list<>, set<>, map<>), udt(list<>, set<>, map<>)>)
         // insert map of UDTs, and UDT has a list, set and map inside it
         String insertIntoMapOfUdts = "INSERT INTO %s (id, udtmap) VALUES (%d, " +
-                "{{f1:['value %d'], f2:{%d}, f3:{%d : 'value %d'}} : {f1:['value %d'], f2:{%d}, f3:{%d : 'value %d'}}})";
+                                     "{{f1:['list value %d'], f2:{'set value %d'}, f3:{%d : 'map value %d'}, f4:(%d, 'tuple value %d')} : " +
+                                     "{f1:['list value %d'], f2:{'set value %d'}, f3:{%d : 'map value %d'}, f4:(%d, 'tuple value %d')}})";
 
         int i = 0;
         for (; i < ROW_COUNT; i++)
         {
-            cluster.schemaChangeIgnoringStoppedInstances(String.format(insertIntoMapOfUdts, MAP_OF_UDT_SOURCE_TABLE,
-                    i, i, i, i, i, i, i, i, i));
+            coordinator.execute(String.format(insertIntoMapOfUdts, MAP_OF_UDT_SOURCE_TABLE, i, i, i, i, i, i, i, i, i, i, i, i, i),
+                                ConsistencyLevel.ALL);
         }
 
         coordinator.execute(String.format("insert into %s (id) values (%d)",
@@ -290,7 +295,8 @@ class BulkWriteUdtTest extends SharedClusterSparkIntegrationTestBase
         int i = 0;
         for (; i < ROW_COUNT; i++)
         {
-            cluster.schemaChangeIgnoringStoppedInstances(String.format(insertIntoUdtWithListOfUdts, UDT_WITH_LIST_OF_UDT_SOURCE_TABLE, i, i, i, i, i));
+            coordinator.execute(String.format(insertIntoUdtWithListOfUdts, UDT_WITH_LIST_OF_UDT_SOURCE_TABLE, i, i, i, i, i),
+                                ConsistencyLevel.ALL);
         }
 
         // test null cases
@@ -330,7 +336,8 @@ class BulkWriteUdtTest extends SharedClusterSparkIntegrationTestBase
         int i = 0;
         for (; i < ROW_COUNT; i++)
         {
-            cluster.schemaChangeIgnoringStoppedInstances(String.format(insertIntoUdtWithSetOfUdts, UDT_WITH_SET_OF_UDT_SOURCE_TABLE, i, i, i, i, i));
+            coordinator.execute(String.format(insertIntoUdtWithSetOfUdts, UDT_WITH_SET_OF_UDT_SOURCE_TABLE, i, i, i, i, i),
+                                ConsistencyLevel.ALL);
         }
 
         // test null cases
@@ -370,7 +377,8 @@ class BulkWriteUdtTest extends SharedClusterSparkIntegrationTestBase
         int i = 0;
         for (; i < ROW_COUNT; i++)
         {
-            cluster.schemaChangeIgnoringStoppedInstances(String.format(insertIntoUdtWithMapOfUdts, UDT_WITH_MAP_OF_UDT_SOURCE_TABLE, i, i, i, i, i));
+            coordinator.execute(String.format(insertIntoUdtWithMapOfUdts, UDT_WITH_MAP_OF_UDT_SOURCE_TABLE, i, i, i, i, i),
+                                ConsistencyLevel.ALL);
         }
 
         // test null cases
@@ -409,7 +417,11 @@ class BulkWriteUdtTest extends SharedClusterSparkIntegrationTestBase
                   // driver writes lists as [] and sets as {},
                   // whereas spark entries have the same type Seq for both lists and sets
                   .replace('[', '{')
-                  .replace(']', '}');
+                  .replace(']', '}')
+                  // Driver writes tuples inside (), whereas
+                  // Spark considers tuples as type GenericSchemaRow and uses {}
+                  .replace('(', '{')
+                  .replace(')', '}');
     }
 
     @NotNull
@@ -426,7 +438,11 @@ class BulkWriteUdtTest extends SharedClusterSparkIntegrationTestBase
                   // driver writes lists as [] and sets as {},
                   // whereas spark entries have the same type Seq for both lists and sets
                   .replace('[', '{')
-                  .replace(']', '}');
+                  .replace(']', '}')
+                  // Driver writes tuples inside (), whereas
+                  // Spark considers tuples as type GenericSchemaRow and uses {}
+                  .replace('(', '{')
+                  .replace(')', '}');
     }
 
     @NotNull
@@ -444,7 +460,11 @@ class BulkWriteUdtTest extends SharedClusterSparkIntegrationTestBase
                   // driver writes lists as [] and sets as {},
                   // whereas spark entries have the same type Seq for both lists and sets
                   .replace('[', '{')
-                  .replace(']', '}');
+                  .replace(']', '}')
+                  // Driver writes tuples inside (), whereas
+                  // Spark considers tuples as type GenericSchemaRow and uses {}
+                  .replace('(', '{')
+                  .replace(')', '}');
     }
 
     @Override

--- a/cassandra-analytics-integration-tests/src/test/java/org/apache/cassandra/analytics/SharedClusterSparkIntegrationTestBase.java
+++ b/cassandra-analytics-integration-tests/src/test/java/org/apache/cassandra/analytics/SharedClusterSparkIntegrationTestBase.java
@@ -203,7 +203,14 @@ public abstract class SharedClusterSparkIntegrationTestBase extends SharedCluste
                 sb.append(":");
             }
         }
-        return sb.toString();
+
+        return sb.toString()
+                 // Both Tuple and UDT come here as GenericSchemaRow. Spark row formatter writes fields of
+                 // tuple indexed with "0": <>, "1:": <> ... etc which do not exist in driver rows, hence remove them.
+                 // Example f4:{"0":2,"1":'tuple value 2'}
+                 // As Tuple can be anywhere in a row (inside a UDT or collections or nested tuple), it is not always
+                 // feasible to insert indexes while formatting driver rows. Instead, remove them from Spark rows here.
+                 .replaceAll("\"\\d+\":", "");
     }
 
     // Format a Spark row to look like what the toString on a UDT looks like


### PR DESCRIPTION
Currently Cassandra bulk writer unable to convert Tuples from sql to cql as No op converter is used. This needs to be handled. Also, need to support Tuples with UDTs nested inside them and vice versa. 

Circle CI: https://app.circleci.com/pipelines/github/skoppu22/cassandra-analytics/27/workflows/ec9c04ac-1e27-429b-8e92-6e4ac37c40ba