### PR TITLE
CASSANALYTICS-155: Add IAM credential support for S3 storage transport

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,7 +116,8 @@ commands:
             # files on each run, so without aggregation only the last class's XML
             # would survive, hiding most results from the CircleCI dashboard.
             # Drain reports into a per-class subdirectory after each iteration.
-            SRC_REPORT_DIR="$(pwd)/build/test-reports/integration"
+            SRC_REPORT_DIR="$(pwd)/build/test-results/cassandra-analytics-integration-tests/test"
+            HTML_REPORT_DIR="$(pwd)/build/reports/tests/cassandra-analytics-integration-tests/test"
             AGG_ROOT="$(pwd)/build/aggregated-test-reports/integration"
             mkdir -p "$AGG_ROOT"
             # collect up exit statuses for all of the test classes and exit with that result at the end.
@@ -133,10 +134,10 @@ commands:
                         mv "$f" "$DEST"/
                         MOVED=1
                     done
-                    for f in "$SRC_REPORT_DIR"/*.html; do
-                        [ -e "$f" ] || continue
-                        mv "$f" "$DEST"/ 2>/dev/null || true
-                    done
+                fi
+                if [ -d "$HTML_REPORT_DIR" ]; then
+                    mkdir -p "$DEST/html"
+                    cp -r "$HTML_REPORT_DIR/." "$DEST/html/"
                 fi
                 # If Gradle produced no XML (e.g. class-level crash before any
                 # @Test ran), synthesize a minimal JUnit record so CircleCI's
@@ -244,8 +245,8 @@ jobs:
 
       - store_artifacts:
           when: always
-          path: build/test-reports
-          destination: test-reports
+          path: build/test-results
+          destination: test-results
 
       - store_artifacts:
           when: always
@@ -254,7 +255,7 @@ jobs:
 
       - store_test_results:
           when: always
-          path: build/test-reports
+          path: build/test-results
 
   # Single parameterized integration-test job, invoked once per Cassandra/Scala
   # compatibility group from the workflow's `matrix:` block.
@@ -286,8 +287,8 @@ jobs:
 
       - store_artifacts:
           when: always
-          path: build/test-reports
-          destination: test-reports
+          path: build/aggregated-test-reports
+          destination: test-results
 
       - store_artifacts:
           when: always

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -200,6 +200,15 @@ jobs:
           fi
 
           ./gradlew --stacktrace clean assemble check -x cassandra-analytics-integration-tests:test -Dcassandra.analytics.bridges.sstable_format=${{ matrix.sstable-format }}
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: unit-test-results-s${{ matrix.scala }}-${{ matrix.sstable-format }}-C${{ matrix.cassandra }}-Spark${{ matrix.spark }}-JDK${{ matrix.jdk }}
+          path: |
+            build/test-results/**
+            build/reports/tests/**
+          retention-days: 30
 
   integration-test:
     name: Integration test - ${{ matrix.config }} (${{ matrix.job_index }})
@@ -302,23 +311,23 @@ jobs:
             done
 
             test_id=$(date +%H%M%S)
-            mkdir -p test-reports/$test_id
+            mkdir -p "test-reports/$test_id/html"
 
             if [ $SKIP == "false" ]; then
               echo Executing test $TEST_NAME
               ./gradlew --stacktrace cassandra-analytics-integration-tests:test --tests $TEST_NAME --no-daemon || EXIT_STATUS=$?;
-              mv build/test-reports/* test-reports/$test_id
+              find build/test-results -name "*.xml" -exec cp {} "test-reports/$test_id/" \; 2>/dev/null || true
+              [ -d "build/reports/tests" ] && cp -r build/reports/tests/. "test-reports/$test_id/html/" 2>/dev/null || true
             else
               echo "Skipping test $TEST_NAME"
             fi
           done;
 
-          tar czf integration-tests.tar.gz test-reports/*
-
           exit $EXIT_STATUS
-      - name: Publish test results
+      - name: Upload test results
+        if: always()
         uses: actions/upload-artifact@v4
-        if: (!cancelled())
         with:
           name: integration-tests-${{ matrix.config }}-${{ matrix.job_index }}
-          path: integration-tests.tar.gz
+          path: test-reports/
+          retention-days: 30

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,7 @@
 0.5.0
 -----
  * Spark 4.0 Support (CASSANALYTICS-34)
+ * Add IAM credential support for S3 storage transport (CASSANALYTICS-155)
  * Make BulkWriterConfig extensible (CASSANALYTICS-168)
 
 0.4.0

--- a/analytics-sidecar-client-common/build.gradle
+++ b/analytics-sidecar-client-common/build.gradle
@@ -34,14 +34,6 @@ if (propertyWithDefault("artifactType", null) == "common") {
 test {
     useJUnitPlatform()
     maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
-    reports {
-        junitXml.setRequired(true)
-        def destDir = Paths.get(rootProject.rootDir.absolutePath, "build", "test-results", "client-common").toFile()
-        println("Destination directory for client-common tests: ${destDir}")
-        junitXml.getOutputLocation().set(destDir)
-        html.setRequired(true)
-        html.getOutputLocation().set(destDir)
-    }
 }
 
 dependencies {

--- a/analytics-sidecar-client-common/src/main/java/org/apache/cassandra/sidecar/common/data/CredentialType.java
+++ b/analytics-sidecar-client-common/src/main/java/org/apache/cassandra/sidecar/common/data/CredentialType.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.sidecar.common.data;
+
+/**
+ * Declares the credential type used by a restore job to authenticate with cloud storage.
+ */
+public enum CredentialType
+{
+    /** Static STS credentials: accessKeyId, secretAccessKey, and sessionToken must all be present. */
+    STATIC,
+    /** IAM instance profile (or ECS task role / IRSA): only region is required; key fields must be absent. */
+    IAM
+}

--- a/analytics-sidecar-client-common/src/main/java/org/apache/cassandra/sidecar/common/data/RestoreJobConstants.java
+++ b/analytics-sidecar-client-common/src/main/java/org/apache/cassandra/sidecar/common/data/RestoreJobConstants.java
@@ -58,6 +58,7 @@ public class RestoreJobConstants
     public static final String SLICE_COMPRESSED_SIZE = "sliceCompressedSize";
     public static final String SECRET_READ_CREDENTIALS = "readCredentials";
     public static final String SECRET_WRITE_CREDENTIALS = "writeCredentials";
+    public static final String JOB_CREDENTIAL_TYPE = "credentialType";
     public static final String CREDENTIALS_ACCESS_KEY_ID = "accessKeyId";
     public static final String CREDENTIALS_SECRET_ACCESS_KEY = "secretAccessKey";
     public static final String CREDENTIALS_SESSION_TOKEN = "sessionToken";

