### PR TITLE
CASSANALYTICS-69 Set KeyStore to be optional

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 1.0.0
+ * Set KeyStore to be optional (CASSANALYTICS-69)
  * Use full ring instead of only IPs from configuration (CASSANALYTICS-20)
  * Bulk Reader should dynamically size the Spark job based on estimated table size (CASSANALYTICS-36)
  * Allow getting cassandra role in Spark options for use in Sidecar requests for RBAC (CASSANALYTICS-61)

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/validation/KeyStoreValidationTests.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/validation/KeyStoreValidationTests.java
@@ -38,7 +38,7 @@ public class KeyStoreValidationTests
         KeyStoreValidation validation = new KeyStoreValidation(secrets);
 
         Throwable throwable = validation.perform();
-        assertNull(throwable);  // KeyStore is optional
+        assertThat(throwable).isNull(); // KeyStore is optional
     }
 
     @Test

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/validation/KeyStoreValidationTests.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/validation/KeyStoreValidationTests.java
@@ -41,8 +41,7 @@ public class KeyStoreValidationTests
         KeyStoreValidation validation = new KeyStoreValidation(secrets);
 
         Throwable throwable = validation.perform();
-        assertInstanceOf(RuntimeException.class, throwable);
-        assertEquals("KeyStore is not configured", throwable.getMessage());
+        assertNull(throwable);  // KeyStore is optional
     }
 
     @Test

--- a/cassandra-analytics-sidecar-client/src/main/java/org/apache/cassandra/spark/validation/KeyStoreValidation.java
+++ b/cassandra-analytics-sidecar-client/src/main/java/org/apache/cassandra/spark/validation/KeyStoreValidation.java
@@ -74,7 +74,7 @@ public class KeyStoreValidation implements StartupValidation
         {
             if (!configured)
             {
-                throw new RuntimeException("KeyStore is not configured");
+                return;  // KeyStore is optional
             }
 
             if (password == null)


### PR DESCRIPTION
Validation currently fails if KeyStore is not present, it would be useful to only fail when KeyStore is invalid or expired.