### PR TITLE
Reading BTI may require partitions and rows indexes

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,6 @@
 0.4.0
 -----
+ * Reading BTI may require partitions and rows indexes (CASSANALYTICS-156)
  * Make KafkaPublisher class generic to publish GenericRecords for different value serializers (CASSANALYTICS-154)
  * Cannot read start offset from BTI index with big partitions (CASSANALYTICS-151)
  * BufferingInputStream fails to read last unaligned chunk (CASSANALYTICS-147)

--- a/cassandra-analytics-common/src/main/java/org/apache/cassandra/spark/data/SSTable.java
+++ b/cassandra-analytics-common/src/main/java/org/apache/cassandra/spark/data/SSTable.java
@@ -111,10 +111,10 @@ public abstract class SSTable implements Serializable, CassandraFile
         {
             throw new IncompleteSSTableException(FileType.SUMMARY, FileType.INDEX);
         }
-        // For BTI format, we just need partitions index
-        if (isBtiFormat() && isMissing(FileType.PARTITIONS_INDEX))
+        // For BTI format, we may need both - partitions and rows index
+        if (isBtiFormat() && (isMissing(FileType.PARTITIONS_INDEX) || isMissing(FileType.ROWS_INDEX)))
         {
-            throw new IncompleteSSTableException(FileType.PARTITIONS_INDEX);
+            throw new IncompleteSSTableException(FileType.PARTITIONS_INDEX, FileType.ROWS_INDEX);
         }
     }
 

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/data/partitioner/SingleReplicaTests.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/data/partitioner/SingleReplicaTests.java
@@ -84,12 +84,20 @@ public class SingleReplicaTests
         runTest(dataFileName, false, FileType.SUMMARY);
     }
 
-    @ParameterizedTest
-    @MethodSource("dataFileNames")
-    public void testMissingOnlyIndexFile(String dataFileName) throws ExecutionException, InterruptedException, IOException
+    @Test
+    public void testBigMissingOnlyIndexFile() throws ExecutionException, InterruptedException, IOException
     {
         // Index.db can be missing if we can use Summary.db
-        runTest(dataFileName, false, FileType.INDEX);
+        runTest("na-1-big-Data.db", false, FileType.INDEX);
+    }
+
+    @Test
+    public void testBtiMissingPartitionsRowsIndexFile()
+    {
+        assertThatThrownBy(() -> runTest("da-1-bti-Data.db", true, FileType.PARTITIONS_INDEX))
+        .isInstanceOf(IOException.class);
+        assertThatThrownBy(() -> runTest("da-1-bti-Data.db", true, FileType.ROWS_INDEX))
+        .isInstanceOf(IOException.class);
     }
 
     @ParameterizedTest
@@ -268,6 +276,9 @@ public class SingleReplicaTests
 
     public static List<Named<String>> dataFileNames()
     {
-        return Arrays.asList(Named.of("BIG", "na-1-big-Data.db"));
+        return Arrays.asList(
+        Named.of("BIG", "na-1-big-Data.db"),
+        Named.of("BTI", "da-1-bti-Data.db")
+        );
     }
 }


### PR DESCRIPTION
Fixes [CASSANALYTICS-156](https://issues.apache.org/jira/browse/CASSANALYTICS-156).