### PR TITLE
CASSANALYTICS-79: Use tokenRangeReplicas endpoint for determining read replicas

### DIFF
--- a/cassandra-analytics-common/src/main/java/org/apache/cassandra/spark/data/partitioner/CassandraRing.java
+++ b/cassandra-analytics-common/src/main/java/org/apache/cassandra/spark/data/partitioner/CassandraRing.java
@@ -109,6 +109,21 @@ public class CassandraRing implements Serializable
     public CassandraRing(Partitioner partitioner,
                          String keyspace,
                          ReplicationFactor replicationFactor,
+                         List<CassandraInstance> instances,
+                         RangeMap<BigInteger, List<CassandraInstance>> replicas,
+                         Multimap<CassandraInstance, Range<BigInteger>> tokenRangeMap)
+    {
+        this.partitioner = partitioner;
+        this.keyspace = keyspace;
+        this.replicationFactor = replicationFactor;
+        this.instances = instances;
+        this.replicas = replicas;
+        this.tokenRangeMap = tokenRangeMap;
+    }
+
+    public CassandraRing(Partitioner partitioner,
+                         String keyspace,
+                         ReplicationFactor replicationFactor,
                          Collection<CassandraInstance> instances)
     {
         this.partitioner = partitioner;

--- a/cassandra-analytics-common/src/main/java/org/apache/cassandra/spark/data/partitioner/CassandraRing.java
+++ b/cassandra-analytics-common/src/main/java/org/apache/cassandra/spark/data/partitioner/CassandraRing.java
@@ -32,7 +32,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.OptionalInt;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ArrayListMultimap;
@@ -106,6 +108,32 @@ public class CassandraRing implements Serializable
         replicaMap.putAll(mappingsToAdd);
     }
 
+    /**
+     * Find the CassandraInstance which owns a given token from a list of
+     * __sorted__ CassandraInstances. If the token is greater than or equal to
+     * the partitioner max token then the CassandraInstance with the smallest
+     * token value is returned, assuming token ring wraparound.
+     */
+    private static int getTokenOwnerIdx(List<CassandraInstance> instances, Partitioner partitioner, BigInteger token)
+    {
+        OptionalInt maybeTokenOwnerIdx = IntStream.range(0, instances.size())
+                .filter(idx -> new BigInteger(instances.get(idx).token()).equals(token))
+                .findFirst();
+
+        if (maybeTokenOwnerIdx.isPresent())
+        {
+            return maybeTokenOwnerIdx.getAsInt();
+        }
+        else if (token.compareTo(partitioner.maxToken()) >= 0)
+        {
+            return 0;
+        }
+        else
+        {
+            throw new RuntimeException(String.format("Could not find instance for token: %s", token));
+        }
+    }
+
     public CassandraRing(Partitioner partitioner,
                          String keyspace,
                          ReplicationFactor replicationFactor,
@@ -119,26 +147,24 @@ public class CassandraRing implements Serializable
                 .sorted(Comparator.comparing(instance -> new BigInteger(instance.token())))
                 .collect(Collectors.toCollection(ArrayList::new));
 
+        // replicas is a mapping of token ranges to CassandraInstances
+        // which are replicas for that range
         replicas = TreeRangeMap.create();
+
+        // tokenRangeMap is mapping of CassandraInstances to token ranges
+        // that they own or are a replica for
         tokenRangeMap = ArrayListMultimap.create();
 
         rangeToReplicas.forEach((range, rangeReplicas) -> {
-            // Find the owner of this range
-            CassandraInstance tokenOwner;
+            int tokenOwnerIdx = getTokenOwnerIdx(this.instances, partitioner, range.upperEndpoint());
 
-            if ((range.upperEndpoint().compareTo(partitioner.maxToken()) >= 0)
-                    && !new BigInteger(this.instances.get(this.instances.size() - 1).token()).equals(partitioner.maxToken()))
-            {
-                tokenOwner = this.instances.get(0);
-            }
-            else
-            {
-                tokenOwner = this.instances.stream()
-                        .filter(instance -> new BigInteger(instance.token()).equals(range.upperEndpoint()))
+            // Find following closest CassandraInstance for each replica and update tokenRangeMap
+            rangeReplicas.forEach(replica ->
+                    IntStream.range(0, this.instances.size())
+                        .map(idx -> (idx + tokenOwnerIdx) % this.instances.size())
+                        .filter(idx -> this.instances.get(idx).nodeName().equals(replica))
                         .findFirst()
-                        .get();
-            }
-            tokenRangeMap.put(tokenOwner, range);
+                        .ifPresent(idx -> tokenRangeMap.get(this.instances.get(idx)).add(range)));
         });
 
         replicas.put(Range.openClosed(partitioner.minToken(), partitioner.maxToken()), Collections.emptyList());

--- a/cassandra-analytics-common/src/main/java/org/apache/cassandra/spark/data/partitioner/CassandraRing.java
+++ b/cassandra-analytics-common/src/main/java/org/apache/cassandra/spark/data/partitioner/CassandraRing.java
@@ -75,6 +75,7 @@ public class CassandraRing implements Serializable
     private String keyspace;
     private ReplicationFactor replicationFactor;
     private List<CassandraInstance> instances;
+    private Map<Range<BigInteger>, List<String>> rangeToReplicas;
 
     private transient RangeMap<BigInteger, List<CassandraInstance>> replicas;
     private transient Multimap<CassandraInstance, Range<BigInteger>> tokenRangeMap;
@@ -146,29 +147,9 @@ public class CassandraRing implements Serializable
         this.instances = instances.stream()
                 .sorted(Comparator.comparing(instance -> new BigInteger(instance.token())))
                 .collect(Collectors.toCollection(ArrayList::new));
+        this.rangeToReplicas = rangeToReplicas;
 
-        // replicas is a mapping of token ranges to CassandraInstances
-        // which are replicas for that range
-        replicas = TreeRangeMap.create();
-
-        // tokenRangeMap is mapping of CassandraInstances to token ranges
-        // that they own or are a replica for
-        tokenRangeMap = ArrayListMultimap.create();
-
-        rangeToReplicas.forEach((range, rangeReplicas) -> {
-            int tokenOwnerIdx = getTokenOwnerIdx(this.instances, partitioner, range.upperEndpoint());
-
-            // Find following closest CassandraInstance for each replica and update tokenRangeMap
-            rangeReplicas.forEach(replica ->
-                    IntStream.range(0, this.instances.size())
-                        .map(idx -> (idx + tokenOwnerIdx) % this.instances.size())
-                        .filter(idx -> this.instances.get(idx).nodeName().equals(replica))
-                        .findFirst()
-                        .ifPresent(idx -> tokenRangeMap.get(this.instances.get(idx)).add(range)));
-        });
-
-        replicas.put(Range.openClosed(partitioner.minToken(), partitioner.maxToken()), Collections.emptyList());
-        tokenRangeMap.asMap().forEach((instance, ranges) -> ranges.forEach(range -> addReplica(instance, range, replicas)));
+        this.initWithRangeToReplicas();
     }
 
     public CassandraRing(Partitioner partitioner,
@@ -183,6 +164,32 @@ public class CassandraRing implements Serializable
                                   .sorted(Comparator.comparing(instance -> new BigInteger(instance.token())))
                                   .collect(Collectors.toCollection(ArrayList::new));
         this.init();
+    }
+
+    private void initWithRangeToReplicas()
+    {
+        // replicas is a mapping of token ranges to CassandraInstances
+        // which are replicas for that range
+        replicas = TreeRangeMap.create();
+
+        // tokenRangeMap is mapping of CassandraInstances to token ranges
+        // that they own or are a replica for
+        tokenRangeMap = ArrayListMultimap.create();
+
+        rangeToReplicas.forEach((range, rangeReplicas) -> {
+            int tokenOwnerIdx = getTokenOwnerIdx(this.instances, partitioner, range.upperEndpoint());
+
+            // Find following closest CassandraInstance for each replica and update tokenRangeMap
+            rangeReplicas.forEach(replica ->
+                    IntStream.range(0, this.instances.size())
+                            .map(idx -> (idx + tokenOwnerIdx) % this.instances.size())
+                            .filter(idx -> this.instances.get(idx).nodeName().equals(replica))
+                            .findFirst()
+                            .ifPresent(idx -> tokenRangeMap.get(this.instances.get(idx)).add(range)));
+        });
+
+        replicas.put(Range.openClosed(partitioner.minToken(), partitioner.maxToken()), Collections.emptyList());
+        tokenRangeMap.asMap().forEach((instance, ranges) -> ranges.forEach(range -> addReplica(instance, range, replicas)));
     }
 
     private void init()