--- a/analytics-sidecar-client-common/src/main/java/org/apache/cassandra/sidecar/common/data/RestoreJobSecrets.java
+++ b/analytics-sidecar-client-common/src/main/java/org/apache/cassandra/sidecar/common/data/RestoreJobSecrets.java
@@ -31,6 +31,21 @@ import static org.apache.cassandra.sidecar.common.data.RestoreJobConstants.SECRE
  */
 public class RestoreJobSecrets
 {
+    /**
+     * Creates a {@link RestoreJobSecrets} for IAM instance profile mode.
+     * Only the regions are provided; the sidecar resolves credentials via the AWS default credential chain.
+     *
+     * @param readRegion  the AWS region of the S3 bucket used for reading
+     * @param writeRegion the AWS region of the S3 bucket used for writing
+     * @return region-only {@link RestoreJobSecrets} signalling IAM mode
+     */
+    public static RestoreJobSecrets iamMode(String readRegion, String writeRegion)
+    {
+        StorageCredentials read = StorageCredentials.builder().region(readRegion).build();
+        StorageCredentials write = StorageCredentials.builder().region(writeRegion).build();
+        return new RestoreJobSecrets(read, write);
+    }
+
     private final StorageCredentials writeCredentials;
     private final StorageCredentials readCredentials;
 

--- a/analytics-sidecar-client-common/src/main/java/org/apache/cassandra/sidecar/common/data/StorageCredentials.java
+++ b/analytics-sidecar-client-common/src/main/java/org/apache/cassandra/sidecar/common/data/StorageCredentials.java
@@ -21,7 +21,9 @@ package org.apache.cassandra.sidecar.common.data;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.jetbrains.annotations.Nullable;
 
 import static org.apache.cassandra.sidecar.common.data.RestoreJobConstants.CREDENTIALS_ACCESS_KEY_ID;
 import static org.apache.cassandra.sidecar.common.data.RestoreJobConstants.CREDENTIALS_REGION;
@@ -29,13 +31,16 @@ import static org.apache.cassandra.sidecar.common.data.RestoreJobConstants.CREDE
 import static org.apache.cassandra.sidecar.common.data.RestoreJobConstants.CREDENTIALS_SESSION_TOKEN;
 
 /**
- * Used for storing credential details needed for either reading/writing to S3
+ * Used for storing credential details needed for either reading/writing to S3.
+ * In IAM mode only {@code region} is required; the key fields are absent and the sidecar
+ * resolves credentials via the AWS default credential chain.
  */
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class StorageCredentials
 {
-    private final String accessKeyId;
-    private final String secretAccessKey;
-    private final String sessionToken;
+    private final @Nullable String accessKeyId;
+    private final @Nullable String secretAccessKey;
+    private final @Nullable String sessionToken;
     private final String region;
 
     public static Builder builder()
@@ -44,14 +49,11 @@ public class StorageCredentials
     }
 
     @JsonCreator
-    public StorageCredentials(@JsonProperty(CREDENTIALS_ACCESS_KEY_ID) String accessKeyId,
-                              @JsonProperty(CREDENTIALS_SECRET_ACCESS_KEY) String secretAccessKey,
-                              @JsonProperty(CREDENTIALS_SESSION_TOKEN) String sessionToken,
+    public StorageCredentials(@JsonProperty(CREDENTIALS_ACCESS_KEY_ID) @Nullable String accessKeyId,
+                              @JsonProperty(CREDENTIALS_SECRET_ACCESS_KEY) @Nullable String secretAccessKey,
+                              @JsonProperty(CREDENTIALS_SESSION_TOKEN) @Nullable String sessionToken,
                               @JsonProperty(CREDENTIALS_REGION) String region)
     {
-        Objects.requireNonNull(accessKeyId, "accessKeyId must be supplied");
-        Objects.requireNonNull(secretAccessKey, "secretAccessKey must be supplied");
-        Objects.requireNonNull(sessionToken, "sessionToken must be supplied");
         Objects.requireNonNull(region, "region must be supplied");
         this.accessKeyId = accessKeyId;
         this.secretAccessKey = secretAccessKey;
@@ -60,19 +62,19 @@ public class StorageCredentials
     }
 
     @JsonProperty(CREDENTIALS_ACCESS_KEY_ID)
-    public String accessKeyId()
+    public @Nullable String accessKeyId()
     {
         return accessKeyId;
     }
 
     @JsonProperty(CREDENTIALS_SECRET_ACCESS_KEY)
-    public String secretAccessKey()
+    public @Nullable String secretAccessKey()
     {
         return secretAccessKey;
     }
 
     @JsonProperty(CREDENTIALS_SESSION_TOKEN)
-    public String sessionToken()
+    public @Nullable String sessionToken()
     {
         return sessionToken;
     }
@@ -81,6 +83,15 @@ public class StorageCredentials
     public String region()
     {
         return region;
+    }
+
+    /**
+     * Returns true if all three key fields are non-null, indicating static AWS credentials are present.
+     * A false result means key fields are absent, which is expected in IAM mode.
+     */
+    public boolean hasStaticCredentials()
+    {
+        return accessKeyId != null && secretAccessKey != null && sessionToken != null;
     }
 
     /**
@@ -123,13 +134,13 @@ public class StorageCredentials
     }
 
     /**
-     * Builds the RestoreJobSecrets
+     * Builds the StorageCredentials
      */
     public static class Builder
     {
-        private String accessKeyId;
-        private String secretAccessKey;
-        private String sessionToken;
+        private @Nullable String accessKeyId;
+        private @Nullable String secretAccessKey;
+        private @Nullable String sessionToken;
         private String region;
 
         private Builder()

--- a/analytics-sidecar-client-common/src/main/java/org/apache/cassandra/sidecar/common/request/data/CreateRestoreJobRequestPayload.java
+++ b/analytics-sidecar-client-common/src/main/java/org/apache/cassandra/sidecar/common/request/data/CreateRestoreJobRequestPayload.java
@@ -29,6 +29,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.cassandra.sidecar.common.DataObjectBuilder;
 import org.apache.cassandra.sidecar.common.data.ConsistencyConfig;
 import org.apache.cassandra.sidecar.common.data.ConsistencyLevel;
+import org.apache.cassandra.sidecar.common.data.CredentialType;
 import org.apache.cassandra.sidecar.common.data.RestoreJobSecrets;
 import org.apache.cassandra.sidecar.common.data.RestoreJobStatus;
 import org.apache.cassandra.sidecar.common.data.SSTableImportOptions;
@@ -38,6 +39,7 @@ import org.jetbrains.annotations.Nullable;
 
 import static org.apache.cassandra.sidecar.common.data.RestoreJobConstants.JOB_AGENT;
 import static org.apache.cassandra.sidecar.common.data.RestoreJobConstants.JOB_CONSISTENCY_LEVEL;
+import static org.apache.cassandra.sidecar.common.data.RestoreJobConstants.JOB_CREDENTIAL_TYPE;
 import static org.apache.cassandra.sidecar.common.data.RestoreJobConstants.JOB_EXPIRE_AT;
 import static org.apache.cassandra.sidecar.common.data.RestoreJobConstants.JOB_ID;
 import static org.apache.cassandra.sidecar.common.data.RestoreJobConstants.JOB_IMPORT_OPTIONS;
@@ -47,6 +49,14 @@ import static org.apache.cassandra.sidecar.common.data.RestoreJobConstants.JOB_S
 
 /**
  * Request payload for creating restore jobs.
+ *
+ * <p>Three credential modes are supported via the optional {@code credentialType} field:
+ * <ul>
+ *   <li><b>absent</b> (field omitted): the sidecar defaults to {@code STATIC}; backward-compatible.</li>
+ *   <li><b>{@link CredentialType#STATIC}</b>: all three key fields must be present on both credentials.</li>
+ *   <li><b>{@link CredentialType#IAM}</b>: key fields must be absent; only {@code region} is required.
+ *       Use {@link RestoreJobSecrets#iamMode(String, String)} to build the secrets object.</li>
+ * </ul>
  */
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
 public class CreateRestoreJobRequestPayload
@@ -54,6 +64,8 @@ public class CreateRestoreJobRequestPayload
     private final UUID jobId;
     private final String jobAgent;
     private final RestoreJobSecrets secrets;
+    @Nullable
+    private final CredentialType credentialType;
     private final SSTableImportOptions importOptions;
     private final long expireAtInMillis;
     private final ConsistencyConfig consistencyConfig;
@@ -75,19 +87,21 @@ public class CreateRestoreJobRequestPayload
     /**
      * CreateRestoreJobRequest deserializer
      *
-     * @param jobId            job id of restore job
-     * @param jobAgent         arbitrary text a job can put, which can be used to identify itself during Http request
-     * @param secrets          secrets to be used by restore job to download data
-     * @param importOptions    the configured options for SSTable import
-     * @param expireAtInMillis a timestamp in the future when the job is considered expired
-     * @param consistencyLevel consistency level a job should satisfy
-     * @param localDatacenter  the local datacenter name; required if using local consistency level and localDatacenterOnly is specified
+     * @param jobId               job id of restore job
+     * @param jobAgent            arbitrary text a job can put, which can be used to identify itself during Http request
+     * @param secrets             secrets to be used by restore job to download data
+     * @param credentialType      the credential mode; when null the sidecar defaults to STATIC
+     * @param importOptions       the configured options for SSTable import
+     * @param expireAtInMillis    a timestamp in the future when the job is considered expired
+     * @param consistencyLevel    consistency level a job should satisfy
+     * @param localDatacenter     the local datacenter name; required if using local consistency level and localDatacenterOnly is specified
      * @param localDatacenterOnly whether the job should restore to the specified local datacenter only
      */
     @JsonCreator
     public CreateRestoreJobRequestPayload(@JsonProperty(JOB_ID) UUID jobId,
                                           @JsonProperty(JOB_AGENT) String jobAgent,
                                           @JsonProperty(JOB_SECRETS) RestoreJobSecrets secrets,
+                                          @JsonProperty(JOB_CREDENTIAL_TYPE) @Nullable CredentialType credentialType,
                                           @JsonProperty(JOB_IMPORT_OPTIONS) SSTableImportOptions importOptions,
                                           @JsonProperty(JOB_EXPIRE_AT) long expireAtInMillis,
                                           @JsonProperty(JOB_CONSISTENCY_LEVEL) String consistencyLevel,
@@ -102,6 +116,7 @@ public class CreateRestoreJobRequestPayload
         this.jobId = jobId;
         this.jobAgent = jobAgent;
         this.secrets = secrets;
+        this.credentialType = credentialType;
         this.importOptions = importOptions == null
                              ? SSTableImportOptions.defaults()
                              : importOptions;
@@ -117,6 +132,7 @@ public class CreateRestoreJobRequestPayload
         this(builder.jobId,
              builder.jobAgent,
              builder.secrets,
+             builder.credentialType,
              builder.importOptions,
              builder.expireAtInMillis,
              nameOrNull(builder.consistencyLevel),
@@ -149,6 +165,17 @@ public class CreateRestoreJobRequestPayload
     public RestoreJobSecrets secrets()
     {
         return secrets;
+    }
+
+    /**
+     * @return the credential type for this job; null means the sidecar will use its default (STATIC)
+     */
+    @JsonProperty(JOB_CREDENTIAL_TYPE)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @Nullable
+    public CredentialType credentialType()
+    {
+        return credentialType;
     }
 
     /**
@@ -220,6 +247,7 @@ public class CreateRestoreJobRequestPayload
                JOB_ID + "='" + jobId + "', " +
                JOB_AGENT + "='" + jobAgent + "', " +
                JOB_SECRETS + "='" + secrets + "', " +
+               JOB_CREDENTIAL_TYPE + "='" + credentialType + "', " +
                JOB_EXPIRE_AT + "='" + expireAtInMillis + "', " +
                JOB_CONSISTENCY_LEVEL + "='" + consistencyLevel() + "', " +
                JOB_LOCAL_DATA_CENTER + "='" + localDatacenter() + "', " +
@@ -238,6 +266,8 @@ public class CreateRestoreJobRequestPayload
 
         private UUID jobId = null;
         private String jobAgent = null;
+        @Nullable
+        private CredentialType credentialType = null;
         private ConsistencyLevel consistencyLevel = null;
         private String localDc = null;
         private boolean localDatacenterOnly = false;
@@ -256,6 +286,11 @@ public class CreateRestoreJobRequestPayload
         public Builder jobAgent(String jobAgent)
         {
             return update(b -> b.jobAgent = jobAgent);
+        }
+
+        public Builder credentialType(@Nullable CredentialType credentialType)
+        {
+            return update(b -> b.credentialType = credentialType);
         }
 
         public Builder updateImportOptions(Consumer<SSTableImportOptions> updater)

--- a/analytics-sidecar-client-common/src/test/java/org/apache/cassandra/sidecar/common/data/RestoreJobSecretsTest.java
+++ b/analytics-sidecar-client-common/src/test/java/org/apache/cassandra/sidecar/common/data/RestoreJobSecretsTest.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.sidecar.common.data;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class RestoreJobSecretsTest
+{
+    @Test
+    void testIamModeCreatesRegionOnlyReadCredentials()
+    {
+        RestoreJobSecrets secrets = RestoreJobSecrets.iamMode("us-east-1", "us-west-2");
+        assertThat(secrets.readCredentials().region()).isEqualTo("us-east-1");
+        assertThat(secrets.readCredentials().accessKeyId()).isNull();
+        assertThat(secrets.readCredentials().secretAccessKey()).isNull();
+        assertThat(secrets.readCredentials().sessionToken()).isNull();
+        assertThat(secrets.readCredentials().hasStaticCredentials()).isFalse();
+    }
+
+    @Test
+    void testIamModeUsesSeparateReadAndWriteRegions()
+    {
+        RestoreJobSecrets secrets = RestoreJobSecrets.iamMode("read-region", "write-region");
+        assertThat(secrets.readCredentials().region()).isEqualTo("read-region");
+        assertThat(secrets.writeCredentials().region()).isEqualTo("write-region");
+        assertThat(secrets.readCredentials().hasStaticCredentials()).isFalse();
+        assertThat(secrets.writeCredentials().hasStaticCredentials()).isFalse();
+    }
+
+    @Test
+    void testConstructorRequiresNonNullReadCredentials()
+    {
+        StorageCredentials write = StorageCredentials.builder().region("us-east-1").build();
+        assertThatThrownBy(() -> new RestoreJobSecrets(null, write))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessageContaining("Read credentials must be supplied");
+    }
+
+    @Test
+    void testConstructorRequiresNonNullWriteCredentials()
+    {
+        StorageCredentials read = StorageCredentials.builder().region("us-east-1").build();
+        assertThatThrownBy(() -> new RestoreJobSecrets(read, null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessageContaining("Write credentials must be supplied");
+    }
+}

--- a/analytics-sidecar-client-common/src/test/java/org/apache/cassandra/sidecar/common/data/StorageCredentialsTest.java
+++ b/analytics-sidecar-client-common/src/test/java/org/apache/cassandra/sidecar/common/data/StorageCredentialsTest.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.sidecar.common.data;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class StorageCredentialsTest
+{
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Test
+    void testHasStaticCredentialsReturnsTrueWhenAllFieldsPresent()
+    {
+        StorageCredentials creds = StorageCredentials.builder()
+                                                     .accessKeyId("key")
+                                                     .secretAccessKey("secret")
+                                                     .sessionToken("token")
+                                                     .region("us-east-1")
+                                                     .build();
+        assertThat(creds.hasStaticCredentials()).isTrue();
+    }
+
+    @Test
+    void testHasStaticCredentialsReturnsFalseForRegionOnlyIamMode()
+    {
+        StorageCredentials creds = StorageCredentials.builder()
+                                                     .region("us-east-1")
+                                                     .build();
+        assertThat(creds.hasStaticCredentials()).isFalse();
+    }
+
+    @Test
+    void testHasStaticCredentialsReturnsFalseWhenAccessKeyIdMissing()
+    {
+        StorageCredentials creds = StorageCredentials.builder()
+                                                     .secretAccessKey("secret")
+                                                     .sessionToken("token")
+                                                     .region("us-east-1")
+                                                     .build();
+        assertThat(creds.hasStaticCredentials()).isFalse();
+    }
+
+    @Test
+    void testHasStaticCredentialsReturnsFalseWhenSecretKeyMissing()
+    {
+        StorageCredentials creds = StorageCredentials.builder()
+                                                     .accessKeyId("key")
+                                                     .sessionToken("token")
+                                                     .region("us-east-1")
+                                                     .build();
+        assertThat(creds.hasStaticCredentials()).isFalse();
+    }
+
+    @Test
+    void testHasStaticCredentialsReturnsFalseWhenSessionTokenMissing()
+    {
+        StorageCredentials creds = StorageCredentials.builder()
+                                                     .accessKeyId("key")
+                                                     .secretAccessKey("secret")
+                                                     .region("us-east-1")
+                                                     .build();
+        assertThat(creds.hasStaticCredentials()).isFalse();
+    }
+
+    @Test
+    void testConstructorRequiresRegion()
+    {
+        assertThatThrownBy(() -> StorageCredentials.builder().build())
+        .isInstanceOf(NullPointerException.class)
+        .hasMessageContaining("region must be supplied");
+    }
+
+    @Test
+    void testSerializationRegionOnlyCredentialsOmitsNullKeyFields() throws JsonProcessingException
+    {
+        StorageCredentials creds = StorageCredentials.builder()
+                                                     .region("us-east-1")
+                                                     .build();
+        String json = MAPPER.writeValueAsString(creds);
+        assertThat(json).contains("\"region\":\"us-east-1\"")
+                        .doesNotContain("accessKeyId")
+                        .doesNotContain("secretAccessKey")
+                        .doesNotContain("sessionToken");
+    }
+
+    @Test
+    void testSerializationFullCredentialsIncludesAllFields() throws JsonProcessingException
+    {
+        StorageCredentials creds = StorageCredentials.builder()
+                                                     .accessKeyId("key")
+                                                     .secretAccessKey("secret")
+                                                     .sessionToken("token")
+                                                     .region("us-east-1")
+                                                     .build();
+        String json = MAPPER.writeValueAsString(creds);
+        assertThat(json).contains("\"accessKeyId\":\"key\"")
+                        .contains("\"secretAccessKey\":\"secret\"")
+                        .contains("\"sessionToken\":\"token\"")
+                        .contains("\"region\":\"us-east-1\"");
+    }
+
+    @Test
+    void testDeserializationRegionOnlyCredentials() throws JsonProcessingException
+    {
+        String json = "{\"region\":\"eu-west-1\"}";
+        StorageCredentials creds = MAPPER.readValue(json, StorageCredentials.class);
+        assertThat(creds.region()).isEqualTo("eu-west-1");
+        assertThat(creds.accessKeyId()).isNull();
+        assertThat(creds.secretAccessKey()).isNull();
+        assertThat(creds.sessionToken()).isNull();
+        assertThat(creds.hasStaticCredentials()).isFalse();
+    }
+
+    @Test
+    void testRoundTripFullCredentials() throws JsonProcessingException
+    {
+        StorageCredentials original = StorageCredentials.builder()
+                                                        .accessKeyId("key")
+                                                        .secretAccessKey("secret")
+                                                        .sessionToken("token")
+                                                        .region("us-west-2")
+                                                        .build();
+        String json = MAPPER.writeValueAsString(original);
+        StorageCredentials roundTripped = MAPPER.readValue(json, StorageCredentials.class);
+        assertThat(roundTripped).isEqualTo(original);
+        assertThat(roundTripped.hasStaticCredentials()).isTrue();
+    }
+}

--- a/analytics-sidecar-client-common/src/test/java/org/apache/cassandra/sidecar/common/request/CreateRestoreJobRequestPayloadTest.java
+++ b/analytics-sidecar-client-common/src/test/java/org/apache/cassandra/sidecar/common/request/CreateRestoreJobRequestPayloadTest.java
@@ -36,7 +36,10 @@ import org.apache.cassandra.sidecar.common.data.SSTableImportOptions;
 import org.apache.cassandra.sidecar.common.request.data.CreateRestoreJobRequestPayload;
 import org.apache.cassandra.sidecar.foundation.RestoreJobSecretsGen;
 
+import org.apache.cassandra.sidecar.common.data.CredentialType;
+
 import static org.apache.cassandra.sidecar.common.data.RestoreJobConstants.JOB_CONSISTENCY_LEVEL;
+import static org.apache.cassandra.sidecar.common.data.RestoreJobConstants.JOB_CREDENTIAL_TYPE;
 import static org.apache.cassandra.sidecar.common.data.RestoreJobConstants.JOB_LOCAL_DATA_CENTER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -189,28 +192,6 @@ class CreateRestoreJobRequestPayloadTest
     }
 
     @Test
-    void testBuilder()
-    {
-        RestoreJobSecrets secrets = RestoreJobSecretsGen.genRestoreJobSecrets();
-        CreateRestoreJobRequestPayload req = CreateRestoreJobRequestPayload
-                                             .builder(secrets, System.currentTimeMillis() + 10000)
-                                             .jobAgent("agent")
-                                             .updateImportOptions(options -> {
-                                                 options
-                                                 .resetLevel(false)
-                                                 .clearRepaired(false);
-                                             })
-                                             .consistencyLevel(ConsistencyLevel.QUORUM)
-                                             .build();
-        assertThat(req.secrets()).isEqualTo(secrets);
-        assertThat(req.jobAgent()).isEqualTo("agent");
-        assertThat(req.importOptions()).isEqualTo(SSTableImportOptions.defaults()
-                                                                      .resetLevel(false)
-                                                                      .clearRepaired(false));
-        assertThat(req.consistencyLevel()).isEqualTo("QUORUM");
-    }
-
-    @Test
     void testCreateLocalQuorumJobWithoutLocalDCFails()
     {
         RestoreJobSecrets secrets = RestoreJobSecretsGen.genRestoreJobSecrets();
@@ -254,5 +235,58 @@ class CreateRestoreJobRequestPayloadTest
                                  .build())
         .isExactlyInstanceOf(IllegalArgumentException.class)
         .hasMessage("Must specify a localDatacenter when restoreToLocalDatacenterOnly is true");
+    }
+
+    @Test
+    void testNullCredentialTypeOmittedFromJson() throws JsonProcessingException
+    {
+        RestoreJobSecrets secrets = RestoreJobSecretsGen.genRestoreJobSecrets();
+        CreateRestoreJobRequestPayload req = CreateRestoreJobRequestPayload
+                                             .builder(secrets, System.currentTimeMillis() + 10000)
+                                             .build();
+        assertThat(req.credentialType()).isNull();
+        String json = MAPPER.writeValueAsString(req);
+        assertThat(json).doesNotContain(JOB_CREDENTIAL_TYPE);
+    }
+
+    @Test
+    void testIamCredentialTypeSerializedInJson() throws JsonProcessingException
+    {
+        RestoreJobSecrets secrets = RestoreJobSecretsGen.genRestoreJobSecrets();
+        CreateRestoreJobRequestPayload req = CreateRestoreJobRequestPayload
+                                             .builder(secrets, System.currentTimeMillis() + 10000)
+                                             .credentialType(CredentialType.IAM)
+                                             .build();
+        assertThat(req.credentialType()).isEqualTo(CredentialType.IAM);
+        String json = MAPPER.writeValueAsString(req);
+        assertThat(json).contains("\"" + JOB_CREDENTIAL_TYPE + "\":\"IAM\"");
+    }
+
+    @Test
+    void testStaticCredentialTypeSerializedInJson() throws JsonProcessingException
+    {
+        RestoreJobSecrets secrets = RestoreJobSecretsGen.genRestoreJobSecrets();
+        CreateRestoreJobRequestPayload req = CreateRestoreJobRequestPayload
+                                             .builder(secrets, System.currentTimeMillis() + 10000)
+                                             .credentialType(CredentialType.STATIC)
+                                             .build();
+        assertThat(req.credentialType()).isEqualTo(CredentialType.STATIC);
+        String json = MAPPER.writeValueAsString(req);
+        assertThat(json).contains("\"" + JOB_CREDENTIAL_TYPE + "\":\"STATIC\"");
+    }
+
+    @Test
+    void testCredentialTypeRoundTrip() throws JsonProcessingException
+    {
+        RestoreJobSecrets secrets = RestoreJobSecretsGen.genRestoreJobSecrets();
+        long expireAt = System.currentTimeMillis() + 10000;
+        CreateRestoreJobRequestPayload original = CreateRestoreJobRequestPayload
+                                                  .builder(secrets, expireAt)
+                                                  .credentialType(CredentialType.IAM)
+                                                  .build();
+        String json = MAPPER.writeValueAsString(original);
+        CreateRestoreJobRequestPayload deserialized = MAPPER.readValue(json, CreateRestoreJobRequestPayload.class);
+        assertThat(deserialized.credentialType()).isEqualTo(CredentialType.IAM);
+        assertThat(deserialized.secrets()).isEqualTo(secrets);
     }
 }

--- a/analytics-sidecar-client/build.gradle
+++ b/analytics-sidecar-client/build.gradle
@@ -35,18 +35,7 @@ if (propertyWithDefault("artifactType", null) == "common") {
 
 test {
     useJUnitPlatform()
-    testLogging {
-        events "passed", "skipped", "failed"
-    }
     maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
-    reports {
-        junitXml.setRequired(true)
-        def destDir = Paths.get(rootProject.rootDir.absolutePath, "build", "test-results", "client").toFile()
-        println("Destination directory for client tests: ${destDir}")
-        junitXml.getOutputLocation().set(destDir)
-        html.setRequired(true)
-        html.getOutputLocation().set(destDir)
-    }
 }
 
 configurations {

--- a/analytics-sidecar-vertx-client-shaded/build.gradle
+++ b/analytics-sidecar-vertx-client-shaded/build.gradle
@@ -54,14 +54,6 @@ dependencies {
 tasks.named('test') {
     // Use JUnit Platform for unit tests.
     useJUnitPlatform()
-    reports {
-        junitXml.setRequired(true)
-        def destDir = Paths.get(rootProject.rootDir.absolutePath, "build", "test-results", "vertx-client-shaded").toFile()
-        println("Destination directory for vertx-client-shaded tests: ${destDir}")
-        junitXml.getOutputLocation().set(destDir)
-        html.setRequired(true)
-        html.getOutputLocation().set(destDir)
-    }
 }
 
 // Relocating a Package

--- a/analytics-sidecar-vertx-client/build.gradle
+++ b/analytics-sidecar-vertx-client/build.gradle
@@ -32,14 +32,6 @@ if (propertyWithDefault("artifactType", null) == "common") {
 test {
     useJUnitPlatform()
     maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
-    reports {
-        junitXml.setRequired(true)
-        def destDir = Paths.get(rootProject.rootDir.absolutePath, "build", "test-results", "vertx-client").toFile()
-        println("Destination directory for vertx-client tests: ${destDir}")
-        junitXml.getOutputLocation().set(destDir)
-        html.setRequired(true)
-        html.getOutputLocation().set(destDir)
-    }
 }
 
 configurations {

--- a/build.gradle
+++ b/build.gradle
@@ -250,10 +250,15 @@ subprojects {
   }
 
   // We want to get all the exception information we can on test failure in a multi-node in-jvm env
-  tasks.withType(Test).configureEach {
+  tasks.withType(Test).configureEach { testTask ->
+    reports {
+      junitXml.outputLocation.set(rootProject.file("build/test-results/${project.name}/${testTask.name}"))
+      html.outputLocation.set(rootProject.file("build/reports/tests/${project.name}/${testTask.name}"))
+    }
     testLogging {
-      showExceptions true
+      events "started", "passed", "skipped", "failed"
       exceptionFormat "full"
+      showExceptions true
       showCauses true
       showStackTraces true
     }

--- a/cassandra-analytics-cdc-codec/build.gradle
+++ b/cassandra-analytics-cdc-codec/build.gradle
@@ -74,15 +74,4 @@ test {
     jvmArgs(project.ext.JDK_OPTIONS)
 
     useJUnitPlatform()
-    reports {
-        def destDir = Paths.get(rootProject.rootDir.absolutePath, "build", "test-reports", "four-zero-types").toFile()
-        junitXml {
-            enabled true
-            destination = destDir
-        }
-        html {
-            enabled true
-            destination = destDir
-        }
-    }
 }

--- a/cassandra-analytics-cdc-sidecar/build.gradle
+++ b/cassandra-analytics-cdc-sidecar/build.gradle
@@ -132,16 +132,5 @@ jar {
 
 test {
     useJUnitPlatform()
-    reports {
-        def destDir = Paths.get(rootProject.rootDir.absolutePath, "build", "test-reports", "cdc-sidecar").toFile()
-        junitXml {
-            enabled true
-            destination = destDir
-        }
-        html {
-            enabled true
-            destination = destDir
-        }
-    }
 }
 

--- a/cassandra-analytics-cdc/build.gradle
+++ b/cassandra-analytics-cdc/build.gradle
@@ -172,9 +172,6 @@ def configureCdcTestTask = { Test task, String majorMinor = null ->
     task.dependsOn(tasks.jar)
     task.classpath += files(jar.archiveFile)
     task.useJUnitPlatform()
-    def destDir = Paths.get(rootProject.rootDir.absolutePath, "build", "test-reports", "cdc").toFile()
-    task.reports.junitXml.outputLocation = destDir
-    task.reports.html.outputLocation = destDir
 }
 
 test {

--- a/cassandra-analytics-common/build.gradle
+++ b/cassandra-analytics-common/build.gradle
@@ -51,15 +51,4 @@ dependencies {
 
 test {
     useJUnitPlatform()
-    reports {
-        def destDir = Paths.get(rootProject.rootDir.absolutePath, "build", "test-reports", "common").toFile()
-        junitXml {
-            enabled true
-            destination = destDir
-        }
-        html {
-            enabled true
-            destination = destDir
-        }
-    }
 }

--- a/cassandra-analytics-core/build.gradle
+++ b/cassandra-analytics-core/build.gradle
@@ -177,13 +177,6 @@ def configureCoreTestTask(Test task, String majorMinor = null) {
     task.dependsOn(tasks.jar)
     task.classpath += files(jar.archiveFile)
 
-    def destDir = Paths.get(rootProject.rootDir.absolutePath, "build", "test-reports", "core").toFile()
-    task.reports.junitXml.outputLocation = destDir
-    task.reports.html.outputLocation = destDir
-
-    task.testLogging {
-        events "started", "passed", "skipped", "failed"
-    }
 }
 
 // Tests tagged 'Sequential' do not run in parallel, to prevent OOM errors

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/BulkSparkConf.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/BulkSparkConf.java
@@ -248,7 +248,21 @@ public class BulkSparkConf implements Serializable
         long maxSizePerSSTableBundleInBytesS3Transport = MapUtils.getLong(options, WriterOptions.MAX_SIZE_PER_SSTABLE_BUNDLE_IN_BYTES_S3_TRANSPORT.name(),
                                                                           DEFAULT_MAX_SIZE_PER_SSTABLE_BUNDLE_IN_BYTES_S3_TRANSPORT);
         String transportExtensionClass = MapUtils.getOrDefault(options, WriterOptions.DATA_TRANSPORT_EXTENSION_CLASS.name(), null);
-        this.dataTransportInfo = new DataTransportInfo(dataTransport, transportExtensionClass, maxSizePerSSTableBundleInBytesS3Transport);
+        String rawCredentialType = MapUtils.getOrDefault(options, WriterOptions.STORAGE_CREDENTIAL_TYPE.name(), null);
+        String storageCredentialType = null;
+        if (rawCredentialType != null)
+        {
+            storageCredentialType = rawCredentialType.toUpperCase();
+            if (!storageCredentialType.equals("STATIC") && !storageCredentialType.equals("IAM"))
+            {
+                throw new IllegalArgumentException(
+                String.format("Invalid value '%s' for option '%s'. Valid values are: STATIC, IAM",
+                              rawCredentialType, WriterOptions.STORAGE_CREDENTIAL_TYPE.name()));
+            }
+        }
+        this.dataTransportInfo = new DataTransportInfo(dataTransport, transportExtensionClass,
+                                                       maxSizePerSSTableBundleInBytesS3Transport,
+                                                       storageCredentialType);
         this.jobKeepAliveMinutes = MapUtils.getInt(options, WriterOptions.JOB_KEEP_ALIVE_MINUTES.name(), MINIMUM_JOB_KEEP_ALIVE_MINUTES);
         if (this.jobKeepAliveMinutes < MINIMUM_JOB_KEEP_ALIVE_MINUTES)
         {

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/CassandraBulkSourceRelation.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/CassandraBulkSourceRelation.java
@@ -34,6 +34,7 @@ import com.google.common.base.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import o.a.c.sidecar.client.shaded.common.data.CredentialType;
 import o.a.c.sidecar.client.shaded.common.data.RestoreJobSecrets;
 import o.a.c.sidecar.client.shaded.common.data.RestoreJobStatus;
 import o.a.c.sidecar.client.shaded.common.request.data.CreateRestoreJobRequestPayload;
@@ -51,6 +52,7 @@ import org.apache.cassandra.spark.bulkwriter.token.ReplicaAwareFailureHandler;
 import org.apache.cassandra.spark.data.partitioner.Partitioner;
 import org.apache.cassandra.spark.exception.SidecarApiCallException;
 import org.apache.cassandra.spark.exception.UnsupportedAnalyticsOperationException;
+import org.apache.cassandra.spark.transports.storage.StorageCredentialPair;
 import org.apache.cassandra.spark.transports.storage.extensions.StorageTransportConfiguration;
 import org.apache.cassandra.spark.transports.storage.extensions.StorageTransportExtension;
 import org.apache.cassandra.spark.transports.storage.extensions.StorageTransportHandler;
@@ -445,11 +447,11 @@ public class CassandraBulkSourceRelation extends BaseRelation implements Inserta
     private void createRestoreJob(TransportContext.CloudStorageTransportContext context)
     {
         StorageTransportConfiguration conf = context.transportConfiguration();
+        String credTypeName = writerContext.job().transportInfo().getStorageCredentialType();
         // todo: refactor to move away from using 'null'
-        RestoreJobSecrets secrets = conf.getStorageCredentialPair(null)
-                                        .toRestoreJobSecrets();
+        RestoreJobSecrets secrets = buildRestoreJobSecrets(conf.getStorageCredentialPair(null), credTypeName);
         JobInfo job = writerContext.job();
-        CreateRestoreJobRequestPayload payload = createJobPayloadBuilder(job, secrets).build();
+        CreateRestoreJobRequestPayload payload = createJobPayloadBuilder(job, secrets, null, credTypeName).build();
         context.dataTransferApi().createRestoreJob(payload);
     }
 
@@ -461,14 +463,14 @@ public class CassandraBulkSourceRelation extends BaseRelation implements Inserta
 
         JobInfo job = writerContext.job();
         ConsistencyLevel cl = job.getConsistencyLevel();
+        String credTypeName = job.transportInfo().getStorageCredentialType();
 
         // create restore job on each cluster
         dataTransferApi.forEach((clusterId, api) -> {
-            RestoreJobSecrets secrets = conf.getStorageCredentialPair(clusterId)
-                                            .toRestoreJobSecrets();
+            RestoreJobSecrets secrets = buildRestoreJobSecrets(conf.getStorageCredentialPair(clusterId), credTypeName);
             CoordinatedWriteConf.ClusterConf cluster = coordinatedWriteConf.cluster(clusterId);
             String localDc = cluster.resolveLocalDc(cl); // resolve the cluster specific localDc name
-            CreateRestoreJobRequestPayload payload = createJobPayloadBuilder(job, secrets, clusterId)
+            CreateRestoreJobRequestPayload payload = createJobPayloadBuilder(job, secrets, clusterId, credTypeName)
                                                      .consistencyLevel(toSidecarConsistencyLevel(cl), localDc)
                                                      // TODO: add test case once we advance the sidecar version that understands the flag,
                                                      //       or a better testing strategy is figured out
@@ -478,12 +480,26 @@ public class CassandraBulkSourceRelation extends BaseRelation implements Inserta
         });
     }
 
-    private CreateRestoreJobRequestPayload.Builder createJobPayloadBuilder(JobInfo job, RestoreJobSecrets secrets)
+    /**
+     * Builds {@link RestoreJobSecrets} appropriate for the given credential type.
+     * When {@code credentialTypeName} is {@code "IAM"}, region-only secrets are produced
+     * and the sidecar will use the AWS default credential chain.
+     * Otherwise, full static credentials from the pair are used.
+     */
+    static RestoreJobSecrets buildRestoreJobSecrets(StorageCredentialPair pair,
+                                                    @org.jetbrains.annotations.Nullable String credentialTypeName)
     {
-        return createJobPayloadBuilder(job, secrets, null);
+        if ("IAM".equals(credentialTypeName))
+        {
+            return RestoreJobSecrets.iamMode(pair.readRegion(), pair.writeRegion());
+        }
+        return pair.toRestoreJobSecrets();
     }
 
-    private CreateRestoreJobRequestPayload.Builder createJobPayloadBuilder(JobInfo job, RestoreJobSecrets secrets, String clusterId)
+    private CreateRestoreJobRequestPayload.Builder createJobPayloadBuilder(JobInfo job,
+                                                                            RestoreJobSecrets secrets,
+                                                                            String clusterId,
+                                                                            @org.jetbrains.annotations.Nullable String credentialTypeName)
     {
         CreateRestoreJobRequestPayload.Builder builder = CreateRestoreJobRequestPayload.builder(secrets, updatedLeaseTime());
         builder.jobAgent(BuildInfo.APPLICATION_NAME)
@@ -492,6 +508,10 @@ public class CassandraBulkSourceRelation extends BaseRelation implements Inserta
                    importOptions.verifySSTables(true) // we disallow the end-user to bypass the non-extended verify anymore
                                 .extendedVerify(false); // always turn off
                });
+        if (credentialTypeName != null)
+        {
+            builder.credentialType(CredentialType.valueOf(credentialTypeName.toUpperCase()));
+        }
         return builder;
     }
 

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/DataTransportInfo.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/DataTransportInfo.java
@@ -21,6 +21,8 @@ package org.apache.cassandra.spark.bulkwriter;
 
 import java.io.Serializable;
 
+import org.jetbrains.annotations.Nullable;
+
 public class DataTransportInfo implements Serializable
 {
     private static final long serialVersionUID = 1823178559314014761L;
@@ -30,11 +32,30 @@ public class DataTransportInfo implements Serializable
     // note this should be shifted under appropriate class
     private final long maxSizePerBundleInBytes;
 
-    public DataTransportInfo(DataTransport transport, String transportExtensionClass, long maxSizePerBundleInBytes)
+    /**
+     * The credential type name (e.g. "STATIC", "IAM"), stored as a String to avoid tight coupling to
+     * shaded sidecar classes and to stay safely serializable across Spark broadcast. Null means the user
+     * did not specify one, and the sidecar will use its default (STATIC).
+     */
+    @Nullable
+    private final String storageCredentialType;
+
+    public DataTransportInfo(DataTransport transport,
+                             String transportExtensionClass,
+                             long maxSizePerBundleInBytes)
+    {
+        this(transport, transportExtensionClass, maxSizePerBundleInBytes, null);
+    }
+
+    public DataTransportInfo(DataTransport transport,
+                             String transportExtensionClass,
+                             long maxSizePerBundleInBytes,
+                             @Nullable String storageCredentialType)
     {
         this.transport = transport;
         this.transportExtensionClass = transportExtensionClass;
         this.maxSizePerBundleInBytes = maxSizePerBundleInBytes;
+        this.storageCredentialType = storageCredentialType;
     }
 
     public DataTransport getTransport()
@@ -52,10 +73,17 @@ public class DataTransportInfo implements Serializable
         return maxSizePerBundleInBytes;
     }
 
+    @Nullable
+    public String getStorageCredentialType()
+    {
+        return storageCredentialType;
+    }
+
     public String toString()
     {
         return "TransportInfo={dataTransport=" + transport
                + ",transportExtensionClass=" + transportExtensionClass
-               + ",maxSizePerBundleInBytes=" + maxSizePerBundleInBytes + '}';
+               + ",maxSizePerBundleInBytes=" + maxSizePerBundleInBytes
+               + ",storageCredentialType=" + storageCredentialType + '}';
     }
 }

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/WriterOptions.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/WriterOptions.java
@@ -140,4 +140,18 @@ public enum WriterOptions implements WriterOption
      * rebuilt separately after the job completes.
      */
     SKIP_SECONDARY_INDEX_CHECK,
+    /**
+     * Option to specify the credential mechanism the sidecar should use to authenticate with S3.
+     * Accepted values (case-insensitive): {@code "STATIC"}, {@code "IAM"}.
+     * <p>
+     * When absent the sidecar defaults to static credentials (backward-compatible behavior).
+     * <ul>
+     *   <li>{@code STATIC}: send full credentials; the sidecar uses {@code StaticCredentialsProvider}.</li>
+     *   <li>{@code IAM}: send region only; the sidecar uses {@code DefaultCredentialsProvider}
+     *       (instance profile / IRSA / ECS task role). The {@link StorageTransportExtension} should
+     *       return a {@code StorageCredentialPair} created with
+     *       {@code StorageCredentialPair.iamPair(readRegion, writeRegion)}.</li>
+     * </ul>
+     */
+    STORAGE_CREDENTIAL_TYPE,
 }

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/cloudstorage/CloudStorageDataTransferApi.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/cloudstorage/CloudStorageDataTransferApi.java
@@ -28,7 +28,7 @@ import o.a.c.sidecar.client.shaded.common.response.data.RestoreJobSummaryRespons
 import o.a.c.sidecar.client.shaded.client.SidecarInstance;
 import org.apache.cassandra.spark.exception.S3ApiCallException;
 import org.apache.cassandra.spark.exception.SidecarApiCallException;
-import org.apache.cassandra.spark.transports.storage.StorageCredentials;
+import org.apache.cassandra.spark.transports.storage.StorageAuth;
 
 /**
  * The collection of APIs for cloud-storage-based data transfer
@@ -37,7 +37,7 @@ public interface CloudStorageDataTransferApi
 {
     /*------ Cloud storage APIs -------*/
 
-    BundleStorageObject uploadBundle(StorageCredentials writeCredentials, Bundle bundle) throws S3ApiCallException;
+    BundleStorageObject uploadBundle(StorageAuth writeAuth, Bundle bundle) throws S3ApiCallException;
 
 
     /*------ Sidecar APIs -------*/

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/cloudstorage/CloudStorageDataTransferApiImpl.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/cloudstorage/CloudStorageDataTransferApiImpl.java
@@ -42,8 +42,9 @@ import org.apache.cassandra.spark.bulkwriter.JobInfo;
 import org.apache.cassandra.spark.data.QualifiedTableName;
 import org.apache.cassandra.spark.exception.S3ApiCallException;
 import org.apache.cassandra.spark.exception.SidecarApiCallException;
-import org.apache.cassandra.spark.transports.storage.StorageCredentials;
+import org.apache.cassandra.spark.transports.storage.StorageAuth;
 import org.jetbrains.annotations.Nullable;
+
 
 /**
  * Encapsulates transfer APIs used by {@link CloudStorageStreamSession}. {@link StorageClient} is used to interact with S3 and
@@ -80,11 +81,11 @@ public class CloudStorageDataTransferApiImpl implements CloudStorageDataTransfer
     /*------ Blob APIs -------*/
 
     @Override
-    public BundleStorageObject uploadBundle(StorageCredentials writeCredentials, Bundle bundle) throws S3ApiCallException
+    public BundleStorageObject uploadBundle(StorageAuth writeAuth, Bundle bundle) throws S3ApiCallException
     {
         try
         {
-            return storageClient.multiPartUpload(writeCredentials, bundle);
+            return storageClient.multiPartUpload(writeAuth, bundle);
         }
         catch (Exception exception)
         {

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/cloudstorage/CloudStorageStreamSession.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/cloudstorage/CloudStorageStreamSession.java
@@ -57,6 +57,8 @@ import org.apache.cassandra.spark.data.QualifiedTableName;
 import org.apache.cassandra.spark.exception.ConsistencyNotSatisfiedException;
 import org.apache.cassandra.spark.exception.S3ApiCallException;
 import org.apache.cassandra.spark.exception.SidecarApiCallException;
+import org.apache.cassandra.spark.transports.storage.IamStorageAuth;
+import org.apache.cassandra.spark.transports.storage.StorageAuth;
 import org.apache.cassandra.spark.transports.storage.StorageCredentials;
 
 /**
@@ -227,11 +229,11 @@ public class CloudStorageStreamSession extends StreamSession<TransportContext.Cl
 
     void sendBundle(Bundle bundle, boolean hasRefreshedCredentials)
     {
-        StorageCredentials writeCredentials = getStorageCredentialsFromSidecar();
+        StorageAuth writeAuth = resolveWriteCredentials();
         BundleStorageObject bundleStorageObject;
         try
         {
-            bundleStorageObject = uploadBundle(writeCredentials, bundle);
+            bundleStorageObject = uploadBundle(writeAuth, bundle);
         }
         catch (Exception e)
         {
@@ -276,6 +278,15 @@ public class CloudStorageStreamSession extends StreamSession<TransportContext.Cl
         }
     }
 
+    private StorageAuth resolveWriteCredentials()
+    {
+        if ("IAM".equals(writerContext.job().transportInfo().getStorageCredentialType()))
+        {
+            return IamStorageAuth.INSTANCE;
+        }
+        return getStorageCredentialsFromSidecar();
+    }
+
     private StorageCredentials getStorageCredentialsFromSidecar()
     {
         try
@@ -293,9 +304,9 @@ public class CloudStorageStreamSession extends StreamSession<TransportContext.Cl
     /**
      * Uploads generated SSTable bundle
      */
-    private BundleStorageObject uploadBundle(StorageCredentials writeCredentials, Bundle bundle) throws S3ApiCallException
+    private BundleStorageObject uploadBundle(StorageAuth writeAuth, Bundle bundle) throws S3ApiCallException
     {
-        BundleStorageObject object = dataTransferApi.uploadBundle(writeCredentials, bundle);
+        BundleStorageObject object = dataTransferApi.uploadBundle(writeAuth, bundle);
         transportContext.transportExtensionImplementation()
                         .onObjectPersisted(transportContext.transportConfiguration()
                                                            .writeAccessConfiguration()

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/cloudstorage/StorageClient.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/cloudstorage/StorageClient.java
@@ -41,12 +41,10 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import org.apache.cassandra.spark.transports.storage.StorageCredentials;
+import org.apache.cassandra.spark.transports.storage.StorageAuth;
 import org.apache.cassandra.spark.transports.storage.extensions.StorageTransportConfiguration;
-import software.amazon.awssdk.auth.credentials.AwsCredentials;
+
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
-import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
-import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
 import software.amazon.awssdk.core.async.AsyncRequestBody;
 import software.amazon.awssdk.core.client.config.SdkAdvancedAsyncClientOption;
@@ -77,7 +75,7 @@ public class StorageClient implements AutoCloseable
     private final DataChunker dataChunker;
     private final Tagging tagging;
     private final S3AsyncClient client;
-    private final Map<StorageCredentials, AwsCredentialsProvider> credentialsCache;
+    private final Map<StorageAuth, AwsCredentialsProvider> credentialsCache;
 
     public StorageClient(StorageTransportConfiguration storageTransportConfiguration,
                          StorageClientConfig storageClientConfig)
@@ -139,27 +137,24 @@ public class StorageClient implements AutoCloseable
      * We use {@link CreateMultipartUploadRequest} to break down each SSTable bundle into chunks, according to
      * chunk size set, and upload to S3.
      *
-     * @param credentials credentials used for uploading to S3
-     * @param bundle      bundle of sstables
+     * @param auth   the auth mechanism for this upload (e.g. {@link org.apache.cassandra.spark.transports.storage.StorageCredentials}
+     *               for static STS keys, {@link org.apache.cassandra.spark.transports.storage.IamStorageAuth} for instance profile)
+     * @param bundle bundle of sstables
      * @return BundleStorageObject representing the uploaded bundle
      * @throws IOException          when an IO exception occurs during the multipart upload
      * @throws ExecutionException   when it fails to retrieve the state of a task
      * @throws InterruptedException when the thread is interrupted
      */
-    public BundleStorageObject multiPartUpload(StorageCredentials credentials,
+    public BundleStorageObject multiPartUpload(StorageAuth auth,
                                                Bundle bundle)
     throws IOException, ExecutionException, InterruptedException
     {
-        if (credentials == null)
-        {
-            throw new IllegalArgumentException("No credentials provided for uploading bundles");
-        }
 
         String key = calculateStorageKeyForBundle(storageTransportConfiguration.getPrefix(),
                                                   bundle.bundleFile);
         String bucket = storageTransportConfiguration.writeAccessConfiguration().bucket();
         CreateMultipartUploadRequest multipartUploadRequest = CreateMultipartUploadRequest.builder()
-                                                                                          .overrideConfiguration(credentialsOverride(credentials))
+                                                                                          .overrideConfiguration(credentialsOverride(auth))
                                                                                           .bucket(bucket)
                                                                                           .key(key)
                                                                                           .tagging(tagging)
@@ -168,7 +163,7 @@ public class StorageClient implements AutoCloseable
         CreateMultipartUploadResponse multipartUploadResponse = client.createMultipartUpload(multipartUploadRequest).get();
         String uploadId = multipartUploadResponse.uploadId();
 
-        List<CompletedPart> completedParts = uploadPartsOfBundle(key, uploadId, credentials, bundle);
+        List<CompletedPart> completedParts = uploadPartsOfBundle(key, uploadId, auth, bundle);
 
         // tell s3 to merge all completed parts by making the CompleteMultipartUploadRequest
         CompletedMultipartUpload completedUpload = CompletedMultipartUpload.builder()
@@ -176,7 +171,7 @@ public class StorageClient implements AutoCloseable
                                                                            .build();
 
         CompleteMultipartUploadRequest completeMultipartUploadRequest = CompleteMultipartUploadRequest.builder()
-                                                                                                      .overrideConfiguration(credentialsOverride(credentials))
+                                                                                                      .overrideConfiguration(credentialsOverride(auth))
                                                                                                       .bucket(bucket)
                                                                                                       .key(key)
                                                                                                       .uploadId(uploadId)
@@ -200,7 +195,7 @@ public class StorageClient implements AutoCloseable
     }
 
     private List<CompletedPart> uploadPartsOfBundle(String key, String uploadId,
-                                                    StorageCredentials credentials,
+                                                    StorageAuth auth,
                                                     Bundle bundle)
     throws IOException, ExecutionException, InterruptedException
     {
@@ -221,7 +216,7 @@ public class StorageClient implements AutoCloseable
                 // get a copy of the remaining ByteBuffer; for the last chunk, the cloned ByteBuffer is resized accordingly.
                 AsyncRequestBody body = AsyncRequestBody.fromRemainingByteBuffer(buffer);
                 UploadPartRequest uploadPartRequest = UploadPartRequest.builder()
-                                                                       .overrideConfiguration(credentialsOverride(credentials))
+                                                                       .overrideConfiguration(credentialsOverride(auth))
                                                                        .bucket(bucket)
                                                                        .key(key)
                                                                        .uploadId(uploadId)
@@ -248,16 +243,8 @@ public class StorageClient implements AutoCloseable
         return prefix + SEPARATOR + bundleLocation.getFileName();
     }
 
-    private AwsCredentialsProvider toCredentialsProvider(StorageCredentials storageCredentials)
+    private Consumer<AwsRequestOverrideConfiguration.Builder> credentialsOverride(StorageAuth auth)
     {
-        AwsCredentials credentials = AwsSessionCredentials.create(storageCredentials.getAccessKeyId(),
-                                                                  storageCredentials.getSecretKey(),
-                                                                  storageCredentials.getSessionToken());
-        return StaticCredentialsProvider.create(credentials);
-    }
-
-    private Consumer<AwsRequestOverrideConfiguration.Builder> credentialsOverride(StorageCredentials credentials)
-    {
-        return b -> b.credentialsProvider(credentialsCache.computeIfAbsent(credentials, this::toCredentialsProvider));
+        return b -> b.credentialsProvider(credentialsCache.computeIfAbsent(auth, StorageAuth::toAwsCredentialsProvider));
     }
 }

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/cloudstorage/coordinated/CoordinatedCloudStorageDataTransferApi.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/bulkwriter/cloudstorage/coordinated/CoordinatedCloudStorageDataTransferApi.java
@@ -52,7 +52,7 @@ import org.apache.cassandra.spark.bulkwriter.cloudstorage.CloudStorageDataTransf
 import org.apache.cassandra.spark.data.QualifiedTableName;
 import org.apache.cassandra.spark.exception.S3ApiCallException;
 import org.apache.cassandra.spark.exception.SidecarApiCallException;
-import org.apache.cassandra.spark.transports.storage.StorageCredentials;
+import org.apache.cassandra.spark.transports.storage.StorageAuth;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -95,9 +95,9 @@ public class CoordinatedCloudStorageDataTransferApi implements CloudStorageDataT
     }
 
     @Override
-    public BundleStorageObject uploadBundle(StorageCredentials writeCredentials, Bundle bundle) throws S3ApiCallException
+    public BundleStorageObject uploadBundle(StorageAuth writeAuth, Bundle bundle) throws S3ApiCallException
     {
-        return dataTransferApis.getAnyValueOrThrow().uploadBundle(writeCredentials, bundle);
+        return dataTransferApis.getAnyValueOrThrow().uploadBundle(writeAuth, bundle);
     }
 
     @Override

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/transports/storage/IamStorageAuth.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/transports/storage/IamStorageAuth.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cassandra.spark.transports.storage;
+
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+
+/**
+ * {@link StorageAuth} implementation for IAM instance profile / IRSA / ECS task role authentication.
+ * Carries no static credentials; the AWS SDK resolves them automatically via its default provider chain.
+ * Use {@link #INSTANCE} — there is no per-instance state.
+ */
+public final class IamStorageAuth implements StorageAuth
+{
+    public static final IamStorageAuth INSTANCE = new IamStorageAuth();
+
+    private IamStorageAuth()
+    {
+    }
+
+    @Override
+    public AwsCredentialsProvider toAwsCredentialsProvider()
+    {
+        return DefaultCredentialsProvider.create();
+    }
+
+    @Override
+    public String toString()
+    {
+        return "IamStorageAuth";
+    }
+}

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/transports/storage/StorageAccessConfiguration.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/transports/storage/StorageAccessConfiguration.java
@@ -33,23 +33,25 @@ public class StorageAccessConfiguration
 {
     private final String region;
     private final String bucket;
-    private final StorageCredentials storageCredentials;
+    private final StorageAuth storageAuth;
 
-    public StorageAccessConfiguration(@NotNull String region, @NotNull String bucket, @NotNull StorageCredentials storageCredentials)
+    public StorageAccessConfiguration(@NotNull String region, @NotNull String bucket,
+                                      @NotNull StorageAuth storageAuth)
     {
         this.region = region;
         this.bucket = bucket;
-        this.storageCredentials = storageCredentials;
+        this.storageAuth = storageAuth;
     }
 
     /**
-     * Create a new instance of StorageAccessConfiguration with the credentials updated
-     * @param newCredentials credentials to update
+     * Create a new instance of StorageAccessConfiguration with the auth updated.
+     *
+     * @param newAuth the new auth mechanism
      * @return new instance
      */
-    public StorageAccessConfiguration copyWithNewCredentials(@NotNull StorageCredentials newCredentials)
+    public StorageAccessConfiguration copyWithNewAuth(@NotNull StorageAuth newAuth)
     {
-        return new StorageAccessConfiguration(this.region, this.bucket, newCredentials);
+        return new StorageAccessConfiguration(this.region, this.bucket, newAuth);
     }
 
     public String region()
@@ -62,9 +64,9 @@ public class StorageAccessConfiguration
         return bucket;
     }
 
-    public StorageCredentials storageCredentials()
+    public StorageAuth storageAuth()
     {
-        return storageCredentials;
+        return storageAuth;
     }
 
     @Override
@@ -83,13 +85,13 @@ public class StorageAccessConfiguration
         StorageAccessConfiguration that = (StorageAccessConfiguration) obj;
         return Objects.equals(region, that.region)
                && Objects.equals(bucket, that.bucket)
-               && Objects.equals(storageCredentials, that.storageCredentials);
+               && Objects.equals(storageAuth, that.storageAuth);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(region, bucket, storageCredentials);
+        return Objects.hash(region, bucket, storageAuth);
     }
 
     @Override
@@ -98,7 +100,7 @@ public class StorageAccessConfiguration
         return "StorageAccessConfiguration{"
                + "region='" + region + '\''
                + ", bucket='" + bucket + '\''
-               + ", credentials='" + storageCredentials + '\''
+               + ", auth='" + storageAuth + '\''
                + '}';
     }
 
@@ -109,16 +111,22 @@ public class StorageAccessConfiguration
         {
             out.writeString(object.region);
             out.writeString(object.bucket);
-            kryo.writeObject(out, object.storageCredentials);
+            String authType = object.storageAuth instanceof IamStorageAuth ? "IAM" : "STATIC";
+            out.writeString(authType);
+            if (!"IAM".equals(authType))
+            {
+                kryo.writeObject(out, (StorageCredentials) object.storageAuth);
+            }
         }
 
         @Override
         public StorageAccessConfiguration read(Kryo kryo, Input in, Class<StorageAccessConfiguration> type)
         {
-            return new StorageAccessConfiguration(
-            in.readString(), // region
-            in.readString(), // bucket
-            kryo.readObject(in, StorageCredentials.class));
+            String region = in.readString();
+            String bucket = in.readString();
+            String authType = in.readString();
+            StorageAuth auth = "IAM".equals(authType) ? IamStorageAuth.INSTANCE : kryo.readObject(in, StorageCredentials.class);
+            return new StorageAccessConfiguration(region, bucket, auth);
         }
     }
 }

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/transports/storage/StorageAuth.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/transports/storage/StorageAuth.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cassandra.spark.transports.storage;
+
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+
+/**
+ * Authentication mechanism used to access cloud storage.
+ *
+ * <ul>
+ *   <li>{@link StorageCredentials} — explicit STS access key / secret / session token</li>
+ *   <li>{@link IamStorageAuth} — IAM instance profile / IRSA / ECS task role;
+ *       no static credentials; the AWS SDK resolves credentials automatically</li>
+ * </ul>
+ *
+ * <p>Callers (e.g. {@code StorageClient}) dispatch via {@link #toAwsCredentialsProvider()}
+ * without branching on the concrete type. New auth mechanisms are added by implementing
+ * this interface — no changes to calling code are required.
+ */
+public interface StorageAuth
+{
+    /**
+     * Returns an {@link AwsCredentialsProvider} for this auth mechanism.
+     * The result is cached by the caller; this method may be invoked at most once per distinct instance.
+     */
+    AwsCredentialsProvider toAwsCredentialsProvider();
+}

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/transports/storage/StorageCredentialPair.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/transports/storage/StorageCredentialPair.java
@@ -24,41 +24,95 @@ import java.util.Objects;
 import o.a.c.sidecar.client.shaded.common.data.RestoreJobSecrets;
 
 /**
- * A class representing the pair of credentials needed to complete an analytics operation using the Storage transport.
- * It is possible that both credentials (read and write) are the same, but also that they could represent
- * the credentials needed for two different buckets when using cross-region synchronization to transfer data
- * between regions.
+ * A class representing the pair of auth configurations needed to complete an analytics operation using the
+ * Storage transport. It is possible that both read and write auth are the same, but they could also represent
+ * different buckets when using cross-region synchronization to transfer data between regions.
+ *
+ * <p>The auth field is a {@link StorageAuth}, either:
+ * <ul>
+ *   <li>{@link StorageCredentials} — explicit STS credentials for static auth</li>
+ *   <li>{@link IamStorageAuth} — no static credentials; the sidecar and Spark executors use the AWS SDK
+ *       default provider chain (instance profile / IRSA / ECS task role)</li>
+ * </ul>
+ *
+ * <p>For IAM mode use {@link #iamPair(String, String)}. The library wires the correct sidecar payload
+ * automatically when {@code STORAGE_CREDENTIAL_TYPE=IAM} is set.
  */
 public class StorageCredentialPair
 {
     private final String writeRegion;
-    public final StorageCredentials writeCredentials;
+    private final StorageAuth writeAuth;
     private final String readRegion;
-    public final StorageCredentials readCredentials;
+    private final StorageAuth readAuth;
+
+    /**
+     * Creates a {@link StorageCredentialPair} for IAM instance profile mode.
+     * The credentials fields are null; only the regions are required so the sidecar can route requests.
+     *
+     * @param readRegion  the AWS region for the read (download) bucket
+     * @param writeRegion the AWS region for the write (upload) bucket
+     * @return a region-only pair suitable for use with {@code STORAGE_CREDENTIAL_TYPE=IAM}
+     */
+    public static StorageCredentialPair iamPair(String readRegion, String writeRegion)
+    {
+        return new StorageCredentialPair(writeRegion, IamStorageAuth.INSTANCE, readRegion, IamStorageAuth.INSTANCE);
+    }
 
     /**
      * Create a new instance of a StorageCredentialPair
      *
      * @param writeRegion the name of the region where write/upload happens
-     * @param writeCredentials the credentials used for writing to the storage endpoint
-     * @param readRegion the name of the region where read/download happens
-     * @param readCredentials  the credentials used to read from the storage endpoint
+     * @param writeAuth   the auth used for writing to the storage endpoint
+     * @param readRegion  the name of the region where read/download happens
+     * @param readAuth    the auth used for reading from the storage endpoint
      */
     public StorageCredentialPair(String writeRegion,
-                                 StorageCredentials writeCredentials,
+                                 StorageAuth writeAuth,
                                  String readRegion,
-                                 StorageCredentials readCredentials)
+                                 StorageAuth readAuth)
     {
         this.writeRegion = writeRegion;
-        this.writeCredentials = writeCredentials;
+        this.writeAuth = writeAuth;
         this.readRegion = readRegion;
-        this.readCredentials = readCredentials;
+        this.readAuth = readAuth;
     }
 
