### PR TITLE
CASSANALYTICS-130 Support per-instance sidecar port resolution in CDC client

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,6 @@
 0.4.0
 -----
+ * Support per-instance sidecar port resolution in CDC client (CASSANALYTICS-130)
  * Change log level for logs in CassandraSchema to debug level to avoid log spamming (CASSANALYTICS-149)
  * Pass SidecarCdcClient as a constructor parameter to avoid thread/resource leaks (CASSANALYTICS-142)
  * Support extended deletion time in CDC for Cassandra 5.0

--- a/cassandra-analytics-cdc-sidecar/src/main/java/org/apache/cassandra/cdc/sidecar/SidecarCdcBuilder.java
+++ b/cassandra-analytics-cdc-sidecar/src/main/java/org/apache/cassandra/cdc/sidecar/SidecarCdcBuilder.java
@@ -19,8 +19,6 @@
 
 package org.apache.cassandra.cdc.sidecar;
 
-import java.util.function.Function;
-
 import com.google.common.base.Preconditions;
 
 import org.apache.cassandra.cdc.CdcBuilder;
@@ -63,12 +61,6 @@ public class SidecarCdcBuilder extends CdcBuilder
     public SidecarCdcBuilder withClusterConfigProvider(ClusterConfigProvider clusterConfigProvider)
     {
         this.clusterConfigProvider = clusterConfigProvider;
-        return this;
-    }
-
-    public SidecarCdcBuilder withPortResolver(@NotNull Function<String, Integer> portResolver)
-    {
-        this.sidecarCdcClient = sidecarCdcClient.withPortResolver(portResolver);
         return this;
     }
 

--- a/cassandra-analytics-cdc-sidecar/src/main/java/org/apache/cassandra/cdc/sidecar/SidecarCdcBuilder.java
+++ b/cassandra-analytics-cdc-sidecar/src/main/java/org/apache/cassandra/cdc/sidecar/SidecarCdcBuilder.java
@@ -19,10 +19,6 @@
 
 package org.apache.cassandra.cdc.sidecar;
 
-import java.io.IOException;
-import java.util.Map;
-import java.util.function.Function;
-
 import com.google.common.base.Preconditions;
 
 import org.apache.cassandra.cdc.CdcBuilder;
@@ -31,22 +27,14 @@ import org.apache.cassandra.cdc.api.EventConsumer;
 import org.apache.cassandra.cdc.api.SchemaSupplier;
 import org.apache.cassandra.cdc.api.TokenRangeSupplier;
 import org.apache.cassandra.cdc.stats.ICdcStats;
-import org.apache.cassandra.clients.Sidecar;
-import org.apache.cassandra.secrets.SecretsProvider;
-import o.a.c.sidecar.client.shaded.client.SidecarClient;
-import org.apache.cassandra.spark.data.partitioner.CassandraInstance;
 import org.apache.cassandra.spark.utils.AsyncExecutor;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 @SuppressWarnings("unused")
 public class SidecarCdcBuilder extends CdcBuilder
 {
     protected ClusterConfigProvider clusterConfigProvider;
     protected SidecarCdcClient sidecarCdcClient;
-    protected SidecarCdcClient.ClientConfig clientConfig;
-    @NotNull
-    protected Function<CassandraInstance, Integer> portResolver;
     protected SidecarDownMonitor downMonitor = SidecarDownMonitor.STUB;
     protected ReplicationFactorSupplier replicationFactorSupplier = ReplicationFactorSupplier.DEFAULT;
     protected SidecarCdcStats sidecarCdcStats = SidecarCdcStats.STUB;
@@ -61,64 +49,13 @@ public class SidecarCdcBuilder extends CdcBuilder
                       SchemaSupplier schemaSupplier,
                       TokenRangeSupplier tokenRangeSupplier,
                       SidecarCdcClient sidecarCdcClient,
-                      @NotNull Function<String, Integer> portResolver,
-                      CdcSidecarInstancesProvider sidecarInstancesProvider,
-                      SidecarCdcClient.ClientConfig clientConfig,
-                      SecretsProvider secretsProvider,
-                      ICdcStats cdcStats) throws IOException
-    {
-        this(
-        jobId,
-        partitionId,
-        cdcOptions,
-        clusterConfigProvider,
-        eventConsumer,
-        schemaSupplier,
-        tokenRangeSupplier,
-        buildPortResolver(sidecarInstancesProvider, clientConfig),
-        clientConfig,
-        Sidecar.from(new SimpleSidecarInstancesProvider(sidecarInstancesProvider.instances().stream()
-                                                                                .map(i -> new SidecarInstanceImpl(i.hostname(), i.port()))
-                                                                                .collect(Collectors.toList())),
-                     clientConfig.toGenericSidecarConfig(), secretsProvider),
-        cdcStats
-        );
-    }
-
-    SidecarCdcBuilder(@NotNull String jobId,
-                      int partitionId,
-                      CdcOptions cdcOptions,
-                      ClusterConfigProvider clusterConfigProvider,
-                      EventConsumer eventConsumer,
-                      SchemaSupplier schemaSupplier,
-                      TokenRangeSupplier tokenRangeSupplier,
-                      @Nullable Function<CassandraInstance, Integer> portResolver,
-                      SidecarCdcClient.ClientConfig clientConfig,
-                      SidecarClient sidecarClient,
                       ICdcStats cdcStats)
     {
         super(jobId, partitionId, eventConsumer, schemaSupplier);
         this.clusterConfigProvider = clusterConfigProvider;
         this.sidecarCdcClient = sidecarCdcClient;
-        this.portResolver = portResolver;
-        this.clientConfig = clientConfig;
-        this.portResolver = portResolver != null ? portResolver : ignored -> clientConfig.effectivePort();
-        this.sidecarCdcClient = new SidecarCdcClient(clientConfig, sidecarClient, cdcStats, this.portResolver);
         withCdcOptions(cdcOptions);
         withTokenRangeSupplier(tokenRangeSupplier);
-    }
-
-    /**
-     * Builds a port resolver function from the {@link CdcSidecarInstancesProvider}. The resolver performs
-     * an O(1) map lookup keyed by hostname, falling back to the configured effective port.
-     */
-    static Function<CassandraInstance, Integer> buildPortResolver(@NotNull CdcSidecarInstancesProvider provider,
-                                                                   @NotNull SidecarCdcClient.ClientConfig clientConfig)
-    {
-        Map<String, Integer> portMap = provider.instances().stream()
-                                               .collect(Collectors.toMap(CdcSidecarInstance::hostname,
-                                                                         CdcSidecarInstance::port));
-        return instance -> portMap.getOrDefault(instance.nodeName(), clientConfig.effectivePort());
     }
 
     public SidecarCdcBuilder withClusterConfigProvider(ClusterConfigProvider clusterConfigProvider)
@@ -130,21 +67,6 @@ public class SidecarCdcBuilder extends CdcBuilder
     public SidecarCdcBuilder withDownMonitor(SidecarDownMonitor downMonitor)
     {
         this.downMonitor = downMonitor;
-        return this;
-    }
-
-    public SidecarCdcBuilder withPortResolver(@NotNull Function<CassandraInstance, Integer> portResolver)
-    {
-        this.portResolver = portResolver;
-        return this;
-    }
-
-    public SidecarCdcBuilder withSidecarClient(SidecarCdcClient.ClientConfig clientConfig,
-                                               SidecarClient sidecarClient,
-                                               ICdcStats cdcStats)
-    {
-        this.clientConfig = clientConfig;
-        this.sidecarCdcClient = new SidecarCdcClient(clientConfig, sidecarClient, cdcStats, portResolver);
         return this;
     }
 

--- a/cassandra-analytics-cdc-sidecar/src/main/java/org/apache/cassandra/cdc/sidecar/SidecarCdcBuilder.java
+++ b/cassandra-analytics-cdc-sidecar/src/main/java/org/apache/cassandra/cdc/sidecar/SidecarCdcBuilder.java
@@ -19,6 +19,8 @@
 
 package org.apache.cassandra.cdc.sidecar;
 
+import java.io.IOException;
+import java.util.Map;
 import java.util.function.Function;
 
 import com.google.common.base.Preconditions;
@@ -29,16 +31,22 @@ import org.apache.cassandra.cdc.api.EventConsumer;
 import org.apache.cassandra.cdc.api.SchemaSupplier;
 import org.apache.cassandra.cdc.api.TokenRangeSupplier;
 import org.apache.cassandra.cdc.stats.ICdcStats;