@@ -343,7 +350,25 @@ public class CassandraRing implements Serializable
         {
             this.instances.add(new CassandraInstance(in.readUTF(), in.readUTF(), in.readUTF()));
         }
-        this.init();
+
+        this.rangeToReplicas = new HashMap<>();
+        int numKeys = in.readShort();
+        for (int key = 0; key < numKeys; key++)
+        {
+            BigInteger rangeStart = new BigInteger(in.readUTF());
+            BigInteger rangeEnd = new BigInteger(in.readUTF());
+            List<String> replicas = new ArrayList<>();
+
+            int numReplicas = in.readShort();
+            for (int replica = 0; replica < numReplicas; replica++)
+            {
+                replicas.add(in.readUTF());
+            }
+
+            this.rangeToReplicas.put(Range.openClosed(rangeStart, rangeEnd), replicas);
+        }
+
+        this.initWithRangeToReplicas();
     }
 
     private void writeObject(ObjectOutputStream out) throws IOException, ClassNotFoundException
@@ -368,6 +393,19 @@ public class CassandraRing implements Serializable
             out.writeUTF(instance.nodeName());
             out.writeUTF(instance.dataCenter());
         }
+
+        out.writeShort(this.rangeToReplicas.size());
+        for (Map.Entry<Range<BigInteger>, List<String>> entry : rangeToReplicas.entrySet())
+        {
+            out.writeUTF(entry.getKey().lowerEndpoint().toString());
+            out.writeUTF(entry.getKey().upperEndpoint().toString());
+
+            out.writeShort(entry.getValue().size());
+            for (String replica : entry.getValue())
+            {
+                out.writeUTF(replica);
+            }
+        }
     }
 
     public static class Serializer extends com.esotericsoftware.kryo.Serializer<CassandraRing>
@@ -379,6 +417,7 @@ public class CassandraRing implements Serializable
             out.writeString(ring.keyspace);
             kryo.writeObject(out, ring.replicationFactor);
             kryo.writeObject(out, ring.instances);
+            kryo.writeObject(out, ring.rangeToReplicas);
         }
 
         @Override
@@ -389,7 +428,8 @@ public class CassandraRing implements Serializable
                                                         : Partitioner.Murmur3Partitioner,
                                      in.readString(),
                                      kryo.readObject(in, ReplicationFactor.class),
-                                     kryo.readObject(in, ArrayList.class));
+                                     kryo.readObject(in, ArrayList.class),
+                                     kryo.readObject(in, Map.class));
         }
     }
 }