+    public String writeRegion()
+    {
+        return writeRegion;
+    }
+
+    public StorageAuth writeAuth()
+    {
+        return writeAuth;
+    }
+
+    public String readRegion()
+    {
+        return readRegion;
+    }
+
+    public StorageAuth readAuth()
+    {
+        return readAuth;
+    }
+
+    /**
+     * Converts this pair to {@link RestoreJobSecrets} for static credential mode.
+     * Throws {@link IllegalStateException} if either auth is not a {@link StorageCredentials} (i.e. this is an IAM pair);
+     * use {@link RestoreJobSecrets#iamMode(String, String)} for IAM mode.
+     */
     public RestoreJobSecrets toRestoreJobSecrets()
     {
-        return new RestoreJobSecrets(readCredentials.toSidecarCredentials(readRegion),
-                                     writeCredentials.toSidecarCredentials(writeRegion));
+        if (!(writeAuth instanceof StorageCredentials) || !(readAuth instanceof StorageCredentials))
+        {
+            throw new IllegalStateException("Cannot call toRestoreJobSecrets() on an IAM credential pair. " +
+                                            "Use RestoreJobSecrets.iamMode() instead.");
+        }
+        StorageCredentials write = (StorageCredentials) writeAuth;
+        StorageCredentials read = (StorageCredentials) readAuth;
+        return new RestoreJobSecrets(read.toSidecarCredentials(readRegion),
+                                     write.toSidecarCredentials(writeRegion));
     }
 
     @Override