+import org.apache.cassandra.clients.Sidecar;
+import org.apache.cassandra.secrets.SecretsProvider;
+import o.a.c.sidecar.client.shaded.client.SidecarClient;
+import org.apache.cassandra.spark.data.partitioner.CassandraInstance;
 import org.apache.cassandra.spark.utils.AsyncExecutor;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 @SuppressWarnings("unused")
 public class SidecarCdcBuilder extends CdcBuilder
 {
     protected ClusterConfigProvider clusterConfigProvider;
     protected SidecarCdcClient sidecarCdcClient;
+    protected SidecarCdcClient.ClientConfig clientConfig;
     @NotNull
-    protected Function<String, Integer> portResolver;
+    protected Function<CassandraInstance, Integer> portResolver;
     protected SidecarDownMonitor downMonitor = SidecarDownMonitor.STUB;
     protected ReplicationFactorSupplier replicationFactorSupplier = ReplicationFactorSupplier.DEFAULT;
     protected SidecarCdcStats sidecarCdcStats = SidecarCdcStats.STUB;
@@ -54,33 +62,63 @@ public class SidecarCdcBuilder extends CdcBuilder
                       TokenRangeSupplier tokenRangeSupplier,
                       SidecarCdcClient sidecarCdcClient,
                       @NotNull Function<String, Integer> portResolver,
+                      CdcSidecarInstancesProvider sidecarInstancesProvider,
+                      SidecarCdcClient.ClientConfig clientConfig,
+                      SecretsProvider secretsProvider,
+                      ICdcStats cdcStats) throws IOException
+    {
+        this(
+        jobId,
+        partitionId,
+        cdcOptions,
+        clusterConfigProvider,
+        eventConsumer,
+        schemaSupplier,
+        tokenRangeSupplier,
+        buildPortResolver(sidecarInstancesProvider, clientConfig),
+        clientConfig,
+        Sidecar.from(new SimpleSidecarInstancesProvider(sidecarInstancesProvider.instances().stream()
+                                                                                .map(i -> new SidecarInstanceImpl(i.hostname(), i.port()))
+                                                                                .collect(Collectors.toList())),
+                     clientConfig.toGenericSidecarConfig(), secretsProvider),
+        cdcStats
+        );
+    }
+
+    SidecarCdcBuilder(@NotNull String jobId,
+                      int partitionId,
+                      CdcOptions cdcOptions,
+                      ClusterConfigProvider clusterConfigProvider,
+                      EventConsumer eventConsumer,
+                      SchemaSupplier schemaSupplier,
+                      TokenRangeSupplier tokenRangeSupplier,
+                      @Nullable Function<CassandraInstance, Integer> portResolver,
+                      SidecarCdcClient.ClientConfig clientConfig,
+                      SidecarClient sidecarClient,
                       ICdcStats cdcStats)
     {
         super(jobId, partitionId, eventConsumer, schemaSupplier);
         this.clusterConfigProvider = clusterConfigProvider;
         this.sidecarCdcClient = sidecarCdcClient;
         this.portResolver = portResolver;
+        this.clientConfig = clientConfig;
+        this.portResolver = portResolver != null ? portResolver : ignored -> clientConfig.effectivePort();
+        this.sidecarCdcClient = new SidecarCdcClient(clientConfig, sidecarClient, cdcStats, this.portResolver);
         withCdcOptions(cdcOptions);
         withTokenRangeSupplier(tokenRangeSupplier);
     }
 
     /**
-     * Builds a port resolver function from the {@link CdcSidecarInstancesProvider}. The resolver looks up
-     * the port for a given hostname from the provider, falling back to the configured effective port.
+     * Builds a port resolver function from the {@link CdcSidecarInstancesProvider}. The resolver performs
+     * an O(1) map lookup keyed by hostname, falling back to the configured effective port.
      */
-    static Function<String, Integer> buildPortResolver(@NotNull CdcSidecarInstancesProvider provider,
-                                                       @NotNull SidecarCdcClient.ClientConfig clientConfig)
+    static Function<CassandraInstance, Integer> buildPortResolver(@NotNull CdcSidecarInstancesProvider provider,
+                                                                   @NotNull SidecarCdcClient.ClientConfig clientConfig)
     {
-        return hostname -> {
-            for (CdcSidecarInstance instance : provider.instances())
-            {
-                if (hostname.equals(instance.hostname()))
-                {
-                    return instance.port();
-                }
-            }
-            return clientConfig.effectivePort();
-        };
+        Map<String, Integer> portMap = provider.instances().stream()
+                                               .collect(Collectors.toMap(CdcSidecarInstance::hostname,
+                                                                         CdcSidecarInstance::port));
+        return instance -> portMap.getOrDefault(instance.nodeName(), clientConfig.effectivePort());
     }
 
     public SidecarCdcBuilder withClusterConfigProvider(ClusterConfigProvider clusterConfigProvider)
@@ -92,6 +130,21 @@ public class SidecarCdcBuilder extends CdcBuilder
     public SidecarCdcBuilder withDownMonitor(SidecarDownMonitor downMonitor)
     {
         this.downMonitor = downMonitor;
+        return this;
+    }
+
+    public SidecarCdcBuilder withPortResolver(@NotNull Function<CassandraInstance, Integer> portResolver)
+    {
+        this.portResolver = portResolver;
+        return this;
+    }
+
+    public SidecarCdcBuilder withSidecarClient(SidecarCdcClient.ClientConfig clientConfig,
+                                               SidecarClient sidecarClient,
+                                               ICdcStats cdcStats)
+    {
+        this.clientConfig = clientConfig;
+        this.sidecarCdcClient = new SidecarCdcClient(clientConfig, sidecarClient, cdcStats, portResolver);
         return this;
     }
 

--- a/cassandra-analytics-cdc-sidecar/src/main/java/org/apache/cassandra/cdc/sidecar/SidecarCdcBuilder.java
+++ b/cassandra-analytics-cdc-sidecar/src/main/java/org/apache/cassandra/cdc/sidecar/SidecarCdcBuilder.java
@@ -19,6 +19,8 @@
 
 package org.apache.cassandra.cdc.sidecar;
 
+import java.util.function.Function;
+
 import com.google.common.base.Preconditions;
 
 import org.apache.cassandra.cdc.CdcBuilder;
@@ -35,6 +37,8 @@ public class SidecarCdcBuilder extends CdcBuilder
 {
     protected ClusterConfigProvider clusterConfigProvider;
     protected SidecarCdcClient sidecarCdcClient;
+    @NotNull
+    protected Function<String, Integer> portResolver;
     protected SidecarDownMonitor downMonitor = SidecarDownMonitor.STUB;
     protected ReplicationFactorSupplier replicationFactorSupplier = ReplicationFactorSupplier.DEFAULT;
     protected SidecarCdcStats sidecarCdcStats = SidecarCdcStats.STUB;
@@ -49,13 +53,34 @@ public class SidecarCdcBuilder extends CdcBuilder
                       SchemaSupplier schemaSupplier,
                       TokenRangeSupplier tokenRangeSupplier,
                       SidecarCdcClient sidecarCdcClient,
+                      @NotNull Function<String, Integer> portResolver,
                       ICdcStats cdcStats)
     {
         super(jobId, partitionId, eventConsumer, schemaSupplier);
         this.clusterConfigProvider = clusterConfigProvider;
         this.sidecarCdcClient = sidecarCdcClient;
+        this.portResolver = portResolver;
         withCdcOptions(cdcOptions);
         withTokenRangeSupplier(tokenRangeSupplier);
+    }
+
+    /**
+     * Builds a port resolver function from the {@link CdcSidecarInstancesProvider}. The resolver looks up
+     * the port for a given hostname from the provider, falling back to the configured effective port.
+     */
+    static Function<String, Integer> buildPortResolver(@NotNull CdcSidecarInstancesProvider provider,
+                                                       @NotNull SidecarCdcClient.ClientConfig clientConfig)
+    {
+        return hostname -> {
+            for (CdcSidecarInstance instance : provider.instances())
+            {
+                if (hostname.equals(instance.hostname()))
+                {
+                    return instance.port();
+                }
+            }
+            return clientConfig.effectivePort();
+        };
     }
 
     public SidecarCdcBuilder withClusterConfigProvider(ClusterConfigProvider clusterConfigProvider)