--- a/cassandra-analytics-common/src/main/java/org/apache/cassandra/spark/data/partitioner/CassandraRing.java
+++ b/cassandra-analytics-common/src/main/java/org/apache/cassandra/spark/data/partitioner/CassandraRing.java
@@ -109,16 +109,40 @@ public class CassandraRing implements Serializable
     public CassandraRing(Partitioner partitioner,
                          String keyspace,
                          ReplicationFactor replicationFactor,
-                         List<CassandraInstance> instances,
-                         RangeMap<BigInteger, List<CassandraInstance>> replicas,
-                         Multimap<CassandraInstance, Range<BigInteger>> tokenRangeMap)
+                         Collection<CassandraInstance> instances,
+                         Map<Range<BigInteger>, List<String>> rangeToReplicas)
     {
         this.partitioner = partitioner;
         this.keyspace = keyspace;
         this.replicationFactor = replicationFactor;
-        this.instances = instances;
-        this.replicas = replicas;
-        this.tokenRangeMap = tokenRangeMap;
+        this.instances = instances.stream()
+                .sorted(Comparator.comparing(instance -> new BigInteger(instance.token())))
+                .collect(Collectors.toCollection(ArrayList::new));
+
+        replicas = TreeRangeMap.create();
+        tokenRangeMap = ArrayListMultimap.create();
+
+        rangeToReplicas.forEach((range, rangeReplicas) -> {
+            // Find the owner of this range
+            CassandraInstance tokenOwner;
+
+            if (range.upperEndpoint().equals(partitioner.maxToken())
+                    && !new BigInteger(this.instances.get(this.instances.size() - 1).token()).equals(partitioner.maxToken()))
+            {
+                tokenOwner = this.instances.get(0);
+            }
+            else
+            {
+                tokenOwner = this.instances.stream()
+                        .filter(instance -> new BigInteger(instance.token()).equals(range.upperEndpoint()))
+                        .findFirst()
+                        .get();
+            }
+            tokenRangeMap.put(tokenOwner, range);
+        });
+
+        replicas.put(Range.openClosed(partitioner.minToken(), partitioner.maxToken()), Collections.emptyList());
+        tokenRangeMap.asMap().forEach((instance, ranges) -> ranges.forEach(range -> addReplica(instance, range, replicas)));
     }
 
     public CassandraRing(Partitioner partitioner,

--- a/cassandra-analytics-common/src/main/java/org/apache/cassandra/spark/data/partitioner/CassandraRing.java
+++ b/cassandra-analytics-common/src/main/java/org/apache/cassandra/spark/data/partitioner/CassandraRing.java
@@ -126,7 +126,7 @@ public class CassandraRing implements Serializable
             // Find the owner of this range
             CassandraInstance tokenOwner;
 
-            if ((range.upperEndpoint().compareTo(partitioner.maxToken()) > 0)
+            if ((range.upperEndpoint().compareTo(partitioner.maxToken()) >= 0)
                     && !new BigInteger(this.instances.get(this.instances.size() - 1).token()).equals(partitioner.maxToken()))
             {
                 tokenOwner = this.instances.get(0);

--- a/cassandra-analytics-common/src/main/java/org/apache/cassandra/spark/data/partitioner/CassandraRing.java
+++ b/cassandra-analytics-common/src/main/java/org/apache/cassandra/spark/data/partitioner/CassandraRing.java
@@ -31,9 +31,9 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
-import java.util.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
@@ -126,7 +126,7 @@ public class CassandraRing implements Serializable
             // Find the owner of this range
             CassandraInstance tokenOwner;
 
-            if (range.upperEndpoint().equals(partitioner.maxToken())
+            if ((range.upperEndpoint().compareTo(partitioner.maxToken()) > 0)
                     && !new BigInteger(this.instances.get(this.instances.size() - 1).token()).equals(partitioner.maxToken()))
             {
                 tokenOwner = this.instances.get(0);

--- a/cassandra-analytics-common/src/test/java/org/apache/cassandra/spark/data/partitioner/CassandraRingTests.java
+++ b/cassandra-analytics-common/src/test/java/org/apache/cassandra/spark/data/partitioner/CassandraRingTests.java
@@ -23,6 +23,7 @@ import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Multimap;
@@ -65,6 +66,12 @@ public class CassandraRingTests
         ranges.forEach(rangeSet::add);
         enclosedTokens.forEach(token -> assertThat(rangeSet.contains(token)).as(token + " should have been a valid token").isTrue());
         excludedTokens.forEach(token -> assertThat(rangeSet.contains(token)).isFalse());
+    }
+
+    private Map.Entry<Range<BigInteger>, List<String>> replicaEntry(String startToken, String endToken, List<String> replicas)
+    {
+        Range<BigInteger> range = Range.openClosed(new BigInteger(startToken), new BigInteger(endToken));
+        return Map.entry(range, replicas);
     }
 
     @Test
@@ -446,5 +453,165 @@ public class CassandraRingTests
                                      BigInteger.valueOf(202L),
                                      Partitioner.Murmur3Partitioner.minToken(),
                                      Partitioner.Murmur3Partitioner.maxToken()));
+    }
+
+    @Test
+    public void testNetworkStrategyRF3Tokens1WithRangeToReplicas()
+    {
+        List<CassandraInstance> instances = Arrays.asList(
+                new CassandraInstance("0", "local0-i1", "DC1"),
+                new CassandraInstance("100", "local0-i2", "DC1"),
+                new CassandraInstance(Partitioner.Murmur3Partitioner.maxToken().toString(), "local0-i3", "DC1"));
+
+        List<String> replicas = List.of("local0-i1", "local0-i2", "local0-i3");
+        Map<Range<BigInteger>, List<String>> rangeToReplicas = Map.ofEntries(
+                replicaEntry(Partitioner.Murmur3Partitioner.minToken().toString(), "0",  replicas),
+                replicaEntry("0", "100",  replicas),
+                replicaEntry("100", Partitioner.Murmur3Partitioner.maxToken().toString(),  replicas)
+        );
+
+        CassandraRing ring = new CassandraRing(
+                Partitioner.Murmur3Partitioner,
+                "test",
+                new ReplicationFactor(
+                        ImmutableMap.of("class", "org.apache.cassandra.locator.NetworkTopologyStrategy", "DC1", "3")),
+                instances,
+                rangeToReplicas);
+
+        assertThat(ring.tokens().toArray()).isEqualTo(Arrays.asList(
+                BigInteger.valueOf(0L),
+                BigInteger.valueOf(100L),
+                Partitioner.Murmur3Partitioner.maxToken()).toArray());
+
+        Multimap<CassandraInstance, Range<BigInteger>> tokenRanges = ring.tokenRanges();
+        for (CassandraInstance instance : instances)
+        {
+            assertThat(mergeRanges(tokenRanges.get(instance)))
+                    .isEqualTo(Range.openClosed(Partitioner.Murmur3Partitioner.minToken(),
+                            Partitioner.Murmur3Partitioner.maxToken()));
+        }
+    }
+
+    @Test
+    public void testNetworkStrategyRF3Tokens4WithRangeToReplicas()
+    {
+        List<CassandraInstance> instances = Arrays.asList(
+                new CassandraInstance("-8000", "local0-i1", "DC1"),
+                new CassandraInstance("-2000", "local0-i1", "DC1"),
+                new CassandraInstance("2000", "local0-i1", "DC1"),
+                new CassandraInstance("8000", "local0-i1", "DC1"),
+                new CassandraInstance("-6000", "local0-i2", "DC1"),
+                new CassandraInstance("-1000", "local0-i2", "DC1"),
+                new CassandraInstance("4000", "local0-i2", "DC1"),
+                new CassandraInstance("9000", "local0-i2", "DC1"),
+                new CassandraInstance("-4000", "local0-i3", "DC1"),
+                new CassandraInstance("-5", "local0-i3", "DC1"),
+                new CassandraInstance("3050", "local0-i3", "DC1"),
+                new CassandraInstance("10000", "local0-i3", "DC1"));
+
+        List<String> replicas = List.of("local0-i1", "local0-i2", "local0-i3");
+        Map<Range<BigInteger>, List<String>> rangeToReplicas = Map.ofEntries(
+                replicaEntry(Partitioner.Murmur3Partitioner.minToken().toString(), "-8000",  replicas),
+                replicaEntry("-8000", "-6000",  replicas),
+                replicaEntry("-6000", "-4000",  replicas),
+                replicaEntry("-4000", "-2000",  replicas),
+                replicaEntry("-2000", "-1000",  replicas),
+                replicaEntry("-1000", "-5",  replicas),
+                replicaEntry("-5", "2000",  replicas),
+                replicaEntry("2000", "3050",  replicas),
+                replicaEntry("3050", "4000",  replicas),
+                replicaEntry("4000", "8000",  replicas),
+                replicaEntry("8000", "9000",  replicas),
+                replicaEntry("9000", "10000",  replicas),
+                replicaEntry("10000", Partitioner.Murmur3Partitioner.maxToken().toString(),  replicas)
+        );
+
+        CassandraRing ring = new CassandraRing(
+                Partitioner.Murmur3Partitioner,
+                "test",
+                new ReplicationFactor(
+                        ImmutableMap.of("class", "org.apache.cassandra.locator.NetworkTopologyStrategy", "DC1", "3")),
+                instances,
+                rangeToReplicas);
+
+        assertThat(ring.tokens().toArray()).isEqualTo(Arrays.asList(
+                BigInteger.valueOf(-8000L), BigInteger.valueOf(-6000L), BigInteger.valueOf(-4000L),
+                BigInteger.valueOf(-2000L), BigInteger.valueOf(-1000L), BigInteger.valueOf(-5L),
+                BigInteger.valueOf(2000L), BigInteger.valueOf(3050L), BigInteger.valueOf(4000L),
+                BigInteger.valueOf(8000L), BigInteger.valueOf(9000L), BigInteger.valueOf(10000L)).toArray());
+
+        Multimap<CassandraInstance, Range<BigInteger>> tokenRanges = ring.tokenRanges();
+
+        // token(0) (-8000) => (MIN -> -8000], (8000 -> 9000], (9000 -> 10000], (10000 -> MAX]
+        //                  => (MIN -> -8000], (8000 -> MAX]
+        validateRanges(tokenRanges.get(instances.get(0)),
+                Arrays.asList(BigInteger.valueOf(-8000), Partitioner.Murmur3Partitioner.maxToken()),
+                Arrays.asList(Partitioner.Murmur3Partitioner.minToken(), BigInteger.valueOf(8000)));
+
+        // token(2) (-2000) => (-8000 -> -6000], (-6000 -> -4000], (-4000 -> -2000]
+        //                  => (-8000 -> -2000]
+        validateRanges(tokenRanges.get(instances.get(1)),
+                Arrays.asList(BigInteger.valueOf(-2000)),
+                Arrays.asList(BigInteger.valueOf(-8000)));
+
+        // token(3) (2000) => (-2000 -> -1000], (-1000 -> -5], (-5 -> 2000]
+        //                 => (-2000 -> 2000]
+        validateRanges(tokenRanges.get(instances.get(2)),
+                Arrays.asList(BigInteger.valueOf(2000)),
+                Arrays.asList(BigInteger.valueOf(-2000)));
+
+        // token(4) (8000) => (2000 -> 3050], (3050 -> 4000], (4000 -> 8000]
+        //                 => (2000 -> 8000]
+        validateRanges(tokenRanges.get(instances.get(3)),
+                Arrays.asList(BigInteger.valueOf(8000)),
+                Arrays.asList(BigInteger.valueOf(2000)));
+
+        // token(5) (-6000) => (MIN -> -8000], (-8000 -> -6000], (9000 -> 10000], (10000 -> MAX]
+        //                 => (MIN -> -6000], (9000 -> MAX)
+        validateRanges(tokenRanges.get(instances.get(4)),
+                Arrays.asList(BigInteger.valueOf(-6000), Partitioner.Murmur3Partitioner.maxToken()),
+                Arrays.asList(Partitioner.Murmur3Partitioner.minToken(), BigInteger.valueOf(9000)));
+
+        // token(6) (-1000) => (-6000 -> -4000], (-4000 -> -2000], (-2000 -> -1000]
+        //                 => (-6000 -> -1000]
+        validateRanges(tokenRanges.get(instances.get(5)),
+                Arrays.asList(BigInteger.valueOf(-1000)),
+                Arrays.asList(BigInteger.valueOf(-6000)));
+
+        // token(7) (4000) => (-1000 -> -5], (-5 -> 2000], (2000 -> 3050], (3050 -> 4000]
+        //                 => (-1000 -> 4000]
+        validateRanges(tokenRanges.get(instances.get(6)),
+                Arrays.asList(BigInteger.valueOf(4000)),
+                Arrays.asList(BigInteger.valueOf(-1000)));
+
+        // token(8) (9000) => (4000 -> 8000], (8000 -> 9000]
+        //                 => (4000 -> 9000]
+        validateRanges(tokenRanges.get(instances.get(7)),
+                Arrays.asList(BigInteger.valueOf(9000)),
+                Arrays.asList(BigInteger.valueOf(4000)));
+
+        // token(9) (-4000) => (MIN -> -8000], (-8000 -> -6000], (-6000 -> -4000], (10000 -> MAX]
+        //                 => (MIN -> -4000], (10000 -> -MAX]
+        validateRanges(tokenRanges.get(instances.get(8)),
+                Arrays.asList(BigInteger.valueOf(-4000), Partitioner.Murmur3Partitioner.maxToken()),
+                Arrays.asList(Partitioner.Murmur3Partitioner.minToken(), BigInteger.valueOf(10000)));
+
+        // token(10) (-5) => (-4000 -> -2000], (-2000 -> -1000], (-1000 -> -5]
+        //                 => (-4000 -> -5]
+        validateRanges(tokenRanges.get(instances.get(9)),
+                Arrays.asList(BigInteger.valueOf(-5)),
+                Arrays.asList(BigInteger.valueOf(-4000)));
+
+        // token(11) (3050) => (-5 -> 2000], (2000 -> 3050]
+        //                 => (-5 -> 3050]
+        validateRanges(tokenRanges.get(instances.get(10)),
+                Arrays.asList(BigInteger.valueOf(3050)),
+                Arrays.asList(BigInteger.valueOf(-5)));
+
+        // token(12) (10000) => (3050 -> 4000], (4000 -> 8000], (8000 -> 9000], (9000 -> 10000]
+        //                 => (3050 -> 10000]
+        validateRanges(tokenRanges.get(instances.get(11)),
+                Arrays.asList(BigInteger.valueOf(10000)),
+                Arrays.asList(BigInteger.valueOf(3050)));
     }
 }

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/data/CassandraDataLayer.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/data/CassandraDataLayer.java
@@ -696,16 +696,14 @@ public class CassandraDataLayer extends PartitionedDataLayer implements StartupV
         ring.stream()
                 .filter(status -> datacenter == null || datacenter.equalsIgnoreCase(status.datacenter()))
                 .sorted(Comparator.comparing(instance -> new BigInteger(instance.token())))