@@ -66,9 +120,9 @@ public class StorageCredentialPair
     {
         return "StorageCredentialPair{"
                + "writeRegion=" + writeRegion
-               + ", writeCredentials=" + writeCredentials
+               + ", writeAuth=" + writeAuth
                + ", readRegion=" + readRegion
-               + ", readCredentials=" + readCredentials
+               + ", readAuth=" + readAuth
                + '}';
     }
 
@@ -85,14 +139,14 @@ public class StorageCredentialPair
         }
         StorageCredentialPair that = (StorageCredentialPair) o;
         return Objects.equals(writeRegion, that.writeRegion)
-               && Objects.equals(writeCredentials, that.writeCredentials)
+               && Objects.equals(writeAuth, that.writeAuth)
                && Objects.equals(readRegion, that.readRegion)
-               && Objects.equals(readCredentials, that.readCredentials);
+               && Objects.equals(readAuth, that.readAuth);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(writeRegion, writeCredentials, readRegion, readCredentials);
+        return Objects.hash(writeRegion, writeAuth, readRegion, readAuth);
     }
 }

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/transports/storage/StorageCredentials.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/transports/storage/StorageCredentials.java
@@ -24,13 +24,17 @@ import java.util.Objects;
 import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 
 /**
  * StorageCredentials are used to represent the security information required to read from or write to a storage endpoint.
  * Storage credentials can be either an access key ID and secret key, or also include a sessionToken when using
  * temporary a temporary IAM credential.
  */
