### PR TITLE
Add security-model discoverability (AGENTS.md -> SECURITY.md -> security model)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,16 @@
+# Agent guidance
+
+This file is read by automated agents (security scanners, code analyzers,
+AI assistants) operating on this repository. It points them at the
+human-authored references they should consult before producing output.
+
+## Security
+
+Security model: [SECURITY.md](./SECURITY.md), which links to the Apache
+Cassandra project security model.
+
+This repository is part of the Apache Cassandra project. Its security model -
+trust boundaries, in-scope / out-of-scope declarations, the security
+properties the project provides and disclaims, and how findings are triaged -
+is the umbrella Cassandra security model linked from SECURITY.md. Consult it
+before reporting security issues.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,17 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please report suspected security vulnerabilities privately to the Apache
+Security Team at <security@apache.org>, following the ASF process at
+<https://www.apache.org/security/>. Do not open public GitHub issues or pull
+requests for security reports.
+
+## Security Model
+
+This repository is part of the Apache Cassandra project. The project's
+security model - what is in and out of scope, the trust boundaries it
+assumes, the security properties it provides and disclaims, and how findings
+are triaged - is documented in the main apache/cassandra repository:
+
+https://github.com/apache/cassandra/blob/trunk/doc/modules/cassandra/pages/reference/security-model.adoc


### PR DESCRIPTION
**This is a proposal for the PMC to review, own, and merge — please correct, reject, or discuss as needed.**

This adds `AGENTS.md` + `SECURITY.md` so automated tooling can mechanically discover the project's security model via the conventional `AGENTS.md → SECURITY.md → security model` chain. This repository is part of the Apache Cassandra project, so both files point at the umbrella Cassandra security model in `apache/cassandra` — no model content is added here.

Context: the ASF Security team is preparing the Cassandra repositories for an automated agentic security scan we're piloting; such scans look for the model along this chain. The Security team has been in touch separately on the PMC's private list.