-                .forEach(ringEntry ->
-                {
+                .forEach(ringEntry -> {
                     CassandraInstance instance = new CassandraInstance(ringEntry.token(), ringEntry.fqdn(), ringEntry.datacenter());
                     instances.add(instance);
                     addressAndPortToInstance.put(String.format("%s:%d", ringEntry.address(), ringEntry.port()), instance);
                 });
 
         tokenRangeReplicas.readReplicas()
-                .forEach(replicaInfo ->
-                {
+                .forEach(replicaInfo -> {
                     BigInteger rangeStart = new BigInteger(replicaInfo.start());
                     BigInteger rangeEnd = new BigInteger(replicaInfo.end());
                     Range<BigInteger> range = Range.openClosed(rangeStart, rangeEnd);

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/data/CassandraDataLayer.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/data/CassandraDataLayer.java
@@ -24,7 +24,17 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
 import java.math.BigInteger;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
@@ -40,11 +50,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
-import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.Multimap;
 import com.google.common.collect.Range;
-import com.google.common.collect.RangeMap;
-import com.google.common.collect.TreeRangeMap;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -673,77 +679,20 @@ public class CassandraDataLayer extends PartitionedDataLayer implements StartupV
                                                      RingResponse ring,
                                                      TokenRangeReplicasResponse tokenRangeReplicas)
     {
-        List<CassandraInstance> instances = new ArrayList<>();
-        Map<String, List<CassandraInstance>> addressAndPortToInstances = new HashMap<>();
+        Map<Range<BigInteger>, List<String>> replicas = tokenRangeReplicas.readReplicas()
+                .stream()
+                .map(replicaInfo -> Map.entry(
+                        Range.openClosed(new BigInteger(replicaInfo.start()), new BigInteger(replicaInfo.end())),
+                        replicaInfo.replicasByDatacenter().get(datacenter)))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
-        // Token Range -> Read replicas for range
-        RangeMap<BigInteger, List<CassandraInstance>> replicas = TreeRangeMap.create();
-
-        // Instance -> Ranges owned by instance
-        Multimap<CassandraInstance, Range<BigInteger>> tokenRangeMap = ArrayListMultimap.create();
-
-        ring.stream()
+        Collection<CassandraInstance> instances = ring
+                .stream()
                 .filter(status -> datacenter == null || datacenter.equalsIgnoreCase(status.datacenter()))
-                .sorted(Comparator.comparing(instance -> new BigInteger(instance.token())))
-                .forEach(ringEntry -> {
-                    CassandraInstance instance = new CassandraInstance(ringEntry.token(), ringEntry.fqdn(), ringEntry.datacenter());
-                    String addressAndPort = String.format("%s:%d", ringEntry.address(), ringEntry.port());
+                .map(status -> new CassandraInstance(status.token(), status.fqdn(), status.datacenter()))
+                .collect(Collectors.toList());
 
-                    instances.add(instance);
-                    addressAndPortToInstances.putIfAbsent(addressAndPort, new ArrayList<>());
-                    addressAndPortToInstances.get(addressAndPort).add(instance);
-                });
-
-        tokenRangeReplicas.readReplicas()
-                .forEach(replicaInfo -> {
-                    BigInteger rangeStart = new BigInteger(replicaInfo.start());
-                    BigInteger rangeEnd = new BigInteger(replicaInfo.end());
-                    Range<BigInteger> range = Range.openClosed(rangeStart, rangeEnd);
-                    List<String> replicasForRange = replicaInfo.replicasByDatacenter().get(datacenter);
-
-                    // If the range end is equal to MAX_TOKEN and the token of the last instance is
-                    // not equal MAX_TOKEN, then the owner of this range should be the instance with
-                    // the smallest token. Otherwise, find the owner based on token equality.
-                    CassandraInstance tokenOwner;
-                    if (rangeEnd.equals(partitioner.maxToken()) && !new BigInteger(instances.get(instances.size() - 1).token()).equals(partitioner.maxToken()))
-                    {
-                        tokenOwner = instances.get(0);
-                    }
-                    else
-                    {
-                        tokenOwner = replicasForRange.stream()
-                                .map(addressAndPortToInstances::get)
-                                .flatMap(Collection::stream)
-                                .filter(instance -> new BigInteger(instance.token()).equals(rangeEnd))
-                                .findFirst()
-                                .get();
-                    }
-
-                    tokenRangeMap.put(tokenOwner, range);
-                });
-
-        // This has been extracted from CassandraRing.addReplica, however I'm not
-        // sure if it's applicable or correct when using vnodes. Rather than mapping
-        // Ranges to CassandraInstance which includes token details, the mapping should
-        // be Ranges to CassandraNode with either all tokens or none.
-        replicas.put(Range.openClosed(partitioner.minToken(), partitioner.maxToken()), Collections.emptyList());
-        tokenRangeMap.asMap().forEach((instance, ranges) -> {
-            ranges.forEach(range -> {
-                // addReplica(instance, range, replicas)
-                RangeMap<BigInteger, List<CassandraInstance>> replicaRanges = replicas.subRangeMap(range);
-                RangeMap<BigInteger, List<CassandraInstance>> mappingsToAdd = TreeRangeMap.create();
-
-                replicaRanges.asMapOfRanges().forEach((key, value) -> {
-                    List<CassandraInstance> replicaInstances = new ArrayList<>(value);
-                    replicaInstances.add(instance);
-                    mappingsToAdd.put(key, replicaInstances);
-                });
-
-                replicas.putAll(mappingsToAdd);
-            });
-        });
-
-        return new CassandraRing(partitioner, keyspace, replicationFactor, instances, replicas, tokenRangeMap);
+        return new CassandraRing(partitioner, keyspace, replicationFactor, instances, replicas);
     }
 
     // Startup Validation

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/data/CassandraDataLayer.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/data/CassandraDataLayer.java
@@ -679,12 +679,7 @@ public class CassandraDataLayer extends PartitionedDataLayer implements StartupV
                                                      RingResponse ring,
                                                      TokenRangeReplicasResponse tokenRangeReplicas)
     {
-        Map<Range<BigInteger>, List<String>> replicas = tokenRangeReplicas.readReplicas()
-                .stream()
-                .map(replicaInfo -> Map.entry(
-                        Range.openClosed(new BigInteger(replicaInfo.start()), new BigInteger(replicaInfo.end())),
-                        replicaInfo.replicasByDatacenter().get(datacenter)))
-                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+        Map<Range<BigInteger>, List<String>> replicas = dcReplicasByRange(tokenRangeReplicas, datacenter);
 
         Collection<CassandraInstance> instances = ring
                 .stream()
@@ -1088,5 +1083,33 @@ public class CassandraDataLayer extends PartitionedDataLayer implements StartupV
         {
             requestedFeatures.set(index, featureAlias);
         }
+    }
+
+    @VisibleForTesting
+    static Map<Range<BigInteger>, List<String>> dcReplicasByRange(TokenRangeReplicasResponse tokenRangeReplicas, String datacenter)
+    {
+        Map<String, String> fqdnByAddressAndPort = new HashMap<>();
+        Map<Range<BigInteger>, List<String>> replicas = new HashMap<>();
+
+        tokenRangeReplicas.replicaMetadata().forEach((addressAndPort, metadata) -> {
+            fqdnByAddressAndPort.putIfAbsent(addressAndPort, metadata.fqdn());
+        });
+
+        tokenRangeReplicas.readReplicas().forEach(replicaInfo -> {
+            Range<BigInteger> range = Range.openClosed(new BigInteger(replicaInfo.start()), new BigInteger(replicaInfo.end()));
+            List<String> dcReplicas = replicaInfo.replicasByDatacenter()
+                    .entrySet()
+                    .stream()
+                    .filter(entry -> datacenter.equalsIgnoreCase(entry.getKey()))
+                    .findFirst()
+                    .get()
+                    .getValue()
+                    .stream().map(fqdnByAddressAndPort::get)
+                    .collect(Collectors.toList());
+
+            replicas.put(range, dcReplicas);
+        });
+
+        return replicas;
     }
 }

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/data/CassandraDataLayer.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/data/CassandraDataLayer.java
@@ -24,18 +24,7 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
 import java.math.BigInteger;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
@@ -685,7 +674,7 @@ public class CassandraDataLayer extends PartitionedDataLayer implements StartupV
                                                      TokenRangeReplicasResponse tokenRangeReplicas)
     {
         List<CassandraInstance> instances = new ArrayList<>();
-        Map<String, CassandraInstance> addressAndPortToInstance = new HashMap<>();
+        Map<String, List<CassandraInstance>> addressAndPortToInstances = new HashMap<>();
 
         // Token Range -> Read replicas for range
         RangeMap<BigInteger, List<CassandraInstance>> replicas = TreeRangeMap.create();
@@ -698,8 +687,11 @@ public class CassandraDataLayer extends PartitionedDataLayer implements StartupV
                 .sorted(Comparator.comparing(instance -> new BigInteger(instance.token())))
                 .forEach(ringEntry -> {
                     CassandraInstance instance = new CassandraInstance(ringEntry.token(), ringEntry.fqdn(), ringEntry.datacenter());
+                    String addressAndPort = String.format("%s:%d", ringEntry.address(), ringEntry.port());
+
                     instances.add(instance);
-                    addressAndPortToInstance.put(String.format("%s:%d", ringEntry.address(), ringEntry.port()), instance);
+                    addressAndPortToInstances.putIfAbsent(addressAndPort, new ArrayList<>());
+                    addressAndPortToInstances.get(addressAndPort).add(instance);
                 });
 
         tokenRangeReplicas.readReplicas()
@@ -707,14 +699,14 @@ public class CassandraDataLayer extends PartitionedDataLayer implements StartupV
                     BigInteger rangeStart = new BigInteger(replicaInfo.start());
                     BigInteger rangeEnd = new BigInteger(replicaInfo.end());
                     Range<BigInteger> range = Range.openClosed(rangeStart, rangeEnd);
+                    List<String> replicasForRange = replicaInfo.replicasByDatacenter().get(datacenter);
 
-                    List<CassandraInstance> instancesForRange = replicaInfo.replicasByDatacenter()
-                            .get(datacenter)
-                            .stream()
-                            .map(addressAndPortToInstance::get)
-                            .collect(Collectors.toList());
-
-                    replicas.put(range, instancesForRange);
+                    // This isn't correct. Because we have multiple instances per Cassandra node when using
+                    // num_tokens > 1, it means that replicas either maps to all instances or a single one.
+                    // For now taking the first, but this needs to be changed.
+                    replicas.put(range, replicasForRange.stream()
+                            .map(replica -> addressAndPortToInstances.get(replica).get(0))
+                            .collect(Collectors.toList()));
 
                     // If the range end is equal to MAX_TOKEN and the token of the last instance is
                     // not equal MAX_TOKEN, then the owner of this range should be the instance with
@@ -726,7 +718,9 @@ public class CassandraDataLayer extends PartitionedDataLayer implements StartupV
                     }
                     else
                     {
-                        tokenOwner = instancesForRange.stream()
+                        tokenOwner = replicasForRange.stream()
+                                .map(addressAndPortToInstances::get)
+                                .flatMap(Collection::stream)
                                 .filter(instance -> new BigInteger(instance.token()).equals(rangeEnd))
                                 .findFirst()
                                 .get();

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/data/CassandraDataLayer.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/data/CassandraDataLayer.java
@@ -701,13 +701,6 @@ public class CassandraDataLayer extends PartitionedDataLayer implements StartupV
                     Range<BigInteger> range = Range.openClosed(rangeStart, rangeEnd);
                     List<String> replicasForRange = replicaInfo.replicasByDatacenter().get(datacenter);
 
-                    // This isn't correct. Because we have multiple instances per Cassandra node when using
-                    // num_tokens > 1, it means that replicas either maps to all instances or a single one.
-                    // For now taking the first, but this needs to be changed.
-                    replicas.put(range, replicasForRange.stream()
-                            .map(replica -> addressAndPortToInstances.get(replica).get(0))
-                            .collect(Collectors.toList()));
-
                     // If the range end is equal to MAX_TOKEN and the token of the last instance is
                     // not equal MAX_TOKEN, then the owner of this range should be the instance with
                     // the smallest token. Otherwise, find the owner based on token equality.
@@ -728,6 +721,27 @@ public class CassandraDataLayer extends PartitionedDataLayer implements StartupV
 
                     tokenRangeMap.put(tokenOwner, range);
                 });
+
+        // This has been extracted from CassandraRing.addReplica, however I'm not
+        // sure if it's applicable or correct when using vnodes. Rather than mapping
+        // Ranges to CassandraInstance which includes token details, the mapping should
+        // be Ranges to CassandraNode with either all tokens or none.
+        replicas.put(Range.openClosed(partitioner.minToken(), partitioner.maxToken()), Collections.emptyList());
+        tokenRangeMap.asMap().forEach((instance, ranges) -> {
+            ranges.forEach(range -> {
+                // addReplica(instance, range, replicas)
+                RangeMap<BigInteger, List<CassandraInstance>> replicaRanges = replicas.subRangeMap(range);
+                RangeMap<BigInteger, List<CassandraInstance>> mappingsToAdd = TreeRangeMap.create();
+
+                replicaRanges.asMapOfRanges().forEach((key, value) -> {
+                    List<CassandraInstance> replicaInstances = new ArrayList<>(value);
+                    replicaInstances.add(instance);
+                    mappingsToAdd.put(key, replicaInstances);
+                });
+
+                replicas.putAll(mappingsToAdd);
+            });
+        });
 
         return new CassandraRing(partitioner, keyspace, replicationFactor, instances, replicas, tokenRangeMap);
     }

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/data/CassandraDataLayer.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/data/CassandraDataLayer.java
@@ -687,10 +687,10 @@ public class CassandraDataLayer extends PartitionedDataLayer implements StartupV
         List<CassandraInstance> instances = new ArrayList<>();
         Map<String, CassandraInstance> addressAndPortToInstance = new HashMap<>();
 
