### PR TITLE
CASSANALYTICS-171: Avoid Spark 4 partitioning warnings during reads

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,6 @@
 0.5.0
 -----
+ * Avoid Spark 4 partitioning warnings during bulk reads (CASSANALYTICS-171)
  * Spark 4.0 Support (CASSANALYTICS-34)
  * Add IAM credential support for S3 storage transport (CASSANALYTICS-155)
  * Make BulkWriterConfig extensible (CASSANALYTICS-168)

--- a/cassandra-analytics-core/src/main/spark4/org/apache/cassandra/spark/sparksql/CassandraScanBuilder.java
+++ b/cassandra-analytics-core/src/main/spark4/org/apache/cassandra/spark/sparksql/CassandraScanBuilder.java
@@ -43,6 +43,7 @@ import org.apache.spark.sql.connector.read.SupportsPushDownFilters;
 import org.apache.spark.sql.connector.read.SupportsPushDownRequiredColumns;
 import org.apache.spark.sql.connector.read.SupportsReportPartitioning;
 import org.apache.spark.sql.connector.read.partitioning.Partitioning;
+import org.apache.spark.sql.connector.read.partitioning.UnknownPartitioning;
 import org.apache.spark.sql.sources.Filter;
 import org.apache.spark.sql.types.StructType;
 import org.apache.spark.sql.util.CaseInsensitiveStringMap;
@@ -121,7 +122,7 @@ class CassandraScanBuilder implements ScanBuilder, Scan, Batch, SupportsPushDown
     @Override
     public Partitioning outputPartitioning()
     {
-        return new CassandraPartitioning(dataLayer);
+        return new UnknownPartitioning(dataLayer.partitionCount());
     }
 
     private List<PartitionKeyFilter> buildPartitionKeyFilters()

--- a/cassandra-analytics-core/src/test/spark4/org/apache/cassandra/spark/sparksql/CassandraScanBuilderTest.java
+++ b/cassandra-analytics-core/src/test/spark4/org/apache/cassandra/spark/sparksql/CassandraScanBuilderTest.java
@@ -19,21 +19,31 @@
 
 package org.apache.cassandra.spark.sparksql;
 
+import org.junit.jupiter.api.Test;
+
 import org.apache.cassandra.spark.data.DataLayer;
 import org.apache.spark.sql.connector.read.partitioning.Partitioning;
+import org.apache.spark.sql.connector.read.partitioning.UnknownPartitioning;
+import org.apache.spark.sql.types.StructType;
+import org.apache.spark.sql.util.CaseInsensitiveStringMap;
 
-class CassandraPartitioning implements Partitioning
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class CassandraScanBuilderTest
 {
-    final DataLayer dataLayer;
-
-    CassandraPartitioning(DataLayer dataLayer)
+    @Test
+    void outputPartitioningReportsUnknownPartitioningWithPartitionCount()
     {
-        this.dataLayer = dataLayer;
-    }
+        DataLayer dataLayer = mock(DataLayer.class);
+        when(dataLayer.partitionCount()).thenReturn(7);
+        CassandraScanBuilder builder =
+            new CassandraScanBuilder(dataLayer, new StructType(), CaseInsensitiveStringMap.empty());
 
-    @Override
-    public int numPartitions()
-    {
-        return dataLayer.partitionCount();
+        Partitioning partitioning = builder.outputPartitioning();
+
+        assertThat(partitioning).isInstanceOf(UnknownPartitioning.class);
+        assertThat(partitioning.numPartitions()).isEqualTo(7);
     }
 }


### PR DESCRIPTION
## Summary
- Report Spark 4 Cassandra scan partitioning as Spark's public `UnknownPartitioning` directly, instead of a custom `Partitioning` subclass.
- Preserve the input partition count when Spark asks `CassandraScanBuilder` for output partitioning.
- Add a Spark 4 unit test covering the reported partitioning contract.

## Why `UnknownPartitioning`
Spark 4's DataSource V2 partitioning contract expects connectors to report one of Spark's public partitioning types, such as `UnknownPartitioning` or `KeyGroupedPartitioning`, rather than implementing `Partitioning` directly. When Spark sees a custom `Partitioning`, `V2ScanPartitioningAndOrdering` ignores it and logs a warning.

Cassandra analytics input partitions are token ranges. Rows in one token range can contain many distinct Cassandra partition keys and many distinct token values, so they do not satisfy `KeyGroupedPartitioning`'s contract that every row in a Spark partition evaluates to the same partition value. Reporting `UnknownPartitioning` preserves the correct partition count without claiming keyed grouping semantics.

Jira: https://issues.apache.org/jira/browse/CASSANALYTICS-171