--- a/cassandra-analytics-cdc-sidecar/src/main/java/org/apache/cassandra/cdc/sidecar/SidecarCdcBuilder.java
+++ b/cassandra-analytics-cdc-sidecar/src/main/java/org/apache/cassandra/cdc/sidecar/SidecarCdcBuilder.java
@@ -19,6 +19,8 @@
 
 package org.apache.cassandra.cdc.sidecar;
 
+import java.util.function.Function;
+
 import com.google.common.base.Preconditions;
 
 import org.apache.cassandra.cdc.CdcBuilder;
@@ -61,6 +63,12 @@ public class SidecarCdcBuilder extends CdcBuilder
     public SidecarCdcBuilder withClusterConfigProvider(ClusterConfigProvider clusterConfigProvider)
     {
         this.clusterConfigProvider = clusterConfigProvider;
+        return this;
+    }
+
+    public SidecarCdcBuilder withPortResolver(@NotNull Function<String, Integer> portResolver)
+    {
+        this.sidecarCdcClient = sidecarCdcClient.withPortResolver(portResolver);
         return this;
     }
 

--- a/cassandra-analytics-cdc-sidecar/src/main/java/org/apache/cassandra/cdc/sidecar/SidecarCdcClient.java
+++ b/cassandra-analytics-cdc-sidecar/src/main/java/org/apache/cassandra/cdc/sidecar/SidecarCdcClient.java
@@ -104,19 +104,6 @@ public class SidecarCdcClient implements AutoCloseable
     }
 
     /**
-     * Returns a new {@link SidecarCdcClient} that is identical to this one except that it uses
-     * the supplied {@code portResolver}. The underlying {@link SidecarClient} and all other
-     * configuration are reused, so no new HTTP connections or thread pools are created.
-     *
-     * @param portResolver function that maps a Sidecar node hostname to its port
-     * @return a new client with the given port resolver
-     */
-    public SidecarCdcClient withPortResolver(@NotNull Function<String, Integer> portResolver)
-    {
-        return new SidecarCdcClient(config, sidecarClient, stats, portResolver);
-    }
-
-    /**
      * Closes the underlying {@link SidecarClient} and releases associated resources (e.g. thread pools,
      * HTTP connections).
      *

--- a/cassandra-analytics-cdc-sidecar/src/main/java/org/apache/cassandra/cdc/sidecar/SidecarCdcClient.java
+++ b/cassandra-analytics-cdc-sidecar/src/main/java/org/apache/cassandra/cdc/sidecar/SidecarCdcClient.java
@@ -64,21 +64,22 @@ public class SidecarCdcClient implements AutoCloseable
     final SidecarClient sidecarClient;
     final ICdcStats stats;
     @NotNull
-    final Function<CassandraInstance, Integer> portResolver;
+    final Function<String, Integer> portResolver;
 
     public SidecarCdcClient(ClientConfig clientConfig,
                             CdcSidecarInstancesProvider instancesProvider,
                             SecretsProvider secretsProvider,
                             ICdcStats cdcStats) throws IOException
     {
-        this(clientConfig, instancesProvider, secretsProvider, cdcStats, null);
+        this(clientConfig, instancesProvider, secretsProvider, cdcStats,
+             ignored -> clientConfig.effectivePort());
     }
 
     public SidecarCdcClient(ClientConfig clientConfig,
                             CdcSidecarInstancesProvider instancesProvider,
                             SecretsProvider secretsProvider,
                             ICdcStats cdcStats,
-                            @Nullable Function<CassandraInstance, Integer> portResolver) throws IOException
+                            @NotNull Function<String, Integer> portResolver) throws IOException
     {
         this(clientConfig,
              Sidecar.from(new SimpleSidecarInstancesProvider(instancesProvider.instances()
@@ -88,13 +89,13 @@ public class SidecarCdcClient implements AutoCloseable
                           clientConfig.toGenericSidecarConfig(),
                           secretsProvider),
              cdcStats,
-             portResolver != null ? portResolver : buildPortResolver(instancesProvider, clientConfig));
+             portResolver);
     }
 
     SidecarCdcClient(ClientConfig config,
                      SidecarClient sidecarClient,
                      ICdcStats stats,
-                     @NotNull Function<CassandraInstance, Integer> portResolver)
+                     @NotNull Function<String, Integer> portResolver)
     {
         this.config = config;
         this.sidecarClient = sidecarClient;
@@ -103,17 +104,16 @@ public class SidecarCdcClient implements AutoCloseable
     }
 
     /**
-     * Builds a port resolver function from the {@link CdcSidecarInstancesProvider}. The instances are
-     * indexed into a hostname-keyed map once (O(n)) at construction time, so that each subsequent
-     * resolution call is O(1). Unknown hostnames fall back to the configured effective port.
+     * Returns a new {@link SidecarCdcClient} that is identical to this one except that it uses
+     * the supplied {@code portResolver}. The underlying {@link SidecarClient} and all other
+     * configuration are reused, so no new HTTP connections or thread pools are created.
+     *
+     * @param portResolver function that maps a Sidecar node hostname to its port
+     * @return a new client with the given port resolver
      */