-        // Map of Token Ranges to Read Replicas
+        // Token Range -> Read replicas for range
         RangeMap<BigInteger, List<CassandraInstance>> replicas = TreeRangeMap.create();
 
-        // Map of Instances -> Owned Token Ranges
+        // Instance -> Ranges owned by instance
         Multimap<CassandraInstance, Range<BigInteger>> tokenRangeMap = ArrayListMultimap.create();
 
         ring.stream()
@@ -716,15 +716,13 @@ public class CassandraDataLayer extends PartitionedDataLayer implements StartupV
 
                     replicas.put(range, instancesForRange);
 
-                    // If the range is up-to MAX_TOKEN and there's no instance which owns MAX_TOKEN
-                    // in the ring, then assign the owner of this range to the instance with the smallest
-                    // MAX_TOKEN to account for wraparound.
+                    // If the range end is equal to MAX_TOKEN and the token of the last instance is
+                    // not equal MAX_TOKEN, then the owner of this range should be the instance with
+                    // the smallest token. Otherwise, find the owner based on token equality.
                     CassandraInstance tokenOwner;
-                    if (rangeEnd.equals(partitioner.maxToken()) && instances.stream().noneMatch(x -> new BigInteger(x.token()).equals(partitioner.maxToken())))
+                    if (rangeEnd.equals(partitioner.maxToken()) && !new BigInteger(instances.get(instances.size() - 1).token()).equals(partitioner.maxToken()))
                     {
-                        tokenOwner = instances.stream()
-                                .min(Comparator.comparing(instance -> new BigInteger(instance.token())))
-                                .get();
+                        tokenOwner = instances.get(0);
                     }
                     else
                     {

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/data/CassandraDataLayer.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/data/CassandraDataLayer.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -50,7 +51,11 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
 import com.google.common.collect.Range;
+import com.google.common.collect.RangeMap;
+import com.google.common.collect.TreeRangeMap;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -62,6 +67,7 @@ import o.a.c.sidecar.client.shaded.common.response.ListSnapshotFilesResponse;
 import o.a.c.sidecar.client.shaded.common.response.NodeSettings;
 import o.a.c.sidecar.client.shaded.common.response.RingResponse;
 import o.a.c.sidecar.client.shaded.common.response.SchemaResponse;
+import o.a.c.sidecar.client.shaded.common.response.TokenRangeReplicasResponse;
 import org.apache.cassandra.analytics.stats.Stats;
 import org.apache.cassandra.bridge.BigNumberConfig;
 import org.apache.cassandra.bridge.BigNumberConfigImpl;
@@ -300,7 +306,10 @@ public class CassandraDataLayer extends PartitionedDataLayer implements StartupV
         udts.forEach(udt -> LOGGER.info("Adding schema UDT: '{}'", udt));
 
         cqlTable = bridge().buildSchema(createStmt, keyspace, replicationFactor, partitioner, udts, null, indexCount, false);
-        CassandraRing ring = createCassandraRingFromRing(partitioner, replicationFactor, ringFuture.get());
+
+        CompletableFuture<TokenRangeReplicasResponse> tokenRangeReplicasFuture = sidecar.tokenRangeReplicas(
+            new ArrayList<>(clusterConfig), maybeQuotedKeyspace);
+        CassandraRing ring = createCassandraRingFromTokenRangeReplicas(partitioner, replicationFactor, ringFuture.get(), tokenRangeReplicasFuture.get());
 
         int effectiveNumberOfCores = sizingFuture.get();
         tokenPartitioner = new TokenPartitioner(ring, options.defaultParallelism(), effectiveNumberOfCores);
@@ -654,6 +663,7 @@ public class CassandraDataLayer extends PartitionedDataLayer implements StartupV
 
     /* Internal Cassandra SSTable */
 
+    // TODO(andrew.johnson): Remove
     @VisibleForTesting
     public CassandraRing createCassandraRingFromRing(Partitioner partitioner,
                                                      ReplicationFactor replicationFactor,
@@ -664,7 +674,72 @@ public class CassandraDataLayer extends PartitionedDataLayer implements StartupV
                                                   .filter(status -> datacenter == null || datacenter.equalsIgnoreCase(status.datacenter()))
                                                   .map(status -> new CassandraInstance(status.token(), status.fqdn(), status.datacenter()))
                                                   .collect(Collectors.toList());
+
         return new CassandraRing(partitioner, keyspace, replicationFactor, instances);
+    }
+
+    @VisibleForTesting
+    public CassandraRing createCassandraRingFromTokenRangeReplicas(Partitioner partitioner,
+                                                     ReplicationFactor replicationFactor,
+                                                     RingResponse ring,
+                                                     TokenRangeReplicasResponse tokenRangeReplicas)
+    {
+        List<CassandraInstance> instances = new ArrayList<>();
+        Map<String, CassandraInstance> addressAndPortToInstance = new HashMap<>();
+
+        // Map of Token Ranges to Read Replicas
+        RangeMap<BigInteger, List<CassandraInstance>> replicas = TreeRangeMap.create();
+
+        // Map of Instances -> Owned Token Ranges
+        Multimap<CassandraInstance, Range<BigInteger>> tokenRangeMap = ArrayListMultimap.create();
+
+        ring.stream()
+                .filter(status -> datacenter == null || datacenter.equalsIgnoreCase(status.datacenter()))
+                .sorted(Comparator.comparing(instance -> new BigInteger(instance.token())))
+                .forEach(ringEntry ->
+                {
+                    CassandraInstance instance = new CassandraInstance(ringEntry.token(), ringEntry.fqdn(), ringEntry.datacenter());
+                    instances.add(instance);
+                    addressAndPortToInstance.put(String.format("%s:%d", ringEntry.address(), ringEntry.port()), instance);
+                });
+
+        tokenRangeReplicas.readReplicas()
+                .forEach(replicaInfo ->
+                {
+                    BigInteger rangeStart = new BigInteger(replicaInfo.start());
+                    BigInteger rangeEnd = new BigInteger(replicaInfo.end());
+                    Range<BigInteger> range = Range.openClosed(rangeStart, rangeEnd);
+
+                    List<CassandraInstance> instancesForRange = replicaInfo.replicasByDatacenter()
+                            .get(datacenter)
+                            .stream()
+                            .map(addressAndPortToInstance::get)
+                            .collect(Collectors.toList());
+
+                    replicas.put(range, instancesForRange);
+
+                    // If the range is up-to MAX_TOKEN and there's no instance which owns MAX_TOKEN
+                    // in the ring, then assign the owner of this range to the instance with the smallest
+                    // MAX_TOKEN to account for wraparound.
+                    CassandraInstance tokenOwner;
+                    if (rangeEnd.equals(partitioner.maxToken()) && instances.stream().noneMatch(x -> new BigInteger(x.token()).equals(partitioner.maxToken())))
+                    {
+                        tokenOwner = instances.stream()
+                                .min(Comparator.comparing(instance -> new BigInteger(instance.token())))
+                                .get();
+                    }
+                    else
+                    {
+                        tokenOwner = instancesForRange.stream()
+                                .filter(instance -> new BigInteger(instance.token()).equals(rangeEnd))
+                                .findFirst()
+                                .get();
+                    }
+
+                    tokenRangeMap.put(tokenOwner, range);
+                });
+
+        return new CassandraRing(partitioner, keyspace, replicationFactor, instances, replicas, tokenRangeMap);
     }
 
     // Startup Validation

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/data/CassandraDataLayerTests.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/data/CassandraDataLayerTests.java
@@ -19,14 +19,20 @@
 
 package org.apache.cassandra.spark.data;
 
+import java.math.BigInteger;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Range;
+import o.a.c.sidecar.client.shaded.common.response.TokenRangeReplicasResponse;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
+import static org.apache.cassandra.spark.data.CassandraDataLayer.dcReplicasByRange;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class CassandraDataLayerTests
@@ -63,5 +69,37 @@ class CassandraDataLayerTests
         .isEqualTo(expectedClearSnapshotStrategy.shouldClearOnCompletion());
         assertThat(clearSnapshotStrategy.hasTTL()).isEqualTo(expectedClearSnapshotStrategy.hasTTL());
         assertThat(clearSnapshotStrategy.ttl()).isEqualTo(expectedClearSnapshotStrategy.ttl());
+    }
+
+    @Test
+    void testDcReplicasByRangeMultiDC()
+    {
+        List<TokenRangeReplicasResponse.ReplicaInfo> readReplicas = List.of(
+                new TokenRangeReplicasResponse.ReplicaInfo("-5000", "5000",
+                        Map.of(
+                            "dc1", List.of("localhost1:9000", "localhost2:9001", "localhost3:9002"),
+                            "dc2", List.of("localhost4:9003"))));
+
+        Map<String, TokenRangeReplicasResponse.ReplicaMetadata> replicaMetadata = Map.of(
+                "localhost1:9000", new TokenRangeReplicasResponse.ReplicaMetadata("Normal", "Up", "replica1-1", "localhost1", 9000, "dc1"),
+                "localhost2:9001", new TokenRangeReplicasResponse.ReplicaMetadata("Normal", "Up", "replica1-2", "localhost2", 9001, "dc1"),
+                "localhost3:9002", new TokenRangeReplicasResponse.ReplicaMetadata("Normal", "Up", "replica1-3", "localhost3", 9002, "dc1"),
+                "localhost4:9003", new TokenRangeReplicasResponse.ReplicaMetadata("Normal", "Up", "replica2-1", "localhost4", 9003, "dc2")
+        );
+
+        TokenRangeReplicasResponse response =
+                new TokenRangeReplicasResponse(Collections.EMPTY_LIST, readReplicas, replicaMetadata);
+
+        Map<Range<BigInteger>, List<String>> expectedDc1 = Map.of(
+                Range.openClosed(new BigInteger("-5000"), new BigInteger("5000")), List.of("replica1-1", "replica1-2", "replica1-3"));
+        Map<Range<BigInteger>, List<String>> actualDc1 = dcReplicasByRange(response, "dc1");
+
+        assertThat(actualDc1).isEqualTo(expectedDc1);
+
+        Map<Range<BigInteger>, List<String>> expectedDc2 = Map.of(
+                Range.openClosed(new BigInteger("-5000"), new BigInteger("5000")), List.of("replica2-1"));
+        Map<Range<BigInteger>, List<String>> actualDc2 = dcReplicasByRange(response, "dc2");
+
+        assertThat(actualDc2).isEqualTo(expectedDc2);
     }
 }

