### PR TITLE
CASSANALYTICS-150 Change commit log mode for CDC tests

### DIFF
--- a/cassandra-five-zero-bridge/src/main/java/org/apache/cassandra/bridge/CdcBridgeImplementation.java
+++ b/cassandra-five-zero-bridge/src/main/java/org/apache/cassandra/bridge/CdcBridgeImplementation.java
@@ -67,7 +67,7 @@ public class CdcBridgeImplementation extends AbstractCdcBridgeImplementation
         DatabaseDescriptor.setCommitLogSyncGroupWindow(30);
         DatabaseDescriptor.setCommitLogSegmentSize(commitLogSegmentSize);
         DatabaseDescriptor.getRawConfig().commitlog_total_space = new DataStorageSpec.IntMebibytesBound(1024);
-        DatabaseDescriptor.initializeCommitLogDiskAccessMode();
+        DatabaseDescriptor.setCommitLogWriteDiskAccessMode(Config.DiskAccessMode.mmap);
         DatabaseDescriptor.setCDCTotalSpaceInMiB(1024);
         DatabaseDescriptor.setCommitLogSegmentMgrProvider((commitLog -> new CommitLogSegmentManagerCDC(commitLog, commitLogPath.toString())));
         setup = true;

--- a/cassandra-five-zero-bridge/src/main/java/org/apache/cassandra/bridge/CdcBridgeImplementation.java
+++ b/cassandra-five-zero-bridge/src/main/java/org/apache/cassandra/bridge/CdcBridgeImplementation.java
@@ -67,7 +67,7 @@ public class CdcBridgeImplementation extends AbstractCdcBridgeImplementation
         DatabaseDescriptor.setCommitLogSyncGroupWindow(30);
         DatabaseDescriptor.setCommitLogSegmentSize(commitLogSegmentSize);
         DatabaseDescriptor.getRawConfig().commitlog_total_space = new DataStorageSpec.IntMebibytesBound(1024);
-        DatabaseDescriptor.setCommitLogWriteDiskAccessMode(Config.DiskAccessMode.direct);
+        DatabaseDescriptor.initializeCommitLogDiskAccessMode();
         DatabaseDescriptor.setCDCTotalSpaceInMiB(1024);
         DatabaseDescriptor.setCommitLogSegmentMgrProvider((commitLog -> new CommitLogSegmentManagerCDC(commitLog, commitLogPath.toString())));
         setup = true;


### PR DESCRIPTION
CDC tests setup in Cassandra analytics is using commit log disk access mode DIRECT. This is causing CI builds running on containers to fail with OOM, as unable to acquire sufficient DIRECT memory on memory constrained containers. Changing commit log mode to mmap works, and this aligns with Cassandra default commit log mode logic (see resolveCommitLogWriteDiskAccessMode in Cassandra)