-    static Function<CassandraInstance, Integer> buildPortResolver(@NotNull CdcSidecarInstancesProvider provider,
-                                                                   @NotNull ClientConfig clientConfig)
+    public SidecarCdcClient withPortResolver(@NotNull Function<String, Integer> portResolver)
     {
-        Map<String, Integer> portMap = provider.instances().stream()
-                                               .collect(Collectors.toMap(CdcSidecarInstance::hostname,
-                                                                         CdcSidecarInstance::port));
-        return instance -> portMap.getOrDefault(instance.nodeName(), clientConfig.effectivePort());
+        return new SidecarCdcClient(config, sidecarClient, stats, portResolver);
     }
 
     /**
@@ -220,7 +220,7 @@ public class SidecarCdcClient implements AutoCloseable
             @Override
             public int port()
             {
-                return portResolver.apply(instance);
+                return portResolver.apply(instance.nodeName());
             }
 
             @Override

--- a/cassandra-analytics-cdc-sidecar/src/main/java/org/apache/cassandra/cdc/sidecar/SidecarCdcClient.java
+++ b/cassandra-analytics-cdc-sidecar/src/main/java/org/apache/cassandra/cdc/sidecar/SidecarCdcClient.java
@@ -64,7 +64,7 @@ public class SidecarCdcClient implements AutoCloseable
     final SidecarClient sidecarClient;
     final ICdcStats stats;
     @NotNull
-    final Function<String, Integer> portResolver;
+    final Function<CassandraInstance, Integer> portResolver;
 
     public SidecarCdcClient(ClientConfig clientConfig,
                             CdcSidecarInstancesProvider instancesProvider,
@@ -85,13 +85,13 @@ public class SidecarCdcClient implements AutoCloseable
                              SidecarClient sidecarClient,
                              ICdcStats stats)
     {
-        this(config, sidecarClient, stats, hostname -> config.effectivePort());
+        this(config, sidecarClient, stats, ignored -> config.effectivePort());
     }
 
     public SidecarCdcClient(ClientConfig config,
                             SidecarClient sidecarClient,
                             ICdcStats stats,
-                            @NotNull Function<String, Integer> portResolver)
+                            @NotNull Function<CassandraInstance, Integer> portResolver)
     {
         this.config = config;
         this.sidecarClient = sidecarClient;
@@ -203,7 +203,7 @@ public class SidecarCdcClient implements AutoCloseable
             @Override
             public int port()
             {
-                return portResolver.apply(instance.nodeName());
+                return portResolver.apply(instance);
             }
 
             @Override

--- a/cassandra-analytics-cdc-sidecar/src/main/java/org/apache/cassandra/cdc/sidecar/SidecarCdcClient.java
+++ b/cassandra-analytics-cdc-sidecar/src/main/java/org/apache/cassandra/cdc/sidecar/SidecarCdcClient.java
@@ -71,6 +71,15 @@ public class SidecarCdcClient implements AutoCloseable
                             SecretsProvider secretsProvider,
                             ICdcStats cdcStats) throws IOException
     {
+        this(clientConfig, instancesProvider, secretsProvider, cdcStats, null);
+    }
+
+    public SidecarCdcClient(ClientConfig clientConfig,
+                            CdcSidecarInstancesProvider instancesProvider,
+                            SecretsProvider secretsProvider,
+                            ICdcStats cdcStats,
+                            @Nullable Function<CassandraInstance, Integer> portResolver) throws IOException
+    {
         this(clientConfig,
              Sidecar.from(new SimpleSidecarInstancesProvider(instancesProvider.instances()
                                                                               .stream()
@@ -78,25 +87,32 @@ public class SidecarCdcClient implements AutoCloseable
                                                                               .collect(Collectors.toList())),
                           clientConfig.toGenericSidecarConfig(),
                           secretsProvider),
-             cdcStats);
+             cdcStats,
+             portResolver != null ? portResolver : buildPortResolver(instancesProvider, clientConfig));
     }
 
-    private SidecarCdcClient(ClientConfig config,
-                             SidecarClient sidecarClient,
-                             ICdcStats stats)
-    {
-        this(config, sidecarClient, stats, ignored -> config.effectivePort());
-    }
-
-    public SidecarCdcClient(ClientConfig config,
-                            SidecarClient sidecarClient,
-                            ICdcStats stats,
-                            @NotNull Function<CassandraInstance, Integer> portResolver)
+    SidecarCdcClient(ClientConfig config,
+                     SidecarClient sidecarClient,
+                     ICdcStats stats,
+                     @NotNull Function<CassandraInstance, Integer> portResolver)
     {
         this.config = config;
         this.sidecarClient = sidecarClient;
         this.stats = stats;
         this.portResolver = portResolver;
+    }
+
+    /**
+     * Builds a port resolver function from the {@link CdcSidecarInstancesProvider}. The resolver performs
+     * an O(1) map lookup keyed by hostname, falling back to the configured effective port.
+     */
+    static Function<CassandraInstance, Integer> buildPortResolver(@NotNull CdcSidecarInstancesProvider provider,
+                                                                   @NotNull ClientConfig clientConfig)
+    {
+        Map<String, Integer> portMap = provider.instances().stream()
+                                               .collect(Collectors.toMap(CdcSidecarInstance::hostname,
+                                                                         CdcSidecarInstance::port));
+        return instance -> portMap.getOrDefault(instance.nodeName(), clientConfig.effectivePort());
     }
 
     /**

--- a/cassandra-analytics-cdc-sidecar/src/main/java/org/apache/cassandra/cdc/sidecar/SidecarCdcClient.java
+++ b/cassandra-analytics-cdc-sidecar/src/main/java/org/apache/cassandra/cdc/sidecar/SidecarCdcClient.java
@@ -64,7 +64,7 @@ public class SidecarCdcClient implements AutoCloseable
     final SidecarClient sidecarClient;
     final ICdcStats stats;
     @NotNull
-    final Function<String, Integer> portResolver;
+    final Function<CassandraInstance, Integer> portResolver;
 
     public SidecarCdcClient(ClientConfig clientConfig,
                             CdcSidecarInstancesProvider instancesProvider,
@@ -79,7 +79,7 @@ public class SidecarCdcClient implements AutoCloseable
                             CdcSidecarInstancesProvider instancesProvider,
                             SecretsProvider secretsProvider,
                             ICdcStats cdcStats,
-                            @NotNull Function<String, Integer> portResolver) throws IOException
+                            @NotNull Function<CassandraInstance, Integer> portResolver) throws IOException
     {
         this(clientConfig,
              Sidecar.from(new SimpleSidecarInstancesProvider(instancesProvider.instances()
@@ -95,7 +95,7 @@ public class SidecarCdcClient implements AutoCloseable
     SidecarCdcClient(ClientConfig config,
                      SidecarClient sidecarClient,
                      ICdcStats stats,
-                     @NotNull Function<String, Integer> portResolver)
+                     @NotNull Function<CassandraInstance, Integer> portResolver)
     {
         this.config = config;
         this.sidecarClient = sidecarClient;
@@ -207,7 +207,7 @@ public class SidecarCdcClient implements AutoCloseable
             @Override
             public int port()
             {
-                return portResolver.apply(instance.nodeName());
+                return portResolver.apply(instance);
             }
 
             @Override

--- a/cassandra-analytics-cdc-sidecar/src/main/java/org/apache/cassandra/cdc/sidecar/SidecarCdcClient.java
+++ b/cassandra-analytics-cdc-sidecar/src/main/java/org/apache/cassandra/cdc/sidecar/SidecarCdcClient.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import o.a.c.sidecar.client.shaded.common.utils.HttpRange;
@@ -45,6 +46,7 @@ import org.apache.cassandra.spark.exceptions.TransportFailureException;
 import org.apache.cassandra.spark.utils.MapUtils;
 import org.apache.cassandra.spark.utils.ThrowableUtils;
 import org.apache.cassandra.spark.utils.streaming.StreamConsumer;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import static org.apache.cassandra.spark.utils.Properties.DEFAULT_MAX_BUFFER_OVERRIDE;
@@ -61,6 +63,8 @@ public class SidecarCdcClient implements AutoCloseable
     final ClientConfig config;
     final SidecarClient sidecarClient;
     final ICdcStats stats;
+    @NotNull
+    final Function<String, Integer> portResolver;
 
     public SidecarCdcClient(ClientConfig clientConfig,
                             CdcSidecarInstancesProvider instancesProvider,
@@ -81,9 +85,18 @@ public class SidecarCdcClient implements AutoCloseable
                              SidecarClient sidecarClient,
                              ICdcStats stats)
     {
+        this(config, sidecarClient, stats, hostname -> config.effectivePort());
+    }
+
+    public SidecarCdcClient(ClientConfig config,
+                            SidecarClient sidecarClient,
+                            ICdcStats stats,
+                            @NotNull Function<String, Integer> portResolver)
+    {
         this.config = config;
         this.sidecarClient = sidecarClient;
         this.stats = stats;
+        this.portResolver = portResolver;
     }
 
     /**
@@ -190,7 +203,7 @@ public class SidecarCdcClient implements AutoCloseable
             @Override
             public int port()
             {
-                return config.effectivePort();
+                return portResolver.apply(instance.nodeName());
             }
 
             @Override

--- a/cassandra-analytics-cdc-sidecar/src/main/java/org/apache/cassandra/cdc/sidecar/SidecarCdcClient.java
+++ b/cassandra-analytics-cdc-sidecar/src/main/java/org/apache/cassandra/cdc/sidecar/SidecarCdcClient.java
@@ -103,8 +103,9 @@ public class SidecarCdcClient implements AutoCloseable
     }
 
     /**
-     * Builds a port resolver function from the {@link CdcSidecarInstancesProvider}. The resolver performs
-     * an O(1) map lookup keyed by hostname, falling back to the configured effective port.
+     * Builds a port resolver function from the {@link CdcSidecarInstancesProvider}. The instances are
+     * indexed into a hostname-keyed map once (O(n)) at construction time, so that each subsequent
+     * resolution call is O(1). Unknown hostnames fall back to the configured effective port.
      */
     static Function<CassandraInstance, Integer> buildPortResolver(@NotNull CdcSidecarInstancesProvider provider,
                                                                    @NotNull ClientConfig clientConfig)

--- a/cassandra-analytics-cdc-sidecar/src/test/java/org/apache/cassandra/cdc/sidecar/SidecarCdcTest.java
+++ b/cassandra-analytics-cdc-sidecar/src/test/java/org/apache/cassandra/cdc/sidecar/SidecarCdcTest.java
@@ -25,6 +25,8 @@ import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import o.a.c.sidecar.client.shaded.client.SidecarClient;
+import o.a.c.sidecar.client.shaded.client.SidecarInstance;
 import org.apache.cassandra.cdc.api.CdcOptions;
 import org.apache.cassandra.cdc.api.EventConsumer;
 import org.apache.cassandra.cdc.api.SchemaSupplier;