--- a/cassandra-analytics-integration-tests/src/test/java/org/apache/cassandra/analytics/CassandraAnalyticsSimpleTest.java
+++ b/cassandra-analytics-integration-tests/src/test/java/org/apache/cassandra/analytics/CassandraAnalyticsSimpleTest.java
@@ -56,7 +56,7 @@ class CassandraAnalyticsSimpleTest extends SharedClusterSparkIntegrationTestBase
 
     @ParameterizedTest
     @MethodSource("options")
-    @Timeout(value = 90) // 30 seconds
+    @Timeout(value = 30) // 30 seconds
     void runSampleJob(Integer ttl, Long timestamp, QualifiedName tableName)
     {
         Map<String, String> writerOptions = new HashMap<>();

--- a/cassandra-analytics-integration-tests/src/test/java/org/apache/cassandra/analytics/CassandraAnalyticsSimpleTest.java
+++ b/cassandra-analytics-integration-tests/src/test/java/org/apache/cassandra/analytics/CassandraAnalyticsSimpleTest.java
@@ -56,7 +56,7 @@ class CassandraAnalyticsSimpleTest extends SharedClusterSparkIntegrationTestBase
 
     @ParameterizedTest
     @MethodSource("options")
-    @Timeout(value = 30) // 30 seconds
+    @Timeout(value = 90) // 30 seconds
     void runSampleJob(Integer ttl, Long timestamp, QualifiedName tableName)
     {
         Map<String, String> writerOptions = new HashMap<>();


### PR DESCRIPTION
Initial implementation for using tokenRangeReplicas endpoint rather than
calculating token ranges and replicas within the library. There's a fair amount
of code which can be removed afterwards, but wanted to keep the PR small.