-public class StorageCredentials
+public class StorageCredentials implements StorageAuth
 {
     private final String accessKeyId;
     private final String secretKey;
@@ -85,6 +89,13 @@ public class StorageCredentials
     public String getSessionToken()
     {
         return sessionToken;
+    }
+
+    @Override
+    public AwsCredentialsProvider toAwsCredentialsProvider()
+    {
+        AwsCredentials credentials = AwsSessionCredentials.create(accessKeyId, secretKey, sessionToken);
+        return StaticCredentialsProvider.create(credentials);
     }
 
     public o.a.c.sidecar.client.shaded.common.data.StorageCredentials toSidecarCredentials(String region)

--- a/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/transports/storage/extensions/StorageTransportConfiguration.java
+++ b/cassandra-analytics-core/src/main/java/org/apache/cassandra/spark/transports/storage/extensions/StorageTransportConfiguration.java
@@ -52,9 +52,9 @@ public class StorageTransportConfiguration
                                          Map<String, String> objectTags)
     {
         this(prefix, objectTags,
-             new StorageAccessConfiguration(writeRegion, writeBucket, storageCredentialPair.writeCredentials),
+             new StorageAccessConfiguration(writeRegion, writeBucket, storageCredentialPair.writeAuth()),
              new MultiClusterContainer<>());
-        StorageAccessConfiguration readAccess = new StorageAccessConfiguration(readRegion, readBucket, storageCredentialPair.readCredentials);
+        StorageAccessConfiguration readAccess = new StorageAccessConfiguration(readRegion, readBucket, storageCredentialPair.readAuth());
         readAccessConfigurations.setValue(null, readAccess);
     }
 