@@ -46,36 +48,31 @@ public class SidecarCdcTest
     @BeforeEach
     public void setup()
     {
-        String jobId = "test-job-123";
-        int partitionId = 0;
-        CdcOptions cdcOptions = mock(CdcOptions.class);
-        ClusterConfigProvider clusterConfigProvider = mock(ClusterConfigProvider.class);
-        EventConsumer eventConsumer = mock(EventConsumer.class);
-        SchemaSupplier schemaSupplier = mock(SchemaSupplier.class);
-        TokenRangeSupplier tokenRangeSupplier = mock(TokenRangeSupplier.class);
-        SidecarCdcClient mockSidecarCdcClient = mock(SidecarCdcClient.class);
-        ICdcStats cdcStats = mock(ICdcStats.class);
-
-        SidecarCdcBuilder builder = new SidecarCdcBuilder(
-            jobId,
-            partitionId,
-            cdcOptions,
-            clusterConfigProvider,
-            eventConsumer,
-            schemaSupplier,
-            tokenRangeSupplier,
-            mockSidecarCdcClient,
-            cdcStats
-        );
-
-        assertThat(builder).isNotNull();
-        assertThat(builder).isInstanceOf(SidecarCdcBuilder.class);
-        assertThat(builder.clusterConfigProvider).isEqualTo(clusterConfigProvider);
-        assertThat(builder.sidecarCdcClient).isEqualTo(mockSidecarCdcClient);
         mockSidecarClient = mock(SidecarClient.class);
         cdcStats = mock(ICdcStats.class);
     }
 
+    @Test
+    public void testBuilderMethodCreatesValidBuilder()
+    {
+        SidecarCdcClient mockSidecarCdcClient = mock(SidecarCdcClient.class);
+
+        SidecarCdcBuilder builder = new SidecarCdcBuilder(
+            "test-job-123",
+            0,
+            mock(CdcOptions.class),
+            mock(ClusterConfigProvider.class),
+            mock(EventConsumer.class),
+            mock(SchemaSupplier.class),
+            mock(TokenRangeSupplier.class),
+            mockSidecarCdcClient,
+            mock(ICdcStats.class)
+        );
+
+        assertThat(builder).isInstanceOf(SidecarCdcBuilder.class);
+        assertThat(builder.clusterConfigProvider).isNotNull();
+        assertThat(builder.sidecarCdcClient).isEqualTo(mockSidecarCdcClient);
+    }
 
     @Test
     public void testPerInstancePortResolution()
@@ -118,47 +115,37 @@ public class SidecarCdcTest
     {
         SidecarCdcClient.ClientConfig clientConfig = SidecarCdcClient.ClientConfig.create(7777, 3, 100L);
 
-        SidecarCdcClient client = new SidecarCdcClient(clientConfig, mockSidecarClient, cdcStats);
+        SidecarCdcClient client = new SidecarCdcClient(clientConfig, mockSidecarClient, cdcStats,
+                                                       ignored -> clientConfig.effectivePort());
 
         assertThat(client.toSidecarInstance(new CassandraInstance("0", "host1", "DC1")).port()).isEqualTo(7777);
     }
 
     @Test
-    public void testWithPortResolverOverridesDefault()
+    public void testBuildPortResolverFromProvider()
     {
-        SidecarCdcClient.ClientConfig clientConfig = SidecarCdcClient.ClientConfig.create(9042, 3, 100L);
-
-        SidecarCdcBuilder builder = new SidecarCdcBuilder(
-            "test-job",
-            0,
-            mock(CdcOptions.class),
-            mock(ClusterConfigProvider.class),
-            mock(EventConsumer.class),
-            mock(SchemaSupplier.class),
-            mock(TokenRangeSupplier.class),
-            null,  // use default portResolver: ignored -> clientConfig.effectivePort()
-            clientConfig,
-            mockSidecarClient,
-            cdcStats
+        List<CdcSidecarInstance> instances = List.of(
+            cdcSidecarInstance("host1", 9043),
+            cdcSidecarInstance("host2", 9044),
+            cdcSidecarInstance("host3", 9045)
         );
+        SidecarCdcClient.ClientConfig clientConfig = SidecarCdcClient.ClientConfig.create(5555, 3, 100L);
 
-        // Before override: default resolver returns effectivePort for every host
-        assertThat(builder.sidecarCdcClient.toSidecarInstance(new CassandraInstance("0", "host1", "DC1")).port())
-            .isEqualTo(9042);
+        var resolver = SidecarCdcClient.buildPortResolver(() -> instances, clientConfig);
 
-        // Apply custom resolver then rebuild the client so it picks up the new resolver
-        Map<String, Integer> portMapping = Map.of("host1", 9100, "host2", 9200);
-        builder.withPortResolver(instance -> portMapping.getOrDefault(instance.nodeName(), clientConfig.effectivePort()))
-               .withSidecarClient(clientConfig, mockSidecarClient, cdcStats);
+        assertThat(resolver.apply(new CassandraInstance("0", "host1", "DC1"))).isEqualTo(9043);
+        assertThat(resolver.apply(new CassandraInstance("100", "host2", "DC1"))).isEqualTo(9044);
+        assertThat(resolver.apply(new CassandraInstance("200", "host3", "DC1"))).isEqualTo(9045);
+        // Unknown host falls back to clientConfig.effectivePort()
+        assertThat(resolver.apply(new CassandraInstance("300", "unknown-host", "DC1"))).isEqualTo(5555);
+    }
 
-        // Known hosts now resolve to their mapped ports
-        assertThat(builder.sidecarCdcClient.toSidecarInstance(new CassandraInstance("0", "host1", "DC1")).port())
-            .isEqualTo(9100);
-        assertThat(builder.sidecarCdcClient.toSidecarInstance(new CassandraInstance("100", "host2", "DC1")).port())
-            .isEqualTo(9200);
-
-        // Unknown host still falls back to effectivePort
-        assertThat(builder.sidecarCdcClient.toSidecarInstance(new CassandraInstance("200", "unknown-host", "DC1")).port())
-            .isEqualTo(9042);
+    private static CdcSidecarInstance cdcSidecarInstance(String hostname, int port)
+    {
+        return new CdcSidecarInstance()
+        {
+            public int port() { return port; }
+            public String hostname() { return hostname; }
+        };
     }
 }

--- a/cassandra-analytics-cdc-sidecar/src/test/java/org/apache/cassandra/cdc/sidecar/SidecarCdcTest.java
+++ b/cassandra-analytics-cdc-sidecar/src/test/java/org/apache/cassandra/cdc/sidecar/SidecarCdcTest.java
@@ -88,7 +88,7 @@ public class SidecarCdcTest
         SidecarCdcClient.ClientConfig clientConfig = SidecarCdcClient.ClientConfig.create();
 
         SidecarCdcClient client = new SidecarCdcClient(clientConfig, mockSidecarClient, cdcStats,
-                                                       hostname -> portMapping.getOrDefault(hostname, 9043));
+                                                       instance -> portMapping.getOrDefault(instance.nodeName(), 9043));
 
         SidecarInstance si1 = client.toSidecarInstance(new CassandraInstance("0", "host1", "DC1"));
         assertThat(si1.hostname()).isEqualTo("host1");