@@ -101,9 +101,9 @@ public class StorageTransportConfiguration
     {
         StorageAccessConfiguration readAccess = readAccessConfigurations.getValueOrThrow(clusterId);
         return new StorageCredentialPair(writeAccessConfiguration.region(),
-                                         writeAccessConfiguration.storageCredentials(),
+                                         writeAccessConfiguration.storageAuth(),
                                          readAccess.region(),
-                                         readAccess.storageCredentials());
+                                         readAccess.storageAuth());
     }
 
     /**
@@ -112,8 +112,8 @@ public class StorageTransportConfiguration
      */
     public void setStorageCredentialPair(@Nullable String clusterId, StorageCredentialPair newCredentials)
     {
-        writeAccessConfiguration = writeAccessConfiguration.copyWithNewCredentials(newCredentials.writeCredentials);
-        readAccessConfigurations.updateValue(clusterId, readAccess -> readAccess.copyWithNewCredentials(newCredentials.readCredentials));
+        writeAccessConfiguration = writeAccessConfiguration.copyWithNewAuth(newCredentials.writeAuth());
+        readAccessConfigurations.updateValue(clusterId, readAccess -> readAccess.copyWithNewAuth(newCredentials.readAuth()));
     }
 
     public String getPrefix()

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/BuildRestoreJobSecretsTest.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/BuildRestoreJobSecretsTest.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cassandra.spark.bulkwriter;
+
+import org.junit.jupiter.api.Test;
+
+import o.a.c.sidecar.client.shaded.common.data.RestoreJobSecrets;
+import org.apache.cassandra.spark.transports.storage.StorageCredentialPair;
+import org.apache.cassandra.spark.transports.storage.StorageCredentials;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link CassandraBulkSourceRelation#buildRestoreJobSecrets(StorageCredentialPair, String)}.
+ */
+class BuildRestoreJobSecretsTest
+{
+    @Test
+    void testNullCredentialTypeReturnsStaticSecrets()
+    {
+        StorageCredentialPair pair = staticPair();
+        RestoreJobSecrets secrets = CassandraBulkSourceRelation.buildRestoreJobSecrets(pair, null);
+        assertThat(secrets.readCredentials().accessKeyId()).isEqualTo("readKey");
+        assertThat(secrets.readCredentials().secretAccessKey()).isEqualTo("readSecret");
+        assertThat(secrets.readCredentials().sessionToken()).isEqualTo("readToken");
+        assertThat(secrets.readCredentials().region()).isEqualTo("us-east-1");
+        assertThat(secrets.writeCredentials().accessKeyId()).isEqualTo("writeKey");
+        assertThat(secrets.writeCredentials().secretAccessKey()).isEqualTo("writeSecret");
+        assertThat(secrets.writeCredentials().sessionToken()).isEqualTo("writeToken");
+        assertThat(secrets.writeCredentials().region()).isEqualTo("eu-west-1");
+    }
+
+    @Test
+    void testIamCredentialTypeReturnsRegionOnlySecrets()
+    {
+        StorageCredentialPair pair = StorageCredentialPair.iamPair("us-east-1", "eu-west-1");
+        RestoreJobSecrets secrets = CassandraBulkSourceRelation.buildRestoreJobSecrets(pair, "IAM");
+        assertThat(secrets.readCredentials().region()).isEqualTo("us-east-1");
+        assertThat(secrets.readCredentials().accessKeyId()).isNull();
+        assertThat(secrets.readCredentials().secretAccessKey()).isNull();
+        assertThat(secrets.readCredentials().sessionToken()).isNull();
+        assertThat(secrets.writeCredentials().region()).isEqualTo("eu-west-1");
+        assertThat(secrets.writeCredentials().accessKeyId()).isNull();
+        assertThat(secrets.writeCredentials().secretAccessKey()).isNull();
+        assertThat(secrets.writeCredentials().sessionToken()).isNull();
+    }
+
+    private StorageCredentialPair staticPair()
+    {
+        return new StorageCredentialPair(
+        "eu-west-1",
+        new StorageCredentials("writeKey", "writeSecret", "writeToken"),
+        "us-east-1",
+        new StorageCredentials("readKey", "readSecret", "readToken"));
+    }
+}

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/BulkSparkConfTest.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/BulkSparkConfTest.java
@@ -373,6 +373,27 @@ class BulkSparkConfTest
         assertThat(conf.cassandraRole).isEqualTo("custom_role");
     }
 
+    @Test
+    void testStorageCredentialTypeValidValues()
+    {
+        Map<String, String> options = copyDefaultOptions();
+        options.put(WriterOptions.STORAGE_CREDENTIAL_TYPE.name(), "STATIC");
+        assertThatNoException().isThrownBy(() -> new BulkSparkConf(sparkConf, options));
+
+        options.put(WriterOptions.STORAGE_CREDENTIAL_TYPE.name(), "IAM");
+        assertThatNoException().isThrownBy(() -> new BulkSparkConf(sparkConf, options));
+    }
+
+    @Test
+    void testStorageCredentialTypeInvalidValue()
+    {
+        Map<String, String> options = copyDefaultOptions();
+        options.put(WriterOptions.STORAGE_CREDENTIAL_TYPE.name(), "INVALID");
+        assertThatThrownBy(() -> new BulkSparkConf(sparkConf, options))
+        .isExactlyInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Invalid value 'INVALID' for option 'STORAGE_CREDENTIAL_TYPE'");
+    }
+
     private Map<String, String> copyDefaultOptions()
     {
         TreeMap<String, String> map = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/cloudstorage/CloudStorageStreamSessionTest.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/bulkwriter/cloudstorage/CloudStorageStreamSessionTest.java
@@ -64,7 +64,7 @@ import org.apache.cassandra.spark.common.Digest;
 import org.apache.cassandra.spark.data.FileSystemSSTable;
 import org.apache.cassandra.spark.data.QualifiedTableName;
 import org.apache.cassandra.spark.exception.SidecarApiCallException;
-import org.apache.cassandra.spark.transports.storage.StorageCredentials;
+import org.apache.cassandra.spark.transports.storage.StorageAuth;
 import org.apache.cassandra.spark.transports.storage.extensions.StorageTransportConfiguration;
 import org.apache.cassandra.spark.transports.storage.extensions.StorageTransportExtension;
 import org.apache.cassandra.spark.utils.TemporaryDirectory;
@@ -218,7 +218,7 @@ class CloudStorageStreamSessionTest
         }
 
         @Override
-        public BundleStorageObject uploadBundle(StorageCredentials writeCredentials, Bundle bundle)
+        public BundleStorageObject uploadBundle(StorageAuth writeAuth, Bundle bundle)
         {
             uploadedBundleManifest.put(bundle.firstToken, bundle);
             return BundleStorageObject.builder()

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/transports/storage/StorageAccessConfigurationTest.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/transports/storage/StorageAccessConfigurationTest.java
@@ -26,15 +26,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 class StorageAccessConfigurationTest
 {
     @Test
-    void testCopyWithNewCredentials()
+    void testCopyWithNewAuth()
     {
         StorageAccessConfiguration config1 = new StorageAccessConfiguration("writeRegion", "writeBucket",
                                                                             new StorageCredentials("access", "secret"));
-        StorageAccessConfiguration config2 = config1.copyWithNewCredentials(new StorageCredentials("newAccess", "newSecret"));
+        StorageAccessConfiguration config2 = config1.copyWithNewAuth(new StorageCredentials("newAccess", "newSecret"));
         assertThat(config1).isNotSameAs(config2);
         assertThat(config1.bucket()).isEqualTo(config2.bucket());
         assertThat(config1.region()).isEqualTo(config2.region());
-        assertThat(config1.storageCredentials()).isNotEqualTo(config2.storageCredentials());
+        assertThat(config1.storageAuth()).isNotEqualTo(config2.storageAuth());
     }
 
     @Test
@@ -47,8 +47,9 @@ class StorageAccessConfigurationTest
         assertThat(config1.hashCode()).isEqualTo(config2.hashCode());
         assertThat(config1).isEqualTo(config2);
 
-        config2 = config1.copyWithNewCredentials(new StorageCredentials("newAccess", "newSecret"));
+        config2 = config1.copyWithNewAuth(new StorageCredentials("newAccess", "newSecret"));
         assertThat(config1.hashCode()).isNotEqualTo(config2.hashCode());
         assertThat(config1).isNotEqualTo(config2);
     }
+
 }

--- a/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/transports/storage/StorageCredentialPairTest.java
+++ b/cassandra-analytics-core/src/test/java/org/apache/cassandra/spark/transports/storage/StorageCredentialPairTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 import o.a.c.sidecar.client.shaded.common.data.RestoreJobSecrets;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class StorageCredentialPairTest
 {
@@ -53,6 +54,15 @@ class StorageCredentialPairTest
         pair2 = makePair(2);
         assertThat(pair1.hashCode()).isNotEqualTo(pair2.hashCode());
         assertThat(pair1).isNotEqualTo(pair2);
+    }
+
+    @Test
+    void testToRestoreJobSecretsThrowsForIamPair()
+    {
+        StorageCredentialPair iamPair = StorageCredentialPair.iamPair("us-east-1", "eu-west-1");
+        assertThatThrownBy(iamPair::toRestoreJobSecrets)
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("IAM credential pair");
     }
 
     private StorageCredentialPair makePair(int id)

--- a/cassandra-analytics-integration-tests/build.gradle
+++ b/cassandra-analytics-integration-tests/build.gradle
@@ -115,17 +115,6 @@ def configureIntegrationTestTask = { Test task, String majorMinor = null ->
         task.systemProperty "suitename", "${descriptor.name}"
     }
 
-    task.testLogging {
-        events "passed", "skipped", "failed"
-
-        showExceptions true
-        exceptionFormat "full"
-        showCauses true
-        showStackTraces true
-
-        showStandardStreams = false
-    }
-
     task.jvmArgs(project.ext.JDK_OPTIONS)
     println("JVM arguments for $project.name are ${task.allJvmArgs}")
 
@@ -142,9 +131,6 @@ def configureIntegrationTestTask = { Test task, String majorMinor = null ->
     }
 
     task.useJUnitPlatform()
-    def destDir = Paths.get(rootProject.rootDir.absolutePath, "build", "test-reports", "integration").toFile()
-    task.reports.junitXml.outputLocation = destDir
-    task.reports.html.outputLocation = destDir
 }
 
 test {

--- a/cassandra-analytics-integration-tests/src/test/java/org/apache/cassandra/analytics/testcontainer/LocalCoordinatedStorageTransportExtension.java
+++ b/cassandra-analytics-integration-tests/src/test/java/org/apache/cassandra/analytics/testcontainer/LocalCoordinatedStorageTransportExtension.java
@@ -49,12 +49,12 @@ public class LocalCoordinatedStorageTransportExtension extends LocalStorageTrans
         StorageCredentialPair tokens = generateTokens();
         return new StorageTransportConfiguration("key-prefix",
                                                  ImmutableMap.of(),
-                                                 new StorageAccessConfiguration("writeRegion", BUCKET_NAME, tokens.writeCredentials),
+                                                 new StorageAccessConfiguration("writeRegion", BUCKET_NAME, tokens.writeAuth()),
                                                  ImmutableMap.of(
                                                  "cluster1",
-                                                 new StorageAccessConfiguration("readRegion1", BUCKET_NAME, tokens.readCredentials),
+                                                 new StorageAccessConfiguration("readRegion1", BUCKET_NAME, tokens.readAuth()),
                                                  "cluster2",
-                                                 new StorageAccessConfiguration("readRegion2", BUCKET_NAME, tokens.readCredentials)));
+                                                 new StorageAccessConfiguration("readRegion2", BUCKET_NAME, tokens.readAuth())));
     }
 
     @Override