@@ -110,7 +110,7 @@ public class SidecarCdcTest
         Map<String, Integer> portMapping = Map.of("host1", 9043);
 
         SidecarCdcClient client = new SidecarCdcClient(clientConfig, mockSidecarClient, cdcStats,
-                                                       hostname -> portMapping.getOrDefault(hostname,
+                                                       instance -> portMapping.getOrDefault(instance.nodeName(),
                                                                                             clientConfig.effectivePort()));
 
         assertThat(client.toSidecarInstance(new CassandraInstance("0", "host1", "DC1")).port()).isEqualTo(9043);

--- a/cassandra-analytics-cdc-sidecar/src/test/java/org/apache/cassandra/cdc/sidecar/SidecarCdcTest.java
+++ b/cassandra-analytics-cdc-sidecar/src/test/java/org/apache/cassandra/cdc/sidecar/SidecarCdcTest.java
@@ -19,7 +19,6 @@
 
 package org.apache.cassandra.cdc.sidecar;
 
-import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -55,22 +54,31 @@ public class SidecarCdcTest
     @Test
     public void testBuilderMethodCreatesValidBuilder()
     {
+        String jobId = "test-job-123";
+        int partitionId = 0;
+        CdcOptions cdcOptions = mock(CdcOptions.class);
+        ClusterConfigProvider clusterConfigProvider = mock(ClusterConfigProvider.class);
+        EventConsumer eventConsumer = mock(EventConsumer.class);
+        SchemaSupplier schemaSupplier = mock(SchemaSupplier.class);
+        TokenRangeSupplier tokenRangeSupplier = mock(TokenRangeSupplier.class);
         SidecarCdcClient mockSidecarCdcClient = mock(SidecarCdcClient.class);
+        ICdcStats cdcStats = mock(ICdcStats.class);
 
         SidecarCdcBuilder builder = new SidecarCdcBuilder(
-            "test-job-123",
-            0,
-            mock(CdcOptions.class),
-            mock(ClusterConfigProvider.class),
-            mock(EventConsumer.class),
-            mock(SchemaSupplier.class),
-            mock(TokenRangeSupplier.class),
+            jobId,
+            partitionId,
+            cdcOptions,
+            clusterConfigProvider,
+            eventConsumer,
+            schemaSupplier,
+            tokenRangeSupplier,
             mockSidecarCdcClient,
-            mock(ICdcStats.class)
+            cdcStats
         );
 
+        assertThat(builder).isNotNull();
         assertThat(builder).isInstanceOf(SidecarCdcBuilder.class);
-        assertThat(builder.clusterConfigProvider).isNotNull();
+        assertThat(builder.clusterConfigProvider).isEqualTo(clusterConfigProvider);
         assertThat(builder.sidecarCdcClient).isEqualTo(mockSidecarCdcClient);
     }
 
@@ -108,44 +116,5 @@ public class SidecarCdcTest
 
         assertThat(client.toSidecarInstance(new CassandraInstance("0", "host1", "DC1")).port()).isEqualTo(9043);
         assertThat(client.toSidecarInstance(new CassandraInstance("100", "unknown-host", "DC1")).port()).isEqualTo(8888);
-    }
-
-    @Test
-    public void testDefaultPortResolverUsesEffectivePort()
-    {
-        SidecarCdcClient.ClientConfig clientConfig = SidecarCdcClient.ClientConfig.create(7777, 3, 100L);
-
-        SidecarCdcClient client = new SidecarCdcClient(clientConfig, mockSidecarClient, cdcStats,
-                                                       ignored -> clientConfig.effectivePort());
-
-        assertThat(client.toSidecarInstance(new CassandraInstance("0", "host1", "DC1")).port()).isEqualTo(7777);
-    }
-
-    @Test
-    public void testBuildPortResolverFromProvider()
-    {
-        List<CdcSidecarInstance> instances = List.of(
-            cdcSidecarInstance("host1", 9043),
-            cdcSidecarInstance("host2", 9044),
-            cdcSidecarInstance("host3", 9045)
-        );
-        SidecarCdcClient.ClientConfig clientConfig = SidecarCdcClient.ClientConfig.create(5555, 3, 100L);
-
-        var resolver = SidecarCdcClient.buildPortResolver(() -> instances, clientConfig);
-
-        assertThat(resolver.apply(new CassandraInstance("0", "host1", "DC1"))).isEqualTo(9043);
-        assertThat(resolver.apply(new CassandraInstance("100", "host2", "DC1"))).isEqualTo(9044);
-        assertThat(resolver.apply(new CassandraInstance("200", "host3", "DC1"))).isEqualTo(9045);
-        // Unknown host falls back to clientConfig.effectivePort()
-        assertThat(resolver.apply(new CassandraInstance("300", "unknown-host", "DC1"))).isEqualTo(5555);
-    }
-
-    private static CdcSidecarInstance cdcSidecarInstance(String hostname, int port)
-    {
-        return new CdcSidecarInstance()
-        {
-            public int port() { return port; }
-            public String hostname() { return hostname; }
-        };
     }
 }

--- a/cassandra-analytics-cdc-sidecar/src/test/java/org/apache/cassandra/cdc/sidecar/SidecarCdcTest.java
+++ b/cassandra-analytics-cdc-sidecar/src/test/java/org/apache/cassandra/cdc/sidecar/SidecarCdcTest.java
@@ -62,7 +62,6 @@ public class SidecarCdcTest
         SchemaSupplier schemaSupplier = mock(SchemaSupplier.class);
         TokenRangeSupplier tokenRangeSupplier = mock(TokenRangeSupplier.class);
         SidecarCdcClient mockSidecarCdcClient = mock(SidecarCdcClient.class);
-        ICdcStats cdcStats = mock(ICdcStats.class);
 
         SidecarCdcBuilder builder = new SidecarCdcBuilder(
             jobId,
@@ -89,7 +88,7 @@ public class SidecarCdcTest
         SidecarCdcClient.ClientConfig clientConfig = SidecarCdcClient.ClientConfig.create();
 
         SidecarCdcClient client = new SidecarCdcClient(clientConfig, mockSidecarClient, cdcStats,
-                                                       instance -> portMapping.getOrDefault(instance.nodeName(), 9043));
+                                                       hostname -> portMapping.getOrDefault(hostname, 9043));
 
         SidecarInstance si1 = client.toSidecarInstance(new CassandraInstance("0", "host1", "DC1"));
         assertThat(si1.hostname()).isEqualTo("host1");
@@ -105,13 +104,52 @@ public class SidecarCdcTest
     }
 
     @Test
+    public void testWithPortResolverOnBuilder()
+    {
+        SidecarCdcClient.ClientConfig clientConfig = SidecarCdcClient.ClientConfig.create(9042, 3, 100L);
+        Map<String, Integer> portMapping = Map.of("host1", 9100, "host2", 9200);
+        SidecarCdcClient baseClient = new SidecarCdcClient(clientConfig, mockSidecarClient, cdcStats,
+                                                           ignored -> clientConfig.effectivePort());
+
+        SidecarCdcBuilder builder = new SidecarCdcBuilder(
+            "test-job",
+            0,
+            mock(CdcOptions.class),
+            mock(ClusterConfigProvider.class),
+            mock(EventConsumer.class),
+            mock(SchemaSupplier.class),
+            mock(TokenRangeSupplier.class),
+            baseClient,
+            cdcStats
+        );
+
+        // Before override: every host resolves to effectivePort
+        assertThat(builder.sidecarCdcClient.toSidecarInstance(new CassandraInstance("0", "host1", "DC1")).port())
+            .isEqualTo(9042);
+
+        // Override via builder chain
+        builder.withPortResolver(hostname -> portMapping.getOrDefault(hostname,
+                                                                      clientConfig.effectivePort()));
+
+        // Known hosts resolve to their mapped ports after override
+        assertThat(builder.sidecarCdcClient.toSidecarInstance(new CassandraInstance("0", "host1", "DC1")).port())
+            .isEqualTo(9100);
+        assertThat(builder.sidecarCdcClient.toSidecarInstance(new CassandraInstance("100", "host2", "DC1")).port())
+            .isEqualTo(9200);
+
+        // Unknown host falls back to effectivePort
+        assertThat(builder.sidecarCdcClient.toSidecarInstance(new CassandraInstance("200", "unknown", "DC1")).port())
+            .isEqualTo(9042);
+    }
+
+    @Test
     public void testFallbackToEffectivePortWhenHostNotFound()
     {
         SidecarCdcClient.ClientConfig clientConfig = SidecarCdcClient.ClientConfig.create(8888, 3, 100L);
         Map<String, Integer> portMapping = Map.of("host1", 9043);
 
         SidecarCdcClient client = new SidecarCdcClient(clientConfig, mockSidecarClient, cdcStats,
-                                                       instance -> portMapping.getOrDefault(instance.nodeName(),
+                                                       hostname -> portMapping.getOrDefault(hostname,
                                                                                             clientConfig.effectivePort()));
 
         assertThat(client.toSidecarInstance(new CassandraInstance("0", "host1", "DC1")).port()).isEqualTo(9043);

--- a/cassandra-analytics-cdc-sidecar/src/test/java/org/apache/cassandra/cdc/sidecar/SidecarCdcTest.java
+++ b/cassandra-analytics-cdc-sidecar/src/test/java/org/apache/cassandra/cdc/sidecar/SidecarCdcTest.java
@@ -104,45 +104,6 @@ public class SidecarCdcTest
     }
 
     @Test
-    public void testWithPortResolverOnBuilder()
-    {
-        SidecarCdcClient.ClientConfig clientConfig = SidecarCdcClient.ClientConfig.create(9042, 3, 100L);
-        Map<String, Integer> portMapping = Map.of("host1", 9100, "host2", 9200);
-        SidecarCdcClient baseClient = new SidecarCdcClient(clientConfig, mockSidecarClient, cdcStats,
-                                                           ignored -> clientConfig.effectivePort());
-
-        SidecarCdcBuilder builder = new SidecarCdcBuilder(
-            "test-job",
-            0,
-            mock(CdcOptions.class),
-            mock(ClusterConfigProvider.class),
-            mock(EventConsumer.class),
-            mock(SchemaSupplier.class),
-            mock(TokenRangeSupplier.class),
-            baseClient,
-            cdcStats
-        );
-
-        // Before override: every host resolves to effectivePort
-        assertThat(builder.sidecarCdcClient.toSidecarInstance(new CassandraInstance("0", "host1", "DC1")).port())
-            .isEqualTo(9042);
-
-        // Override via builder chain
-        builder.withPortResolver(hostname -> portMapping.getOrDefault(hostname,
-                                                                      clientConfig.effectivePort()));
-
-        // Known hosts resolve to their mapped ports after override
-        assertThat(builder.sidecarCdcClient.toSidecarInstance(new CassandraInstance("0", "host1", "DC1")).port())
-            .isEqualTo(9100);
-        assertThat(builder.sidecarCdcClient.toSidecarInstance(new CassandraInstance("100", "host2", "DC1")).port())
-            .isEqualTo(9200);
-
-        // Unknown host falls back to effectivePort
-        assertThat(builder.sidecarCdcClient.toSidecarInstance(new CassandraInstance("200", "unknown", "DC1")).port())
-            .isEqualTo(9042);
-    }
-
-    @Test
     public void testFallbackToEffectivePortWhenHostNotFound()
     {
         SidecarCdcClient.ClientConfig clientConfig = SidecarCdcClient.ClientConfig.create(8888, 3, 100L);

--- a/cassandra-analytics-cdc-sidecar/src/test/java/org/apache/cassandra/cdc/sidecar/SidecarCdcTest.java
+++ b/cassandra-analytics-cdc-sidecar/src/test/java/org/apache/cassandra/cdc/sidecar/SidecarCdcTest.java
@@ -19,12 +19,10 @@
 
 package org.apache.cassandra.cdc.sidecar;
 
-import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import org.apache.cassandra.cdc.api.CdcOptions;
@@ -42,8 +40,11 @@ import static org.mockito.Mockito.mock;
  */
 public class SidecarCdcTest
 {
-    @Test
-    public void testBuilderMethodCreatesValidBuilder()
+    private SidecarClient mockSidecarClient;
+    private ICdcStats cdcStats;
+
+    @BeforeEach
+    public void setup()
     {
         String jobId = "test-job-123";
         int partitionId = 0;
@@ -71,104 +72,93 @@ public class SidecarCdcTest
         assertThat(builder).isInstanceOf(SidecarCdcBuilder.class);
         assertThat(builder.clusterConfigProvider).isEqualTo(clusterConfigProvider);
         assertThat(builder.sidecarCdcClient).isEqualTo(mockSidecarCdcClient);
+        mockSidecarClient = mock(SidecarClient.class);
+        cdcStats = mock(ICdcStats.class);
     }
+
 
     @Test
     public void testPerInstancePortResolution()
     {
-        Map<String, Integer> portMapping = new HashMap<>();
-        portMapping.put("host1", 9043);
-        portMapping.put("host2", 9044);
-        portMapping.put("host3", 9045);
-        Function<String, Integer> portResolver = hostname -> portMapping.getOrDefault(hostname, 9043);
-
+        Map<String, Integer> portMapping = Map.of("host1", 9043, "host2", 9044, "host3", 9045);
         SidecarCdcClient.ClientConfig clientConfig = SidecarCdcClient.ClientConfig.create();
-        SidecarClient mockSidecarClient = mock(SidecarClient.class);
-        ICdcStats cdcStats = mock(ICdcStats.class);
 
-        SidecarCdcClient client = new SidecarCdcClient(clientConfig, mockSidecarClient, cdcStats, portResolver);
+        SidecarCdcClient client = new SidecarCdcClient(clientConfig, mockSidecarClient, cdcStats,
+                                                       instance -> portMapping.getOrDefault(instance.nodeName(), 9043));
 
         SidecarInstance si1 = client.toSidecarInstance(new CassandraInstance("0", "host1", "DC1"));
-        assertThat(si1.port()).isEqualTo(9043);
         assertThat(si1.hostname()).isEqualTo("host1");
+        assertThat(si1.port()).isEqualTo(9043);
 
         SidecarInstance si2 = client.toSidecarInstance(new CassandraInstance("100", "host2", "DC1"));
-        assertThat(si2.port()).isEqualTo(9044);
         assertThat(si2.hostname()).isEqualTo("host2");
+        assertThat(si2.port()).isEqualTo(9044);
 
         SidecarInstance si3 = client.toSidecarInstance(new CassandraInstance("200", "host3", "DC1"));
-        assertThat(si3.port()).isEqualTo(9045);
         assertThat(si3.hostname()).isEqualTo("host3");
+        assertThat(si3.port()).isEqualTo(9045);
     }
 
     @Test
     public void testFallbackToEffectivePortWhenHostNotFound()
     {
-        Map<String, Integer> portMapping = new HashMap<>();
-        portMapping.put("host1", 9043);
         SidecarCdcClient.ClientConfig clientConfig = SidecarCdcClient.ClientConfig.create(8888, 3, 100L);
-        Function<String, Integer> portResolver = hostname -> portMapping.getOrDefault(hostname, clientConfig.effectivePort());
+        Map<String, Integer> portMapping = Map.of("host1", 9043);
 
-        SidecarClient mockSidecarClient = mock(SidecarClient.class);
-        ICdcStats cdcStats = mock(ICdcStats.class);
+        SidecarCdcClient client = new SidecarCdcClient(clientConfig, mockSidecarClient, cdcStats,
+                                                       instance -> portMapping.getOrDefault(instance.nodeName(),
+                                                                                            clientConfig.effectivePort()));
 
-        SidecarCdcClient client = new SidecarCdcClient(clientConfig, mockSidecarClient, cdcStats, portResolver);
-
-        SidecarInstance si1 = client.toSidecarInstance(new CassandraInstance("0", "host1", "DC1"));
-        assertThat(si1.port()).isEqualTo(9043);
-
-        SidecarInstance si2 = client.toSidecarInstance(new CassandraInstance("100", "unknown-host", "DC1"));
-        assertThat(si2.port()).isEqualTo(8888);
+        assertThat(client.toSidecarInstance(new CassandraInstance("0", "host1", "DC1")).port()).isEqualTo(9043);
+        assertThat(client.toSidecarInstance(new CassandraInstance("100", "unknown-host", "DC1")).port()).isEqualTo(8888);
     }
 
     @Test
     public void testDefaultPortResolverUsesEffectivePort()
     {
         SidecarCdcClient.ClientConfig clientConfig = SidecarCdcClient.ClientConfig.create(7777, 3, 100L);
-        SidecarClient mockSidecarClient = mock(SidecarClient.class);
-        ICdcStats cdcStats = mock(ICdcStats.class);
 
         SidecarCdcClient client = new SidecarCdcClient(clientConfig, mockSidecarClient, cdcStats);
 
-        SidecarInstance si = client.toSidecarInstance(new CassandraInstance("0", "host1", "DC1"));
-        assertThat(si.port()).isEqualTo(7777);
+        assertThat(client.toSidecarInstance(new CassandraInstance("0", "host1", "DC1")).port()).isEqualTo(7777);
     }
 
     @Test
-    public void testBuildPortResolverFromProvider()
+    public void testWithPortResolverOverridesDefault()
     {
-        List<CdcSidecarInstance> instances = Arrays.asList(
-            cdcSidecarInstance("host1", 9043),
-            cdcSidecarInstance("host2", 9044),
-            cdcSidecarInstance("host3", 9045)
+        SidecarCdcClient.ClientConfig clientConfig = SidecarCdcClient.ClientConfig.create(9042, 3, 100L);
+
+        SidecarCdcBuilder builder = new SidecarCdcBuilder(
+            "test-job",
+            0,
+            mock(CdcOptions.class),
+            mock(ClusterConfigProvider.class),
+            mock(EventConsumer.class),
+            mock(SchemaSupplier.class),
+            mock(TokenRangeSupplier.class),
+            null,  // use default portResolver: ignored -> clientConfig.effectivePort()
+            clientConfig,
+            mockSidecarClient,
+            cdcStats
         );
-        CdcSidecarInstancesProvider provider = () -> instances;
-        SidecarCdcClient.ClientConfig clientConfig = SidecarCdcClient.ClientConfig.create(5555, 3, 100L);
 
-        Function<String, Integer> resolver = SidecarCdcBuilder.buildPortResolver(provider, clientConfig);
+        // Before override: default resolver returns effectivePort for every host
+        assertThat(builder.sidecarCdcClient.toSidecarInstance(new CassandraInstance("0", "host1", "DC1")).port())
+            .isEqualTo(9042);
 
-        assertThat(resolver.apply("host1")).isEqualTo(9043);
-        assertThat(resolver.apply("host2")).isEqualTo(9044);
-        assertThat(resolver.apply("host3")).isEqualTo(9045);
-        // Unknown host falls back to clientConfig.effectivePort()
-        assertThat(resolver.apply("unknown-host")).isEqualTo(5555);
-    }
+        // Apply custom resolver then rebuild the client so it picks up the new resolver
+        Map<String, Integer> portMapping = Map.of("host1", 9100, "host2", 9200);
+        builder.withPortResolver(instance -> portMapping.getOrDefault(instance.nodeName(), clientConfig.effectivePort()))
+               .withSidecarClient(clientConfig, mockSidecarClient, cdcStats);
 
-    private static CdcSidecarInstance cdcSidecarInstance(String hostname, int port)
-    {
-        return new CdcSidecarInstance()
-        {
-            @Override
-            public int port()
-            {
-                return port;
-            }
+        // Known hosts now resolve to their mapped ports
+        assertThat(builder.sidecarCdcClient.toSidecarInstance(new CassandraInstance("0", "host1", "DC1")).port())
+            .isEqualTo(9100);
+        assertThat(builder.sidecarCdcClient.toSidecarInstance(new CassandraInstance("100", "host2", "DC1")).port())
+            .isEqualTo(9200);
 
-            @Override
-            public String hostname()
-            {
-                return hostname;
-            }
-        };
+        // Unknown host still falls back to effectivePort
+        assertThat(builder.sidecarCdcClient.toSidecarInstance(new CassandraInstance("200", "unknown-host", "DC1")).port())
+            .isEqualTo(9042);
     }
 }

--- a/cassandra-analytics-cdc-sidecar/src/test/java/org/apache/cassandra/cdc/sidecar/SidecarCdcTest.java
+++ b/cassandra-analytics-cdc-sidecar/src/test/java/org/apache/cassandra/cdc/sidecar/SidecarCdcTest.java
@@ -19,6 +19,12 @@
 
 package org.apache.cassandra.cdc.sidecar;
 
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
 import org.junit.jupiter.api.Test;
 
 import org.apache.cassandra.cdc.api.CdcOptions;
@@ -26,6 +32,7 @@ import org.apache.cassandra.cdc.api.EventConsumer;
 import org.apache.cassandra.cdc.api.SchemaSupplier;
 import org.apache.cassandra.cdc.api.TokenRangeSupplier;
 import org.apache.cassandra.cdc.stats.ICdcStats;
+import org.apache.cassandra.spark.data.partitioner.CassandraInstance;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -64,5 +71,104 @@ public class SidecarCdcTest
         assertThat(builder).isInstanceOf(SidecarCdcBuilder.class);
         assertThat(builder.clusterConfigProvider).isEqualTo(clusterConfigProvider);
         assertThat(builder.sidecarCdcClient).isEqualTo(mockSidecarCdcClient);
+    }
+
+    @Test
+    public void testPerInstancePortResolution()
+    {
+        Map<String, Integer> portMapping = new HashMap<>();
+        portMapping.put("host1", 9043);
+        portMapping.put("host2", 9044);
+        portMapping.put("host3", 9045);
+        Function<String, Integer> portResolver = hostname -> portMapping.getOrDefault(hostname, 9043);
+
+        SidecarCdcClient.ClientConfig clientConfig = SidecarCdcClient.ClientConfig.create();
+        SidecarClient mockSidecarClient = mock(SidecarClient.class);
+        ICdcStats cdcStats = mock(ICdcStats.class);
+
+        SidecarCdcClient client = new SidecarCdcClient(clientConfig, mockSidecarClient, cdcStats, portResolver);
+
+        SidecarInstance si1 = client.toSidecarInstance(new CassandraInstance("0", "host1", "DC1"));
+        assertThat(si1.port()).isEqualTo(9043);
+        assertThat(si1.hostname()).isEqualTo("host1");
+
+        SidecarInstance si2 = client.toSidecarInstance(new CassandraInstance("100", "host2", "DC1"));
+        assertThat(si2.port()).isEqualTo(9044);
+        assertThat(si2.hostname()).isEqualTo("host2");
+
+        SidecarInstance si3 = client.toSidecarInstance(new CassandraInstance("200", "host3", "DC1"));
+        assertThat(si3.port()).isEqualTo(9045);
+        assertThat(si3.hostname()).isEqualTo("host3");
+    }
+
+    @Test
+    public void testFallbackToEffectivePortWhenHostNotFound()
+    {
+        Map<String, Integer> portMapping = new HashMap<>();
+        portMapping.put("host1", 9043);
+        SidecarCdcClient.ClientConfig clientConfig = SidecarCdcClient.ClientConfig.create(8888, 3, 100L);
+        Function<String, Integer> portResolver = hostname -> portMapping.getOrDefault(hostname, clientConfig.effectivePort());
+
+        SidecarClient mockSidecarClient = mock(SidecarClient.class);
+        ICdcStats cdcStats = mock(ICdcStats.class);
+
+        SidecarCdcClient client = new SidecarCdcClient(clientConfig, mockSidecarClient, cdcStats, portResolver);
+
+        SidecarInstance si1 = client.toSidecarInstance(new CassandraInstance("0", "host1", "DC1"));
+        assertThat(si1.port()).isEqualTo(9043);
+
+        SidecarInstance si2 = client.toSidecarInstance(new CassandraInstance("100", "unknown-host", "DC1"));
+        assertThat(si2.port()).isEqualTo(8888);
+    }
+
+    @Test
+    public void testDefaultPortResolverUsesEffectivePort()
+    {
+        SidecarCdcClient.ClientConfig clientConfig = SidecarCdcClient.ClientConfig.create(7777, 3, 100L);
+        SidecarClient mockSidecarClient = mock(SidecarClient.class);
+        ICdcStats cdcStats = mock(ICdcStats.class);
+
+        SidecarCdcClient client = new SidecarCdcClient(clientConfig, mockSidecarClient, cdcStats);
+
+        SidecarInstance si = client.toSidecarInstance(new CassandraInstance("0", "host1", "DC1"));
+        assertThat(si.port()).isEqualTo(7777);
+    }
+
+    @Test
+    public void testBuildPortResolverFromProvider()
+    {
+        List<CdcSidecarInstance> instances = Arrays.asList(
+            cdcSidecarInstance("host1", 9043),
+            cdcSidecarInstance("host2", 9044),
+            cdcSidecarInstance("host3", 9045)
+        );
+        CdcSidecarInstancesProvider provider = () -> instances;
+        SidecarCdcClient.ClientConfig clientConfig = SidecarCdcClient.ClientConfig.create(5555, 3, 100L);
+
+        Function<String, Integer> resolver = SidecarCdcBuilder.buildPortResolver(provider, clientConfig);
+
+        assertThat(resolver.apply("host1")).isEqualTo(9043);
+        assertThat(resolver.apply("host2")).isEqualTo(9044);
+        assertThat(resolver.apply("host3")).isEqualTo(9045);
+        // Unknown host falls back to clientConfig.effectivePort()
+        assertThat(resolver.apply("unknown-host")).isEqualTo(5555);
+    }
+
+    private static CdcSidecarInstance cdcSidecarInstance(String hostname, int port)
+    {
+        return new CdcSidecarInstance()
+        {
+            @Override
+            public int port()
+            {
+                return port;
+            }
+
+            @Override
+            public String hostname()
+            {
+                return hostname;
+            }
+        };
     }
 }


### PR DESCRIPTION
Currently when the sidecar tries to call another sidecar instance it assumes another sidecar will use the same port as itself, this change make the port as a input parameter so that the downstream caller can have the option to pass in the port if other sidecar is using a different port.