--- a/cassandra-five-zero-bridge/build.gradle
+++ b/cassandra-five-zero-bridge/build.gradle
@@ -93,17 +93,6 @@ jar {
 test {
     systemProperty "cassandra.analytics.bridges.sstable_format", System.getProperty("cassandra.analytics.bridges.sstable_format", "big")
     useJUnitPlatform()
-    reports {
-        def destDir = Paths.get(rootProject.rootDir.absolutePath, "build", "test-reports", "five-zero-bridge").toFile()
-        junitXml {
-            enabled true
-            destination = destDir
-        }
-        html {
-            enabled true
-            destination = destDir
-        }
-    }
 }
 
 // automatically run BIG and BTI tests for Cassandra 5.x bridge
@@ -115,17 +104,6 @@ tasks.register('testBti', Test) {
 
     systemProperty "cassandra.analytics.bridges.sstable_format", "bti"
     useJUnitPlatform()
-    reports {
-        def destDir = Paths.get(rootProject.rootDir.absolutePath, "build", "test-reports", "five-zero-bridge").toFile()
-        junitXml {
-            enabled true
-            destination = destDir
-        }
-        html {
-            enabled true
-            destination = destDir
-        }
-    }
 }
 
 check {

--- a/cassandra-five-zero-types/build.gradle
+++ b/cassandra-five-zero-types/build.gradle
@@ -48,15 +48,4 @@ jar {
 
 test {
     useJUnitPlatform()
-    reports {
-        def destDir = Paths.get(rootProject.rootDir.absolutePath, "build", "test-reports", "five-zero-types").toFile()
-        junitXml {
-            enabled true
-            destination = destDir
-        }
-        html {
-            enabled true
-            destination = destDir
-        }
-    }
 }

--- a/cassandra-four-zero-bridge/build.gradle
+++ b/cassandra-four-zero-bridge/build.gradle
@@ -72,15 +72,4 @@ jar {
 
 test {
     useJUnitPlatform()
-    reports {
-        def destDir = Paths.get(rootProject.rootDir.absolutePath, "build", "test-reports", "four-zero-bridge").toFile()
-        junitXml {
-            enabled true
-            destination = destDir
-        }
-        html {
-            enabled true
-            destination = destDir
-        }
-    }
 }

--- a/cassandra-four-zero-types/build.gradle
+++ b/cassandra-four-zero-types/build.gradle
@@ -41,15 +41,4 @@ jar {
 
 test {
     useJUnitPlatform()
-    reports {
-        def destDir = Paths.get(rootProject.rootDir.absolutePath, "build", "test-reports", "four-zero-types").toFile()
-        junitXml {
-            enabled true
-            destination = destDir
-        }
-        html {
-            enabled true
-            destination = destDir
-        }
-    }
 }

--- a/docs/src/user.adoc
+++ b/docs/src/user.adoc
@@ -342,30 +342,48 @@ as soon as it can be downloaded from S3 storage.
 |no
 |
 a|
-Configuration of coordinated write operation in JSON format. Lists all remote Cassandra clusters to write,
-together with list of local Sidecar instances. This property is required only when importing data to multiple
-Cassandra clusters.
+Configuration of coordinated write operation in JSON format. Each key is a logical cluster ID that must match
+the keys in the read bucket map returned by `StorageTransportExtension.getStorageConfiguration()`. This property
+is required only when importing data to multiple targets via the 2-phase coordination protocol.
 
-Example:
+Two topologies are supported:
+
+*Multiple independent Cassandra clusters* — each entry points to a separate Cassandra deployment with its own
+Sidecar instances. Set `writeToLocalDcOnly: false` to validate consistency across the whole cluster.
 
 [source,json]
 ----
 {
-  "cluster1": {
-    "sidecarContactPoints": [
-      "instance-1:9999",
-      "instance-2:9999",
-      "instance-3:9999"
-    ],
-    "localDc": "dc1",
+  "cluster-us": {
+    "sidecarContactPoints": ["us-sidecar-1:9043", "us-sidecar-2:9043"],
+    "localDc": "us-east",
     "writeToLocalDcOnly": false
   },
-  "cluster2": {
-    "sidecarContactPoints": [
-      "instance-4:8888"
-    ],
-    "localDc": "dc2",
+  "cluster-eu": {
+    "sidecarContactPoints": ["eu-sidecar-1:9043", "eu-sidecar-2:9043"],
+    "localDc": "eu-west",
     "writeToLocalDcOnly": false
+  }
+}
+----
+
+*Multiple DCs within a single Cassandra cluster* — use one entry per DC, pointing to the Sidecar instances
+in that DC. Set `localDc` to the DC name and `writeToLocalDcOnly: true` to scope both the write and the
+consistency check to that DC. S3 Cross-Region Replication provides a separate read bucket for each DC
+(see <<S3 Bucket Topology>>).
+
+[source,json]
+----
+{
+  "dc-us-east": {
+    "sidecarContactPoints": ["us-sidecar-1:9043", "us-sidecar-2:9043"],
+    "localDc": "us-east",
+    "writeToLocalDcOnly": true
+  },
+  "dc-eu-west": {
+    "sidecarContactPoints": ["eu-sidecar-1:9043", "eu-sidecar-2:9043"],
+    "localDc": "eu-west",
+    "writeToLocalDcOnly": true
   }
 }
 ----
@@ -375,6 +393,17 @@ Example:
 |
 |Fully qualified class name that implements `StorageTransportExtension` interface. Consult JavaDoc for
 implementation details
+
+|_storage_credential_type_
+|no
+|`STATIC`
+a|Controls how Spark executors and Sidecar authenticate to S3. Accepted values (case-insensitive):
+
+* `STATIC`: STS access key / secret / session token credentials are passed to Sidecar. The `StorageTransportExtension`
+  must supply a `StorageCredentialPair` built with `StorageCredentials`.
+* `IAM`: No credentials are passed. Both the Spark executors and Sidecar use the AWS SDK default provider chain
+  (EC2 instance profile, EKS IRSA, ECS task role). The `StorageTransportExtension` must supply a
+  `StorageCredentialPair` built with `StorageCredentialPair.iamPair(writeRegion, readRegion)`.
 
 |_storage_client_endpoint_override_
 |no
@@ -417,6 +446,135 @@ implementation details
 |Specifies concurrency of the NIO HTTP component employed in S3 client
 
 |===
+
+=== S3 Bucket Topology
+
+The library separates write and read access into distinct `StorageAccessConfiguration` objects, each with its own
+bucket, region, and credentials. This maps to the following topology:
+
+* **Write bucket**: a single S3 bucket in one region where all Spark executors upload SSTable bundles.
+* **Read bucket per cluster**: each target Cassandra cluster reads from a bucket in its own region. In a
+  cross-region setup this is a replica of the write bucket, configured externally via S3 Cross-Region Replication.
+  The library does not manage replication — it only tells each Sidecar instance which bucket and region to pull from.
+
+For a single-cluster write, write and read buckets may be the same bucket in the same region, or different buckets
+when Sidecar should read from a regional replica.
+
+=== Implementing StorageTransportExtension
+
+The `StorageTransportExtension` interface is the integration point where bucket names, regions, and credentials
+are supplied. The library calls `getStorageConfiguration()` once on startup, then registers a
+`CredentialChangeListener` via `setCredentialChangeListener()` so the extension can push refreshed credentials
+during long-running jobs without restarting.
+
+==== Static credentials (STS tokens)
+
+Use `StorageCredentials` when a credential vending service issues short-lived STS tokens. Store the listener
+and call `onCredentialsChanged()` on each refresh.
+
+[source,java]
+----
+public class MyStorageTransportExtension implements StorageTransportExtension {
+    private String jobId;
+    private CredentialChangeListener credentialChangeListener;
+
+    @Override
+    public void initialize(String jobId, SparkConf conf, boolean isOnDriver) {
+        this.jobId = jobId;
+    }
+
+    @Override
+    public StorageTransportConfiguration getStorageConfiguration() {
+        StorageCredentialPair credentials = new StorageCredentialPair(
+            "us-east-1",
+            new StorageCredentials("writeAccessKeyId", "writeSecretKey", "writeSessionToken"),
+            "eu-west-1",
+            new StorageCredentials("readAccessKeyId", "readSecretKey", "readSessionToken"));
+
+        return new StorageTransportConfiguration(
+            "my-write-bucket",    // Spark executors upload here
+            "us-east-1",
+            "my-read-bucket-eu",  // Sidecar in eu-west-1 reads from this S3 replica
+            "eu-west-1",
+            "job-prefix",
+            credentials,
+            Map.of());
+    }
+
+    @Override
+    public void setCredentialChangeListener(CredentialChangeListener listener) {
+        this.credentialChangeListener = listener;
+        startTokenRefreshScheduler();
+    }
+
+    private void onTokenRefresh(StorageCredentialPair newCredentials) {
+        credentialChangeListener.onCredentialsChanged(jobId, newCredentials);
+    }
+
+    // ... remaining lifecycle methods
+}
+----
+
+Set `storage_credential_type=STATIC` (or omit it; STATIC is the default).
+
+==== IAM credentials (instance profile / IRSA / ECS task role)
+
+Use IAM mode when Spark executors and Sidecar instances have AWS identity attached at the infrastructure level.
+Only regions are required — no credentials are passed in the configuration.
+
+[source,java]
+----
+public class MyIamStorageTransportExtension implements StorageTransportExtension {
+
+    @Override
+    public void initialize(String jobId, SparkConf conf, boolean isOnDriver) { }
+
+    @Override
+    public StorageTransportConfiguration getStorageConfiguration() {
+        return new StorageTransportConfiguration(
+            "my-write-bucket",
+            "us-east-1",
+            "my-read-bucket-eu",
+            "eu-west-1",
+            "job-prefix",
+            StorageCredentialPair.iamPair("us-east-1", "eu-west-1"),
+            Map.of());
+    }
+
+    @Override
+    public void setCredentialChangeListener(CredentialChangeListener listener) {
+        // no-op: credentials are resolved by the AWS SDK default provider chain
+    }
+
+    // ... remaining lifecycle methods
+}
+----
+
+Set `storage_credential_type=IAM` in your write options.
+
+==== Multi-cluster (coordinated write)
+
+For coordinated writes to multiple clusters, use the constructor that accepts a read-configuration map keyed by
+`clusterId`. Each entry must have its own bucket and region. The `clusterId` keys must match those in
+`coordinated_write_config`.
+
+[source,java]
+----
+@Override
+public StorageTransportConfiguration getStorageConfiguration() {
+    return new StorageTransportConfiguration(
+        "job-prefix",
+        Map.of(),
+        new StorageAccessConfiguration("us-east-1", "my-write-bucket", IamStorageAuth.INSTANCE),
+        Map.of(
+            "cluster-eu", new StorageAccessConfiguration("eu-west-1",      "my-read-bucket-eu", IamStorageAuth.INSTANCE),
+            "cluster-ap", new StorageAccessConfiguration("ap-southeast-1", "my-read-bucket-ap", IamStorageAuth.INSTANCE)
+        ));
+}
+----
+
+For static credentials, replace `IamStorageAuth.INSTANCE` with a `StorageCredentials` instance and call
+`credentialChangeListener.onCredentialsChanged(jobId, clusterId, newCredentials)` per cluster on refresh.
 
 === Other Properties
 


### PR DESCRIPTION
## Summary

- Adds `CredentialType` enum (`STATIC` / `IAM`) to control how Spark executors and Sidecar authenticate to S3
- `STATIC` (default): existing behavior — STS access key/secret/session token passed via `StorageCredentials`
- `IAM`: no credentials passed; both executor and Sidecar use the AWS SDK default provider chain (EC2 instance profile, EKS IRSA, ECS task role)
- New `StorageAuth` interface with `StaticStorageAuth` and `IamStorageAuth` implementations
- `StorageCredentialPair.iamPair(writeRegion, readRegion)` factory for IAM-only pairs
- `RestoreJobSecrets` updated to carry the credential type and omit secrets when IAM is used
- Documentation updates covering the new `storage_credential_type` option and S3 bucket topology

## Test plan

- [ ] New unit tests in `BuildRestoreJobSecretsTest`, `RestoreJobSecretsTest`, `StorageCredentialsTest`, `StorageCredentialPairTest`, and `CreateRestoreJobRequestPayloadTest` cover both `STATIC` and `IAM` paths
- [ ] `StorageAccessConfigurationTest` updated to reflect new auth model
- [ ] `CloudStorageStreamSessionTest` updated for credential type propagation

## JIRA

https://issues.apache.org/jira/browse/CASSANALYTICS-155